### PR TITLE
fix(boolean): SolidExt boolean methods: self -> &self

### DIFF
--- a/examples/04_boolean.rs
+++ b/examples/04_boolean.rs
@@ -13,17 +13,17 @@ fn main() -> Result<(), cadrum::Error> {
         .color("#e67e22");
 
     // union: merge both shapes into one — offset X=0
-    let union = make_box.clone()
+    let union = make_box
         .union(&[make_cyl.clone()])?;
 
     // subtract: box minus cylinder — offset X=40
-    let subtract = make_box.clone()
+    let subtract = make_box
         .subtract(&[make_cyl.clone()])?
         .translate(DVec3::new(40.0, 0.0, 0.0));
 
     // intersect: only the overlapping volume — offset X=80
-    let intersect = make_box.clone()
-        .intersect(&[make_cyl.clone()])?
+    let intersect = make_box
+        .intersect(&[make_cyl])?
         .translate(DVec3::new(80.0, 0.0, 0.0));
 
     let shapes: Vec<Solid> = [union, subtract, intersect].concat();

--- a/src/occt/solid.rs
+++ b/src/occt/solid.rs
@@ -332,19 +332,16 @@ impl SolidExt for Solid {
 
 	// ==================== Boolean wrappers ====================
 
-	fn union_with_metadata<'a>(self, tool: impl IntoIterator<Item = &'a Solid>) -> Result<(Vec<Solid>, [Vec<u64>; 2]), Error> {
-		let arr = [self];
-		<Solid as SolidStruct>::boolean_union(arr.iter(), tool)
+	fn union_with_metadata<'a>(&self, tool: impl IntoIterator<Item = &'a Solid>) -> Result<(Vec<Solid>, [Vec<u64>; 2]), Error> {
+		<Solid as SolidStruct>::boolean_union([self], tool)
 	}
 
-	fn subtract_with_metadata<'a>(self, tool: impl IntoIterator<Item = &'a Solid>) -> Result<(Vec<Solid>, [Vec<u64>; 2]), Error> {
-		let arr = [self];
-		<Solid as SolidStruct>::boolean_subtract(arr.iter(), tool)
+	fn subtract_with_metadata<'a>(&self, tool: impl IntoIterator<Item = &'a Solid>) -> Result<(Vec<Solid>, [Vec<u64>; 2]), Error> {
+		<Solid as SolidStruct>::boolean_subtract([self], tool)
 	}
 
-	fn intersect_with_metadata<'a>(self, tool: impl IntoIterator<Item = &'a Solid>) -> Result<(Vec<Solid>, [Vec<u64>; 2]), Error> {
-		let arr = [self];
-		<Solid as SolidStruct>::boolean_intersect(arr.iter(), tool)
+	fn intersect_with_metadata<'a>(&self, tool: impl IntoIterator<Item = &'a Solid>) -> Result<(Vec<Solid>, [Vec<u64>; 2]), Error> {
+		<Solid as SolidStruct>::boolean_intersect([self], tool)
 	}
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -439,12 +439,12 @@ pub trait SolidExt: Transform {
 	fn color_clear(self) -> Self;
 
 	// --- Boolean (-> Vec<Self::Elem>) ---
-	fn union_with_metadata<'a>(self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<(Vec<Self::Elem>, [Vec<u64>; 2]), Error> where Self::Elem: 'a;
-	fn subtract_with_metadata<'a>(self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<(Vec<Self::Elem>, [Vec<u64>; 2]), Error> where Self::Elem: 'a;
-	fn intersect_with_metadata<'a>(self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<(Vec<Self::Elem>, [Vec<u64>; 2]), Error> where Self::Elem: 'a;
-	fn union<'a>(self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<Vec<Self::Elem>, Error> where Self::Elem: 'a { Ok(self.union_with_metadata(tool)?.0) }
-	fn subtract<'a>(self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<Vec<Self::Elem>, Error> where Self::Elem: 'a { Ok(self.subtract_with_metadata(tool)?.0) }
-	fn intersect<'a>(self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<Vec<Self::Elem>, Error> where Self::Elem: 'a { Ok(self.intersect_with_metadata(tool)?.0) }
+	fn union_with_metadata<'a>(&self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<(Vec<Self::Elem>, [Vec<u64>; 2]), Error> where Self::Elem: 'a;
+	fn subtract_with_metadata<'a>(&self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<(Vec<Self::Elem>, [Vec<u64>; 2]), Error> where Self::Elem: 'a;
+	fn intersect_with_metadata<'a>(&self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<(Vec<Self::Elem>, [Vec<u64>; 2]), Error> where Self::Elem: 'a;
+	fn union<'a>(&self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<Vec<Self::Elem>, Error> where Self::Elem: 'a { Ok(self.union_with_metadata(tool)?.0) }
+	fn subtract<'a>(&self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<Vec<Self::Elem>, Error> where Self::Elem: 'a { Ok(self.subtract_with_metadata(tool)?.0) }
+	fn intersect<'a>(&self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<Vec<Self::Elem>, Error> where Self::Elem: 'a { Ok(self.intersect_with_metadata(tool)?.0) }
 }
 
 // `impl SolidExt for Solid` lives in the backend module (e.g. src/occt/solid.rs)
