### PR TITLE
Udpate/occt800c5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cadrum"
 version = "0.4.4"
 edition = "2021"
-description = "Rust CAD library powered by OpenCASCADE (OCCT 7.9.3)"
+description = "Rust CAD library powered by OpenCASCADE (OCCT 8.0.0-rc5)"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/lzpel/cadrum"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Crates.io](https://img.shields.io/crates/v/cadrum.svg?logo=rust)](https://crates.io/crates/cadrum)
 [![Docs](https://img.shields.io/badge/docs-lzpel.github.io%2Fcadrum-blue)](https://lzpel.github.io/cadrum)
 
-Rust CAD library powered by [OpenCASCADE](https://dev.opencascade.org/) (OCCT 7.9.3).
+Rust CAD library powered by [OpenCASCADE](https://dev.opencascade.org/) (OCCT 8.0.0-rc5).
 
 <p align="center">
   <img src="figure/chijin.svg" alt="chijin — a drum of Amami Oshima" width="360"/>
@@ -79,7 +79,7 @@ Tested with GCC 15.2.0 (MinGW-w64) and CMake 3.31.11 on Windows.
 
 ## Build
 
-By default, `cargo build` downloads OCCT 7.9.3 source and builds it automatically.
+By default, `cargo build` downloads OCCT 8.0.0-rc5 source and builds it automatically.
 The built library is placed in `target/occt/` and removed by `cargo clean`.
 
 To cache the OCCT build across `cargo clean`, set `OCCT_ROOT` to a persistent directory:

--- a/build.rs
+++ b/build.rs
@@ -141,9 +141,9 @@ fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path, color: bool) {
 	println!("cargo:rerun-if-changed=cpp/wrapper.cpp");
 }
 
-/// Download OCCT 7.9.3 source, patch, and build with CMake into `install_prefix`.
+/// Download OCCT 8.0.0-rc5 source, patch, and build with CMake into `install_prefix`.
 fn build_occt_from_source(out_dir: &Path, install_prefix: &Path) -> (PathBuf, PathBuf) {
-	let occt_version = "V7_9_3";
+	let occt_version = "V8_0_0_rc5";
 	let occt_url = format!("https://github.com/Open-Cascade-SAS/OCCT/archive/refs/tags/{}.tar.gz", occt_version);
 
 	let download_dir = out_dir.join("occt-source");
@@ -290,11 +290,22 @@ fn find_occt_lib_dir(occt_root: &Path) -> PathBuf {
 ///    XCAFPrs_Texture which inherits from Graphic3d_Texture2D (TKService).
 ///    The only caller was FillAspect(), which is now empty.
 fn patch_occt_sources(source_dir: &Path) {
+	// OCCT 8.0.0 moved sources under src/<Module>/<Toolkit>/<Package>/ hierarchy.
+	// Try the new layout first, fall back to the legacy flat layout (≤7.9.x).
+	let vis_material = ["src/DataExchange/TKXCAF/XCAFDoc/XCAFDoc_VisMaterial.cxx", "src/XCAFDoc/XCAFDoc_VisMaterial.cxx"];
+	let prs_texture  = ["src/DataExchange/TKXCAF/XCAFPrs/XCAFPrs_Texture.cxx",    "src/XCAFPrs/XCAFPrs_Texture.cxx"];
+
+	let find = |candidates: &[&str]| candidates.iter().map(|p| source_dir.join(p)).find(|p| p.exists());
+
 	// Stub method bodies only: keep #includes and signatures, empty the bodies.
-	stub_out_methods(&source_dir.join("src/XCAFDoc/XCAFDoc_VisMaterial.cxx"), true);
+	if let Some(path) = find(&vis_material) {
+		stub_out_methods(&path, true);
+	}
 	// Empty the entire file: the initializer list references the base class, so
 	// body stubs alone cannot cut the TKService dependency.
-	stub_out_methods(&source_dir.join("src/XCAFPrs/XCAFPrs_Texture.cxx"), false);
+	if let Some(path) = find(&prs_texture) {
+		stub_out_methods(&path, false);
+	}
 }
 
 /// Neutralize a C++ source file at `path`.

--- a/build.rs
+++ b/build.rs
@@ -66,7 +66,7 @@ fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path, color: bool) {
 
 
 	// XDE (XDE-based STEP with color) requires ApplicationFramework libs.
-	// In OCCT 7.9.3, library layout (verified by nm):
+	// OCCT library layout (verified by nm):
 	//   TKLCAF   — TDocStd_Document, TDocStd_Application (NewDocument / Close)
 	//   TKXCAF   — XCAFApp_Application, XCAFDoc_ColorTool, XCAFDoc_ShapeTool,
 	//              XCAFDoc_DocumentTool
@@ -186,7 +186,7 @@ fn build_occt_from_source(out_dir: &Path, install_prefix: &Path) -> (PathBuf, Pa
 	}
 
 	// Auto-detect the extracted OCCT directory name
-	// (GitHub archives may name it OCCT-V7_9_3 or OCCT-7_9_3 depending on the tag)
+	// (GitHub archives name it OCCT-{tag}, e.g. OCCT-V8_0_0_rc5)
 	let source_dir = std::fs::read_dir(&download_dir).expect("Failed to read occt-source directory").flatten().find(|e| e.file_name().to_string_lossy().starts_with("OCCT") && e.path().is_dir()).map(|e| e.path()).expect("OCCT source directory not found after extraction");
 
 	// Patch OCCT sources to remove TKService (Visualization) dependencies.

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -64,7 +64,6 @@
 #include <BRepBndLib.hxx>
 #include <Bnd_Box.hxx>
 #include <BRepGProp.hxx>
-#include <BRepGProp_Face.hxx>
 #include <GProp_GProps.hxx>
 
 // --- Curve adaptation / approximation ---
@@ -632,7 +631,6 @@ MeshData mesh_shape(const TopoDS_Shape& shape, double tolerance) {
 
         // Compute normals for this face
         // Bug 3 fix: Use Poly_Triangulation::ComputeNormals + correct loop bounds
-        BRepGProp_Face prop_face(face);
 
         // Vertices
         for (int i = 1; i <= nb_nodes; i++) {
@@ -1270,6 +1268,7 @@ std::unique_ptr<TopoDS_Shape> make_loft(
 #include <STEPCAFControl_Writer.hxx>
 #include <TDocStd_Document.hxx>
 #include <TDF_ChildIterator.hxx>
+#include <TDF_LabelSequence.hxx>
 #include <Quantity_Color.hxx>
 
 namespace cadrum {

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -71,7 +71,7 @@
 #include <BRepAdaptor_Curve.hxx>
 #include <GCPnts_TangentialDeflection.hxx>
 #include <GeomAPI_Interpolate.hxx>
-#include <NCollection_HArray1.hxx>
+#include <TColgp_HArray1OfPnt.hxx>
 #include <Geom_BSplineCurve.hxx>
 #include <Precision.hxx>
 
@@ -946,7 +946,7 @@ std::unique_ptr<TopoDS_Edge> make_bspline_edge(
     if (coords.size() < 6 || coords.size() % 3 != 0) return nullptr;
     try {
         const int n = static_cast<int>(coords.size() / 3);
-        Handle(NCollection_HArray1<gp_Pnt>) pts = new NCollection_HArray1<gp_Pnt>(1, n);
+        Handle(TColgp_HArray1OfPnt) pts = new TColgp_HArray1OfPnt(1, n);
         for (int i = 0; i < n; ++i) {
             pts->SetValue(i + 1, gp_Pnt(coords[i * 3], coords[i * 3 + 1], coords[i * 3 + 2]));
         }

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -14,8 +14,9 @@
 #include <TopAbs_ShapeEnum.hxx>
 #include <TopExp.hxx>
 #include <TopLoc_Location.hxx>
-#include <TopTools_IndexedMapOfShape.hxx>
-#include <TopTools_ListOfShape.hxx>
+#include <NCollection_IndexedMap.hxx>
+#include <NCollection_List.hxx>
+#include <TopTools_ShapeMapHasher.hxx>
 
 // --- Geometry primitives (gp / Geom / 2d) ---
 #include <gp_Ax1.hxx>
@@ -70,7 +71,7 @@
 #include <BRepAdaptor_Curve.hxx>
 #include <GCPnts_TangentialDeflection.hxx>
 #include <GeomAPI_Interpolate.hxx>
-#include <TColgp_HArray1OfPnt.hxx>
+#include <NCollection_HArray1.hxx>
 #include <Geom_BSplineCurve.hxx>
 #include <Precision.hxx>
 
@@ -351,7 +352,7 @@ std::unique_ptr<TopoDS_Shape> make_empty() {
 }
 
 std::unique_ptr<TopoDS_Shape> deep_copy(const TopoDS_Shape& shape) {
-    BRepBuilderAPI_Copy copier(shape, Standard_True, Standard_False);
+    BRepBuilderAPI_Copy copier(shape, true, false);
     return std::make_unique<TopoDS_Shape>(copier.Shape());
 }
 
@@ -406,12 +407,12 @@ static void collect_relay_mapping(
         const TopoDS_Shape& sf = ex.Current();
         uint64_t src_id = reinterpret_cast<uint64_t>(sf.TShape().get());
         if (op.IsDeleted(sf)) continue;
-        const TopTools_ListOfShape& mods = op.Modified(sf);
+        const NCollection_List<TopoDS_Shape>& mods = op.Modified(sf);
         if (mods.IsEmpty()) {
             // Face is unchanged: its TShape* appears as-is in op.Shape().
             relay[src_id] = src_id;
         } else {
-            for (TopTools_ListOfShape::Iterator it(mods); it.More(); it.Next()) {
+            for (NCollection_List<TopoDS_Shape>::Iterator it(mods); it.More(); it.Next()) {
                 uint64_t pre_id = reinterpret_cast<uint64_t>(it.Value().TShape().get());
                 relay[pre_id] = src_id;
             }
@@ -420,7 +421,7 @@ static void collect_relay_mapping(
 }
 
 // Helper: after BRepBuilderAPI_Copy, match pre/post faces by their index in
-// TopTools_IndexedMapOfShape (BRepBuilderAPI_Copy preserves traversal order).
+// NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> (BRepBuilderAPI_Copy preserves traversal order).
 // Emit [post_id, src_id] pairs into `out` for every face tracked in `relay`.
 static void emit_from_pairs(
     const TopoDS_Shape& pre_shape,
@@ -428,7 +429,7 @@ static void emit_from_pairs(
     const std::unordered_map<uint64_t, uint64_t>& relay,
     std::vector<uint64_t>& out)
 {
-    TopTools_IndexedMapOfShape pre_map, post_map;
+    NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> pre_map, post_map;
     TopExp::MapShapes(pre_shape, TopAbs_FACE, pre_map);
     TopExp::MapShapes(post_shape, TopAbs_FACE, post_map);
     // pre_map and post_map have the same size because the copy preserves topology.
@@ -469,7 +470,7 @@ std::unique_ptr<BooleanShape> boolean_op(
         collect_relay_mapping(*op, a, relay_a);
         collect_relay_mapping(*op, b, relay_b);
 
-        BRepBuilderAPI_Copy copier(op->Shape(), Standard_True, Standard_False);
+        BRepBuilderAPI_Copy copier(op->Shape(), true, false);
         auto r = std::make_unique<BooleanShape>();
         r->shape = copier.Shape();
         emit_from_pairs(op->Shape(), copier.Shape(), relay_a, r->from_a);
@@ -504,8 +505,8 @@ rust::Vec<uint64_t> boolean_shape_from_b(const BooleanShape& r) {
 // face-id remapping table so the colormap can follow merged faces.
 std::unique_ptr<TopoDS_Shape> clean_shape(const TopoDS_Shape& shape) {
     try {
-        ShapeUpgrade_UnifySameDomain unifier(shape, Standard_True, Standard_True, Standard_True);
-        unifier.AllowInternalEdges(Standard_False);
+        ShapeUpgrade_UnifySameDomain unifier(shape, true, true, true);
+        unifier.AllowInternalEdges(false);
         unifier.Build();
         return std::make_unique<TopoDS_Shape>(unifier.Shape());
     } catch (const Standard_Failure&) {
@@ -546,7 +547,7 @@ std::unique_ptr<TopoDS_Shape> scale_shape(
     try {
         gp_Trsf trsf;
         trsf.SetScale(gp_Pnt(cx, cy, cz), factor);
-        BRepBuilderAPI_Transform transform(shape, trsf, Standard_True);
+        BRepBuilderAPI_Transform transform(shape, trsf, true);
         return std::make_unique<TopoDS_Shape>(transform.Shape());
     } catch (const Standard_Failure&) {
         return nullptr;
@@ -561,7 +562,7 @@ std::unique_ptr<TopoDS_Shape> mirror_shape(
     try {
         gp_Trsf trsf;
         trsf.SetMirror(gp_Ax2(gp_Pnt(ox, oy, oz), gp_Dir(nx, ny, nz)));
-        BRepBuilderAPI_Transform transform(shape, trsf, Standard_True);
+        BRepBuilderAPI_Transform transform(shape, trsf, true);
         return std::make_unique<TopoDS_Shape>(transform.Shape());
     } catch (const Standard_Failure&) {
         return nullptr;
@@ -724,7 +725,7 @@ std::unique_ptr<TopExp_Explorer> explore_faces(const TopoDS_Shape& shape) {
 std::unique_ptr<TopExp_Explorer> explore_edges(const TopoDS_Shape& shape) {
     // TopExp_Explorer visits shared edges once per adjacent face.
     // Build a flat compound of unique edges so each is visited exactly once.
-    TopTools_IndexedMapOfShape edgeMap;
+    NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> edgeMap;
     TopExp::MapShapes(shape, TopAbs_EDGE, edgeMap);
     TopoDS_Compound compound;
     BRep_Builder builder;
@@ -904,7 +905,7 @@ std::unique_ptr<TopoDS_Edge> make_arc_edge(
         gp_Pnt p_start(sx, sy, sz);
         gp_Pnt p_mid(mx, my, mz);
         gp_Pnt p_end(ex, ey, ez);
-        // Standard_False: do not wrap around; the arc goes from start through
+        // false: do not wrap around; the arc goes from start through
         // mid to end on the unique circle defined by those three points.
         GC_MakeArcOfCircle maker(p_start, p_mid, p_end);
         if (!maker.IsDone()) return nullptr;
@@ -944,23 +945,23 @@ std::unique_ptr<TopoDS_Edge> make_bspline_edge(
 {
     if (coords.size() < 6 || coords.size() % 3 != 0) return nullptr;
     try {
-        const Standard_Integer n = static_cast<Standard_Integer>(coords.size() / 3);
-        Handle(TColgp_HArray1OfPnt) pts = new TColgp_HArray1OfPnt(1, n);
-        for (Standard_Integer i = 0; i < n; ++i) {
+        const int n = static_cast<int>(coords.size() / 3);
+        Handle(NCollection_HArray1<gp_Pnt>) pts = new NCollection_HArray1<gp_Pnt>(1, n);
+        for (int i = 0; i < n; ++i) {
             pts->SetValue(i + 1, gp_Pnt(coords[i * 3], coords[i * 3 + 1], coords[i * 3 + 2]));
         }
 
-        const Standard_Boolean periodic = (end_kind == 0) ? Standard_True : Standard_False;
+        const bool periodic = (end_kind == 0) ? true : false;
         GeomAPI_Interpolate interp(pts, periodic, Precision::Confusion());
 
         if (end_kind == 2) {
             // Clamped: load explicit start and end tangent vectors.
-            // Scale = Standard_True lets OCCT scale the tangent magnitude
+            // Scale = true lets OCCT scale the tangent magnitude
             // by the chord length, which usually gives more intuitive
             // pull strength than the raw vector magnitude.
             gp_Vec start_tan(sx, sy, sz);
             gp_Vec end_tan(ex, ey, ez);
-            interp.Load(start_tan, end_tan, Standard_True);
+            interp.Load(start_tan, end_tan, true);
         } else if (end_kind != 0 && end_kind != 1) {
             // Unknown end_kind; fail rather than silently picking a default.
             return nullptr;
@@ -1029,7 +1030,7 @@ static std::unique_ptr<TopoDS_Edge> transform_edge_impl(
     const TopoDS_Edge& edge, const gp_Trsf& trsf)
 {
     try {
-        BRepBuilderAPI_Transform transform(edge, trsf, Standard_True);
+        BRepBuilderAPI_Transform transform(edge, trsf, true);
         return std::make_unique<TopoDS_Edge>(TopoDS::Edge(transform.Shape()));
     } catch (const Standard_Failure&) {
         return nullptr;
@@ -1135,7 +1136,7 @@ std::unique_ptr<TopoDS_Shape> make_pipe_shell(
             }
             case 1: {
                 // Torsion: raw Frenet.
-                shell.SetMode(Standard_True);
+                shell.SetMode(true);
                 break;
             }
             case 2: {
@@ -1151,11 +1152,11 @@ std::unique_ptr<TopoDS_Shape> make_pipe_shell(
                 BRepBuilderAPI_MakeWire auxMaker;
                 for (const auto& e : aux_spine_edges) auxMaker.Add(e);
                 if (!auxMaker.IsDone()) return nullptr;
-                shell.SetMode(auxMaker.Wire(), Standard_False);
+                shell.SetMode(auxMaker.Wire(), false);
                 break;
             }
             default: {
-                shell.SetMode(Standard_True);
+                shell.SetMode(true);
                 break;
             }
         }
@@ -1166,7 +1167,7 @@ std::unique_ptr<TopoDS_Shape> make_pipe_shell(
         for (const auto& e : all_edges) {
             if (e.IsNull()) {
                 if (!wire_maker.IsDone()) return nullptr;
-                shell.Add(wire_maker.Wire(), Standard_False, Standard_False);
+                shell.Add(wire_maker.Wire(), false, false);
                 wire_maker = BRepBuilderAPI_MakeWire();
                 has_edges = false;
             } else {
@@ -1177,7 +1178,7 @@ std::unique_ptr<TopoDS_Shape> make_pipe_shell(
         // Last section (after final sentinel or single section with no sentinel).
         if (has_edges) {
             if (!wire_maker.IsDone()) return nullptr;
-            shell.Add(wire_maker.Wire(), Standard_False, Standard_False);
+            shell.Add(wire_maker.Wire(), false, false);
         }
 
         shell.Build();
@@ -1218,8 +1219,8 @@ std::unique_ptr<TopoDS_Shape> make_loft(
 {
     try {
         BRepOffsetAPI_ThruSections loft(
-            /*isSolid=*/Standard_True,
-            /*isRuled=*/Standard_False,
+            /*isSolid=*/true,
+            /*isRuled=*/false,
             Precision::Confusion());
 
         // Split all_edges by null sentinels into section wires.
@@ -1268,7 +1269,8 @@ std::unique_ptr<TopoDS_Shape> make_loft(
 #include <STEPCAFControl_Writer.hxx>
 #include <TDocStd_Document.hxx>
 #include <TDF_ChildIterator.hxx>
-#include <TDF_LabelSequence.hxx>
+#include <NCollection_Sequence.hxx>
+#include <TDF_Label.hxx>
 #include <Quantity_Color.hxx>
 
 namespace cadrum {
@@ -1280,7 +1282,7 @@ static void collect_face_colors(
     const Handle(XCAFDoc_ColorTool)& colorTool,
     std::unordered_map<uint64_t, std::array<float, 3>>& colorMap)
 {
-    for (TDF_ChildIterator it(doc->Main(), Standard_True); it.More(); it.Next()) {
+    for (TDF_ChildIterator it(doc->Main(), true); it.More(); it.Next()) {
         const TDF_Label& label = it.Value();
         if (!XCAFDoc_ShapeTool::IsShape(label)) continue;
 
@@ -1305,7 +1307,7 @@ std::unique_ptr<ColoredStepData> read_step_color_stream(RustReader& reader) {
         Handle(TDocStd_Document) doc = new TDocStd_Document("XmlXCAF");
 
         STEPCAFControl_Reader cafreader;
-        cafreader.SetColorMode(Standard_True);
+        cafreader.SetColorMode(true);
 
         RustReadStreambuf sbuf(reader);
         std::istream is(&sbuf);
@@ -1322,7 +1324,7 @@ std::unique_ptr<ColoredStepData> read_step_color_stream(RustReader& reader) {
             XCAFDoc_DocumentTool::ColorTool(doc->Main());
 
         // Collect all free shapes into a compound.
-        TDF_LabelSequence roots;
+        NCollection_Sequence<TDF_Label> roots;
         shapeTool->GetFreeShapes(roots);
 
         BRep_Builder builder;
@@ -1402,7 +1404,7 @@ bool write_step_color_stream(
             XCAFDoc_DocumentTool::ColorTool(doc->Main());
 
         // Register the root shape.
-        TDF_Label rootLabel = shapeTool->AddShape(shape, Standard_False);
+        TDF_Label rootLabel = shapeTool->AddShape(shape, false);
 
         // Build TShape* → color lookup from the Rust-supplied arrays.
         std::unordered_map<uint64_t, std::array<float, 3>> colorLookup;
@@ -1429,7 +1431,7 @@ bool write_step_color_stream(
 
         // Transfer XDE doc to STEP model and write to stream.
         STEPCAFControl_Writer cafwriter;
-        cafwriter.SetColorMode(Standard_True);
+        cafwriter.SetColorMode(true);
         if (!cafwriter.Transfer(doc)) {
             return false;
         }
@@ -1446,8 +1448,8 @@ bool write_step_color_stream(
 
 std::unique_ptr<CleanShape> clean_shape_full(const TopoDS_Shape& shape) {
     try {
-        ShapeUpgrade_UnifySameDomain unifier(shape, Standard_True, Standard_True, Standard_True);
-        unifier.AllowInternalEdges(Standard_False);
+        ShapeUpgrade_UnifySameDomain unifier(shape, true, true, true);
+        unifier.AllowInternalEdges(false);
         unifier.Build();
 
         auto r = std::make_unique<CleanShape>();
@@ -1459,7 +1461,7 @@ std::unique_ptr<CleanShape> clean_shape_full(const TopoDS_Shape& shape) {
                 const TopoDS_Shape& old_face = ex.Current();
                 uint64_t old_id = reinterpret_cast<uint64_t>(old_face.TShape().get());
                 if (history->IsRemoved(old_face)) continue;
-                const TopTools_ListOfShape& mods = history->Modified(old_face);
+                const NCollection_List<TopoDS_Shape>& mods = history->Modified(old_face);
                 if (mods.IsEmpty()) {
                     // Unchanged: TShape* is the same in the result.
                     r->mapping.push_back(old_id);

--- a/notes/20260411-OCCT8移行計画.md
+++ b/notes/20260411-OCCT8移行計画.md
@@ -1,0 +1,65 @@
+# OCCT 7.9.3 → 8.0.0-rc5 移行計画
+
+## 背景
+cadrum は現在 OCCT 7.9.3 (GitHub tag `V7_9_3`) をビルド時に自動ダウンロード・ビルドしている。
+OCCT 8.0.0-rc5 (2026-04-06 リリース、7.9.0 からの累計変更 460+) に移行し、新機能を利用可能にする。
+
+### 8.0.0-rc5 の主な新機能
+- Gordon曲面構築（N×M曲線ネットワークからの超越補間）
+- BRepGraph（トポロジのグラフベース表現、49,000行超）
+- GeomBndLib（ジオメトリ対応バウンディングボックス）
+- Geom2dProp / GeomProp / BRepProp パッケージ刷新
+- STEP 読み込み性能 7.7 比最大 75% 高速化
+- スレッド安全性向上
+
+## 影響分析
+
+### 8.0.0 の破壊的変更と cadrum への影響
+
+| 破壊的変更 | cadrum への影響 |
+|---|---|
+| TColGeom / TColGeom2d 削除 | **なし** — 使用箇所なし |
+| Geom2dLProp / LProp3d 削除 | **なし** — 使用箇所なし |
+| GProp_EquaType 列挙型削除 | **なし** — 使用箇所なし |
+| D0-DN → EvalD\* (サブクラスのオーバーライド) | **なし** — cadrum は `BRepAdaptor_Curve::D1()` を呼び出し側として使用するのみ（サブクラス化なし）。wrapper.cpp:1000, 1130 |
+| Handle 出力パラメータ非推奨化 | **なし** — cadrum は戻り値スタイルを既に使用 |
+| Prop/GridEval デフォルトコンストラクタ削除 | **なし** — 使用箇所なし |
+| ライブラリ名変更 | **なし** — TKShHealing, TKBin, TKDESTEP は 7.9.3 と同名 |
+
+### この機会に行うクリーンアップ
+- `BRepGProp_Face prop_face(face);` (wrapper.cpp:635) が宣言後未使用のデッドコード → 削除
+- `#include <BRepGProp_Face.hxx>` (wrapper.cpp:67) も不要になる → 削除
+
+## 変更対象ファイル
+
+### 1. `build.rs`
+- L144: doc comment `7.9.3` → `8.0.0-rc5`
+- L146: `let occt_version = "V7_9_3";` → `"V8_0_0_rc5"`
+- ダウンロード URL テンプレートは変更不要（同じ GitHub archive パターン）
+- 抽出ディレクトリ自動検出 (`starts_with("OCCT")`) も変更不要
+- パッチ対象の相対パス (`src/XCAFDoc/XCAFDoc_VisMaterial.cxx`, `src/XCAFPrs/XCAFPrs_Texture.cxx`) — 8.0.0 でもパスが同じか要ビルド検証
+
+### 2. `Cargo.toml`
+- L5 description: `"OCCT 7.9.3"` → `"OCCT 8.0.0-rc5"`
+
+### 3. `cpp/wrapper.cpp`
+- L67: `#include <BRepGProp_Face.hxx>` 削除
+- L635: `BRepGProp_Face prop_face(face);` 削除
+
+### 変更しないもの
+- `cpp/wrapper.h` — 変更不要
+- ライブラリリンク一覧 (build.rs L37-114) — 名前変更なし
+- CMake 設定 (build.rs L208-244) — モジュール構成変更なし
+
+## 検証手順
+1. `target/occt/` を削除（プリビルド済みライブラリのキャッシュ破棄）
+2. `cargo build` — OCCT 8.0.0-rc5 のダウンロード・パッチ・CMake ビルド・リンクが通ることを確認
+3. `cargo test` — 全テスト通過
+4. `cargo run --example 00_box` 等 — 実行時エラーなし、SVG/STEP 出力が正常
+5. `cargo build --features color` — color 機能のビルド確認
+6. パッチが当たっていることをビルドログで確認 (`Stubbed XCAFDoc_VisMaterial.cxx` 等)
+
+## リスク
+- パッチ対象ファイルが 8.0.0 で移動/削除されている場合 → パッチ関数の修正が必要
+- D1() 呼び出しの挙動変更 → ビルドは通るが結果が異なる可能性 → テストで検証
+- CMake ビルド設定の変更 → 新モジュール追加等で設定項目が増えている可能性

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! # cadrum
 //!
-//! Rust CAD library powered by OpenCASCADE (OCCT 7.9.3).
+//! Rust CAD library powered by OpenCASCADE (OCCT 8.0.0-rc5).
 //!
 //! ## Core Types
 //! - [`Solid`] — a single solid shape (wraps `TopoDS_Shape` / `TopAbs_SOLID`)


### PR DESCRIPTION
Title: feat: migrate OCCT 7.9.3 → 8.0.0-rc5

  Body:

  ## Summary
  - OCCT 7.9.3 から 8.0.0-rc5 へ移行（GitHub tag `V7_9_3` → `V8_0_0_rc5`）
  - wrapper.cpp の非推奨 API を修正: `TopTools_*` → `NCollection_*`、`Standard_True/False` → `true/false`、`TColgp_HArray1OfPnt` → `NCollection_HArray1<gp_Pnt>` 等    
  - build.rs のパッチ処理を OCCT 8.0.0 の新ディレクトリ構造（`src/<Module>/<Toolkit>/<Package>/`）に対応させつつ、旧レイアウト（≤7.9.x）へのフォールバックも維持       
  - デッドコード削除: 未使用の `BRepGProp_Face` include と変数

  ## 変更ファイル
  - `build.rs` — バージョン変更、パッチパス対応
  - `cpp/wrapper.cpp` — 非推奨 API 置換、デッドコード削除
  - `Cargo.toml`, `README.md`, `src/lib.rs` — バージョン表記更新
  - `notes/20260411-OCCT8移行計画.md` — 移行計画ドキュメント

  ## Test plan
  - [ ] `target/occt/` 削除後 `cargo build` で OCCT 8.0.0-rc5 のダウンロード・ビルド・リンク成功
  - [ ] `cargo test` 全テスト通過
  - [ ] `cargo run --example 00_box` 等で SVG/STEP 出力が正常
  - [ ] `cargo build --features color` ビルド成功