@@ -479,13 +479,13 @@ impl<T: SolidStruct> SolidExt for Vec<T> {
 	fn color_clear(self) -> Self {
 		self.into_iter().map(|s| s.color_clear()).collect()
 	}
-	fn union_with_metadata<'a>(self, tool: impl IntoIterator<Item = &'a T>) -> Result<(Vec<T>, [Vec<u64>; 2]), Error> where T: 'a {
+	fn union_with_metadata<'a>(&self, tool: impl IntoIterator<Item = &'a T>) -> Result<(Vec<T>, [Vec<u64>; 2]), Error> where T: 'a {
 		T::boolean_union(self.iter(), tool)
 	}
-	fn subtract_with_metadata<'a>(self, tool: impl IntoIterator<Item = &'a T>) -> Result<(Vec<T>, [Vec<u64>; 2]), Error> where T: 'a {
+	fn subtract_with_metadata<'a>(&self, tool: impl IntoIterator<Item = &'a T>) -> Result<(Vec<T>, [Vec<u64>; 2]), Error> where T: 'a {
 		T::boolean_subtract(self.iter(), tool)
 	}
-	fn intersect_with_metadata<'a>(self, tool: impl IntoIterator<Item = &'a T>) -> Result<(Vec<T>, [Vec<u64>; 2]), Error> where T: 'a {
+	fn intersect_with_metadata<'a>(&self, tool: impl IntoIterator<Item = &'a T>) -> Result<(Vec<T>, [Vec<u64>; 2]), Error> where T: 'a {
 		T::boolean_intersect(self.iter(), tool)
 	}
 }
@@ -522,13 +522,13 @@ impl<T: SolidStruct, const N: usize> SolidExt for [T; N] {
 	fn color_clear(self) -> Self {
 		self.map(|s| s.color_clear())
 	}
-	fn union_with_metadata<'a>(self, tool: impl IntoIterator<Item = &'a T>) -> Result<(Vec<T>, [Vec<u64>; 2]), Error> where T: 'a {
+	fn union_with_metadata<'a>(&self, tool: impl IntoIterator<Item = &'a T>) -> Result<(Vec<T>, [Vec<u64>; 2]), Error> where T: 'a {
 		T::boolean_union(self.iter(), tool)
 	}
-	fn subtract_with_metadata<'a>(self, tool: impl IntoIterator<Item = &'a T>) -> Result<(Vec<T>, [Vec<u64>; 2]), Error> where T: 'a {
+	fn subtract_with_metadata<'a>(&self, tool: impl IntoIterator<Item = &'a T>) -> Result<(Vec<T>, [Vec<u64>; 2]), Error> where T: 'a {
 		T::boolean_subtract(self.iter(), tool)
 	}
-	fn intersect_with_metadata<'a>(self, tool: impl IntoIterator<Item = &'a T>) -> Result<(Vec<T>, [Vec<u64>; 2]), Error> where T: 'a {
+	fn intersect_with_metadata<'a>(&self, tool: impl IntoIterator<Item = &'a T>) -> Result<(Vec<T>, [Vec<u64>; 2]), Error> where T: 'a {
 		T::boolean_intersect(self.iter(), tool)
 	}
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -48,7 +48,7 @@ fn shape_to_brep_bytes<'a>(shape: impl IntoIterator<Item = &'a Solid>) -> Vec<u8
 fn test_t01_union_drop_result_first() {
 	let a = test_box();
 	let b = test_box_2();
-	let result = a.clone().union([&b]).unwrap();
+	let result = a.union([&b]).unwrap();
 	drop(result);
 	drop(a);
 	drop(b);
@@ -58,7 +58,7 @@ fn test_t01_union_drop_result_first() {
 fn test_t01_union_drop_result_last() {
 	let a = test_box();
 	let b = test_box_2();
-	let result = a.clone().union([&b]).unwrap();
+	let result = a.union([&b]).unwrap();
 	drop(a);
 	drop(b);
 	drop(result);
@@ -68,7 +68,7 @@ fn test_t01_union_drop_result_last() {
 fn test_t01_subtract_drop_order() {
 	let a = test_box();
 	let b = test_box_2();
-	let result = a.clone().subtract([&b]).unwrap();
+	let result = a.subtract([&b]).unwrap();
 	drop(a);
 	drop(b);
 	drop(result);
@@ -78,7 +78,7 @@ fn test_t01_subtract_drop_order() {
 fn test_t01_intersect_drop_order() {
 	let a = test_box();
 	let b = test_box_2();
-	let result = a.clone().intersect([&b]).unwrap();
+	let result = a.intersect([&b]).unwrap();
 	drop(a);
 	drop(b);
 	drop(result);
@@ -89,8 +89,8 @@ fn test_t01_chained_boolean_drops() {
 	let a = test_box();
 	let b = test_box_2();
 	let c = test_box_3();
-	let r1 = a.clone().union([&b]).unwrap();
-	let r2 = r1.clone().subtract([&c]).unwrap();
+	let r1 = a.union([&b]).unwrap();
+	let r2 = r1.subtract([&c]).unwrap();
 	drop(r1);
 	drop(r2);
 	drop(a);
@@ -191,8 +191,8 @@ fn test_t06_brep_roundtrip() {
 fn test_t08_boolean_returns_shape() {
 	let a = test_box();
 	let b = test_box_2();
-	let _union: Vec<Solid> = a.clone().union([&b]).unwrap();
-	let _sub: Vec<Solid> = a.clone().subtract([&b]).unwrap();
+	let _union: Vec<Solid> = a.union([&b]).unwrap();
+	let _sub: Vec<Solid> = a.subtract([&b]).unwrap();
 	let _inter: Vec<Solid> = a.intersect([&b]).unwrap();
 }
 

--- a/tests/shape.rs
+++ b/tests/shape.rs
@@ -35,12 +35,12 @@ fn test_union_of_translated_overlapping_solids_has_single_volume() {
 	let b_moved: Vec<Solid> = b.clone().into_iter().map(|s| s.translate(dvec3(-100.0, 0.0, 0.0))).collect();
 
 	// b と b_moved は実態が別であることを確認: a と b（移動前）を union するとvolumeは2つ分（2000）。
-	let result_no_move: Vec<Solid> = a.clone().union(&b).expect("union should succeed");
+	let result_no_move: Vec<Solid> = a.union(&b).expect("union should succeed");
 	let volume_no_move: f64 = result_no_move.iter().map(|s| s.volume()).sum();
 	assert!((volume_no_move - 2000.0).abs() < 1e-3, "expected volume ~2000, got {volume_no_move}");
 
 	// b_moved は a と完全に重なるので union すると1つ分（1000）。
-	let result: Vec<Solid> = a.clone().union(&b_moved).expect("union should succeed");
+	let result: Vec<Solid> = a.union(&b_moved).expect("union should succeed");
 	let volume: f64 = result.iter().map(|s| s.volume()).sum();
 	assert!((volume - 1000.0).abs() < 1e-3, "expected volume ~1000, got {volume}");
 

--- a/tests/subtract.rs
+++ b/tests/subtract.rs
@@ -32,7 +32,7 @@ fn run_subtract(offset: DVec3, optimized: bool) -> (Duration, Vec<Solid>) {
 				skipped += 1;
 				results.push(sa.clone());
 			} else {
-				let r = sa.clone().subtract(tools.iter().copied()).unwrap();
+				let r = sa.subtract(tools.iter().copied()).unwrap();
 				results.extend(r);
 			}
 		}

--- a/tests/union.rs
+++ b/tests/union.rs
@@ -14,10 +14,11 @@ fn test_union_cylinders() {
 	println!("union([A], [B]) solid count: {}", union_a_b.len());
 
 	let union_ab_cd = [a.clone(), b.clone()].union(&[c.clone(), d.clone()]).unwrap();
+
 	println!("union([A, B], [C, D]) solid count: {}", union_ab_cd.len());
 
 	let all = [a, b, c, d];
-	let union_all_all = all.clone().union(&all).unwrap();
+	let union_all_all = all.union(&all).unwrap();
 	println!("union([ABCD], [ABCD]) solid count: {}", union_all_all.len());
 
 	//


### PR DESCRIPTION
## Summary- Change receiver of 6 boolean methods in SolidExt (union, subtract, intersect + _with_metadata) from `self` to `&self`- The downstream FFI layer (boolean_op_impl) only requires `&Solid` references, so consuming self was unnecessary- Remove unnecessary `.clone()` calls at call sites (7 files: examples + tests)## Test plan- [x] `cargo build` success- [x] `cargo test` all passed (47 passed, 1 ignored)- [x] Transform methods and color/color_clear confirmed to require self (UniquePtr move) - left as-is