### PR TITLE
refactor(build): unify OCCT cache + replace prebuilt feature with source-build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,15 @@ categories = ["graphics", "science"]
 exclude = ["/figure", "/notes", "/steps", "/sandbox*", "/.github"]
 
 [features]
-default = ["color", "prebuilt"]
+default = ["color"]
 # Enable TShapeId, Rgb, and colormap on Shape for face-level color tracking
 color = []
 # Pure Rust CAD backend (no OCCT dependency)
 pure = []
-# Download prebuilt OCCT tarball from GitHub Release instead of building from source
-prebuilt = []
+# Build OCCT from upstream sources when the cache is empty, instead of
+# downloading a prebuilt tarball. Off by default — most users will use the
+# prebuilt binary path.
+source-build = []
 
 [dependencies]
 cxx = "1"

--- a/README.md
+++ b/README.md
@@ -654,20 +654,24 @@ Prebuilts are published for these targets:
 - `x86_64-pc-windows-gnu`
 - `x86_64-pc-windows-msvc`
 
-Resolution order (build.rs picks the first option that applies):
+Resolution model (build.rs):
 
-1. **`OCCT_ROOT` env var** — if set and the directory already contains OCCT libs, link directly.
-   If set but empty, OCCT is built from source into that directory.
-2. **`prebuilt` cargo feature (default ON)** — for supported targets, download the matching
-   tarball from GitHub Release and extract under `target/`. Falls through to source build on
-   network failure or 404.
-3. **Source build** — download OCCT source from upstream and build with CMake into
-   `target/occt/` (10–30 minutes).
+1. `OCCT_ROOT` defines the single cache location. If unset, it defaults to
+   `target/cadrum-occt-v800rc5-<triple>/`. Whether explicit or default, the
+   semantics are the same: if the directory already contains OCCT headers
+   and libs, link directly.
+2. **Cache miss** — populate the cache:
+   - Without `source-build` feature (default): download the prebuilt tarball
+     for `<triple>` from GitHub Release and extract into the cache dir.
+     If the target is not in the supported list, `build.rs` panics with a
+     pointer back here.
+   - With `source-build` feature: download OCCT source from upstream and
+     build with CMake into the cache dir (10–30 minutes).
 
-To force the source build path (e.g. unsupported target, or you want to patch OCCT locally):
+To build on an unsupported triple, or to patch OCCT locally:
 
 ```sh
-cargo build --no-default-features --features color
+cargo build --features source-build
 ```
 
 To pin OCCT to a persistent location across `cargo clean`:
@@ -682,6 +686,9 @@ cargo build
 - `color` (default): Colored STEP I/O via XDE (`STEPCAFControl`). Enables `write_step_with_colors`,
   `read_step_with_colors`, and per-face color on `Solid`.
   Colors are preserved through boolean operations and other transformations.
+- `source-build` (default OFF): Build OCCT from upstream sources via CMake when the cache is
+  empty, instead of downloading a prebuilt tarball. Enable this if you are on a triple with no
+  published prebuilt, or if you want to patch OCCT locally.
 
 ## Showcase
 

--- a/build.rs
+++ b/build.rs
@@ -352,9 +352,15 @@ fn build_occt_from_source(out_dir: &Path, install_prefix: &Path) -> (PathBuf, Pa
 			// and rejects any non-ASCII byte in narrow string literals. OCCT's
 			// .rc files are cp1252-encoded (the © character arrives as a single
 			// 0xA9 byte, per the error's "codepoint (169)"), so tell llvm-rc to
-			// interpret narrow strings as cp1252. This is a no-op on Unix RC
-			// toolchains (there is no RC step on non-Windows targets).
-			.define("CMAKE_RC_FLAGS", "-C 1252")
+			// interpret narrow strings as cp1252.
+			//
+			// We pass this via CMAKE_RC_FLAGS_INIT, NOT CMAKE_RC_FLAGS, because
+			// cargo-xwin's override.cmake contains this line:
+			//   string(REPLACE "/D" "-D" CMAKE_RC_FLAGS "${CMAKE_RC_FLAGS_INIT}")
+			// which unconditionally overwrites whatever we set in CMAKE_RC_FLAGS.
+			// CMAKE_RC_FLAGS_INIT survives the overwrite and flows through the
+			// REPLACE into CMAKE_RC_FLAGS. Harmless on Unix targets (no RC step).
+			.define("CMAKE_RC_FLAGS_INIT", "-C 1252")
 			.build();
 
 		eprintln!("OCCT built at: {}", built.display());

--- a/build.rs
+++ b/build.rs
@@ -385,7 +385,8 @@ fn find_occt_lib_dir(occt_root: &Path) -> PathBuf {
 	occt_root.join("lib")
 }
 
-/// Patch OCCT source files to remove unwanted link dependencies:
+/// Patch OCCT source files to work around unwanted link dependencies and
+/// platform-specific toolchain quirks:
 ///
 /// 1. TKService (Visualization) — even with BUILD_MODULE_Visualization=OFF:
 ///    - XCAFDoc_VisMaterial.cxx: stub bodies that use Graphic3d_* types.
@@ -398,6 +399,15 @@ fn find_occt_lib_dir(occt_root: &Path) -> PathBuf {
 ///    - OSD_signal.cxx: stub bodies (MessageBoxA / MessageBeep on MSVC).
 ///    - OSD_FileNode.cxx: stub bodies (SetFileSecurityW + OSD_WNT helpers).
 ///    - OSD_Process.cxx: stub bodies (OpenProcessToken, GetUserNameW, EqualSid).
+///
+/// 3. glibc-only headers (musl target):
+///    - Standard_StackTrace.cxx: stub bodies (backtrace, backtrace_symbols)
+///      and comment out `<execinfo.h>` which musl does not ship.
+///
+/// 4. llvm-rc narrow-string ASCII restriction (cargo-xwin MSVC target):
+///    - Every `.rc` / `.rc.in` file under the source tree: replace `©` (0xA9)
+///      with `(c)` so llvm-rc does not reject the non-ASCII byte in
+///      VERSIONINFO narrow string literals.
 fn patch_occt_sources(source_dir: &Path) {
 	// OCCT 8.0.0 moved sources under src/<Module>/<Toolkit>/<Package>/ hierarchy.
 	// Try the new layout first, fall back to the legacy flat layout (≤7.9.x).
@@ -450,6 +460,83 @@ fn patch_occt_sources(source_dir: &Path) {
 	// OSD_Process.cxx: OpenProcessToken, GetUserNameW, EqualSid (advapi32).
 	if let Some(path) = find_osd("OSD_Process.cxx") {
 		stub_out_methods(&path, true);
+	}
+
+	// --- musl: execinfo.h is a glibc extension, not present in musl libc. ---
+	// Standard_StackTrace.cxx uses backtrace() / backtrace_symbols() for error
+	// reporting. Stub the method bodies so the calls disappear, then comment
+	// out the <execinfo.h> include so the preprocessor no longer tries to find
+	// the missing header.
+	let stack_trace = [
+		"src/FoundationClasses/TKernel/Standard/Standard_StackTrace.cxx",
+		"src/Standard/Standard_StackTrace.cxx",
+	];
+	if let Some(path) = find(&stack_trace) {
+		stub_out_methods(&path, true);
+		comment_out_include(&path, "execinfo.h");
+	}
+
+	// --- llvm-rc (cargo-xwin): narrow string literals must be pure ASCII. ---
+	// OCCT's TKernel.rc embeds the copyright symbol © (0xA9) in a VERSIONINFO
+	// narrow string. MSVC's rc.exe accepts this, but llvm-rc — which cargo-xwin
+	// uses for MSVC cross-builds — rejects any non-ASCII byte in a non-Unicode
+	// string. Walk the source tree and replace © with (c) in every .rc / .rc.in
+	// file so all RC toolchains accept the result.
+	walk_and_sanitize_rc(source_dir);
+}
+
+/// Comment out a `#include <name>` directive in `path`. Used to sever the
+/// dependency on platform-specific headers (e.g. `execinfo.h` on musl) after
+/// the referring method bodies have been stubbed out.
+fn comment_out_include(path: &Path, header: &str) {
+	if !path.exists() {
+		return;
+	}
+	let content = std::fs::read_to_string(path).expect("Failed to read file for include patching");
+	let needle = format!("#include <{}>", header);
+	if !content.contains(&needle) {
+		return;
+	}
+	let replacement = format!("// {} (patched out by cadrum build.rs)", needle);
+	let patched = content.replace(&needle, &replacement);
+	std::fs::write(path, patched).expect("Failed to write patched include file");
+	eprintln!("Patched out <{}> in {}", header, path.file_name().unwrap().to_string_lossy());
+}
+
+/// Replace the copyright symbol © (U+00A9) with `(c)` in every `.rc` / `.rc.in`
+/// file under `root`. llvm-rc (used by cargo-xwin for MSVC cross-builds)
+/// rejects non-ASCII bytes in narrow RC string literals. Replacing the single
+/// offending character keeps the file pure ASCII, which every RC toolchain
+/// accepts without any codepage or encoding gymnastics.
+fn walk_and_sanitize_rc(root: &Path) {
+	let Ok(entries) = std::fs::read_dir(root) else { return };
+	for entry in entries.flatten() {
+		let path = entry.path();
+		if path.is_dir() {
+			walk_and_sanitize_rc(&path);
+			continue;
+		}
+		let Some(name) = path.file_name().and_then(|n| n.to_str()) else { continue };
+		if !(name.ends_with(".rc") || name.ends_with(".rc.in")) {
+			continue;
+		}
+		let Ok(bytes) = std::fs::read(&path) else { continue };
+		// Handle both UTF-8 (© = 0xC2 0xA9) and Latin1/ANSI (© = 0xA9) encodings.
+		let patched: Vec<u8> = if let Ok(s) = std::str::from_utf8(&bytes) {
+			let replaced = s.replace('\u{A9}', "(c)");
+			if replaced == s { continue; }
+			replaced.into_bytes()
+		} else {
+			if !bytes.contains(&0xA9) { continue; }
+			let mut out = Vec::with_capacity(bytes.len());
+			for &b in &bytes {
+				if b == 0xA9 { out.extend_from_slice(b"(c)"); } else { out.push(b); }
+			}
+			out
+		};
+		if std::fs::write(&path, patched).is_ok() {
+			eprintln!("Sanitized © → (c) in {}", path.display());
+		}
 	}
 }
 

--- a/build.rs
+++ b/build.rs
@@ -348,6 +348,13 @@ fn build_occt_from_source(out_dir: &Path, install_prefix: &Path) -> (PathBuf, Pa
 			.define("BUILD_SAMPLES_QT", "OFF")
 			.define("BUILD_Inspector", "OFF")
 			.define("BUILD_ENABLE_FPE_SIGNAL_HANDLER", "OFF")
+			// llvm-rc (cargo-xwin MSVC path) defaults to codepage 0 (ASCII only)
+			// and rejects any non-ASCII byte in narrow string literals. OCCT's
+			// .rc files are cp1252-encoded (the © character arrives as a single
+			// 0xA9 byte, per the error's "codepoint (169)"), so tell llvm-rc to
+			// interpret narrow strings as cp1252. This is a no-op on Unix RC
+			// toolchains (there is no RC step on non-Windows targets).
+			.define("CMAKE_RC_FLAGS", "-C 1252")
 			.build();
 
 		eprintln!("OCCT built at: {}", built.display());
@@ -404,10 +411,11 @@ fn find_occt_lib_dir(occt_root: &Path) -> PathBuf {
 ///    - Standard_StackTrace.cxx: stub bodies (backtrace, backtrace_symbols)
 ///      and comment out `<execinfo.h>` which musl does not ship.
 ///
-/// 4. llvm-rc narrow-string ASCII restriction (cargo-xwin MSVC target):
-///    - Every `.rc` / `.rc.in` file under the source tree: replace `©` (0xA9)
-///      with `(c)` so llvm-rc does not reject the non-ASCII byte in
-///      VERSIONINFO narrow string literals.
+/// Note on the llvm-rc non-ASCII issue (cargo-xwin MSVC target): this is
+/// NOT patched here. It is handled at the CMake layer by passing
+/// `CMAKE_RC_FLAGS=-C 1252` so llvm-rc interprets narrow RC string literals
+/// as cp1252, accepting the whole range of Latin-1 characters instead of
+/// rejecting any byte above 0x7F.
 fn patch_occt_sources(source_dir: &Path) {
 	// OCCT 8.0.0 moved sources under src/<Module>/<Toolkit>/<Package>/ hierarchy.
 	// Try the new layout first, fall back to the legacy flat layout (≤7.9.x).
@@ -475,14 +483,6 @@ fn patch_occt_sources(source_dir: &Path) {
 		stub_out_methods(&path, true);
 		comment_out_include(&path, "execinfo.h");
 	}
-
-	// --- llvm-rc (cargo-xwin): narrow string literals must be pure ASCII. ---
-	// OCCT's TKernel.rc embeds the copyright symbol © (0xA9) in a VERSIONINFO
-	// narrow string. MSVC's rc.exe accepts this, but llvm-rc — which cargo-xwin
-	// uses for MSVC cross-builds — rejects any non-ASCII byte in a non-Unicode
-	// string. Walk the source tree and replace © with (c) in every .rc / .rc.in
-	// file so all RC toolchains accept the result.
-	walk_and_sanitize_rc(source_dir);
 }
 
 /// Comment out a `#include <name>` directive in `path`. Used to sever the
@@ -501,43 +501,6 @@ fn comment_out_include(path: &Path, header: &str) {
 	let patched = content.replace(&needle, &replacement);
 	std::fs::write(path, patched).expect("Failed to write patched include file");
 	eprintln!("Patched out <{}> in {}", header, path.file_name().unwrap().to_string_lossy());
-}
-
-/// Replace the copyright symbol © (U+00A9) with `(c)` in every `.rc` / `.rc.in`
-/// file under `root`. llvm-rc (used by cargo-xwin for MSVC cross-builds)
-/// rejects non-ASCII bytes in narrow RC string literals. Replacing the single
-/// offending character keeps the file pure ASCII, which every RC toolchain
-/// accepts without any codepage or encoding gymnastics.
-fn walk_and_sanitize_rc(root: &Path) {
-	let Ok(entries) = std::fs::read_dir(root) else { return };
-	for entry in entries.flatten() {
-		let path = entry.path();
-		if path.is_dir() {
-			walk_and_sanitize_rc(&path);
-			continue;
-		}
-		let Some(name) = path.file_name().and_then(|n| n.to_str()) else { continue };
-		if !(name.ends_with(".rc") || name.ends_with(".rc.in")) {
-			continue;
-		}
-		let Ok(bytes) = std::fs::read(&path) else { continue };
-		// Handle both UTF-8 (© = 0xC2 0xA9) and Latin1/ANSI (© = 0xA9) encodings.
-		let patched: Vec<u8> = if let Ok(s) = std::str::from_utf8(&bytes) {
-			let replaced = s.replace('\u{A9}', "(c)");
-			if replaced == s { continue; }
-			replaced.into_bytes()
-		} else {
-			if !bytes.contains(&0xA9) { continue; }
-			let mut out = Vec::with_capacity(bytes.len());
-			for &b in &bytes {
-				if b == 0xA9 { out.extend_from_slice(b"(c)"); } else { out.push(b); }
-			}
-			out
-		};
-		if std::fs::write(&path, patched).is_ok() {
-			eprintln!("Sanitized © → (c) in {}", path.display());
-		}
-	}
 }
 
 /// Neutralize a C++ source file at `path`.

--- a/build.rs
+++ b/build.rs
@@ -12,13 +12,6 @@ const OCCT_VERSION: &str = "V8_0_0_rc5";
 /// Bump this when rebuilding prebuilts for the same OCCT version.
 const OCCT_PREBUILT_TAG: &str = "occt-v800rc5";
 
-/// Target triples for which prebuilt tarballs are published.
-const PREBUILT_TARGETS: &[&str] = &[
-	"x86_64-unknown-linux-musl",
-	"x86_64-pc-windows-gnu",
-	"x86_64-pc-windows-msvc",
-];
-
 /// `V8_0_0_rc5` → `v800rc5`. Shared rule: lowercase and drop underscores.
 fn slug(version: &str) -> String {
 	version.to_ascii_lowercase().replace('_', "")
@@ -26,6 +19,7 @@ fn slug(version: &str) -> String {
 
 fn main() {
 	println!("cargo:rerun-if-env-changed=OCCT_ROOT");
+	println!("cargo:rerun-if-env-changed=CARGO_TARGET_DIR");
 	println!("cargo:rerun-if-env-changed=CADRUM_PREBUILT_URL");
 	println!("cargo:rerun-if-changed=src/traits.rs");
 	println!("cargo:rerun-if-changed=build_delegation.rs");
@@ -45,58 +39,59 @@ fn main() {
 	link_occt_libraries(&occt_include, &occt_lib_dir, cfg!(feature = "color"));
 }
 
-/// Resolve (include_dir, lib_dir) by priority:
-///   1. explicit `OCCT_ROOT` env var (with libs already present → link-only)
-///   2. `prebuilt` feature + supported target → download & extract tarball
-///   3. fall back to building OCCT from source into `target/occt`
+/// Resolve (include_dir, lib_dir) for OCCT.
+///
+/// Model: `OCCT_ROOT` is the single cache location. If unset, it defaults to
+/// `target/cadrum-occt-<slug>-<target>/`. The `source-build` feature only
+/// changes how a cache miss is populated; it does nothing on a cache hit.
+///
+///   1. Compute `effective_root = OCCT_ROOT or default`
+///   2. If `effective_root` already has both lib and include → use it
+///   3. Otherwise, populate it:
+///        - `source-build` feature ON  → build from upstream OCCT sources
+///        - `source-build` feature OFF → download prebuilt tarball (panic on failure)
 fn resolve_occt(manifest_dir: &Path, out_dir: &Path, target: &str) -> (PathBuf, PathBuf) {
-	// Priority 1: explicit OCCT_ROOT
-	if let Ok(explicit) = env::var("OCCT_ROOT") {
-		let root = PathBuf::from(explicit);
-		let lib_dir = find_occt_lib_dir(&root);
-		println!("cargo:rerun-if-changed={}", lib_dir.display());
-		if lib_dir.exists() {
-			return (find_occt_include_dir(&root), lib_dir);
-		}
-		// OCCT_ROOT set but empty: build into it (legacy behaviour)
-		eprintln!("cargo:warning=OCCT not found at {}. Building from source — this may take 10-30 minutes.", root.display());
-		return build_occt_from_source(out_dir, &root);
+	// Default cache dir lives alongside other cargo build artifacts. Honor
+	// `CARGO_TARGET_DIR` if set so that isolated-per-container builds (docker)
+	// don't all collide on the same OCCT install path.
+	let target_dir: PathBuf = env::var("CARGO_TARGET_DIR").map(PathBuf::from).unwrap_or_else(|_| manifest_dir.join("target"));
+	let default_root = target_dir.join(format!("cadrum-occt-{}-{}", slug(OCCT_VERSION), target));
+	let effective_root: PathBuf = env::var("OCCT_ROOT").map(PathBuf::from).unwrap_or_else(|_| default_root.clone());
+
+	println!("cargo:rerun-if-changed={}", effective_root.display());
+
+	let lib_dir = find_occt_lib_dir(&effective_root);
+	let include_dir = find_occt_include_dir(&effective_root);
+	if lib_dir.exists() && include_dir.exists() {
+		return (include_dir, lib_dir);
 	}
 
-	// Priority 2: prebuilt feature + supported target
-	if cfg!(feature = "prebuilt") && PREBUILT_TARGETS.contains(&target) {
-		let dest = manifest_dir.join("target").join(format!("cadrum-occt-{}-{}", slug(OCCT_VERSION), target));
-		if let Some(result) = try_prebuilt(&dest, target) {
-			return result;
-		}
-		eprintln!("cargo:warning=prebuilt OCCT download failed, falling back to source build");
+	// Cache miss: populate effective_root.
+	if cfg!(feature = "source-build") {
+		eprintln!("cargo:warning=OCCT cache miss at {} — building from source (this may take 10-30 minutes)", effective_root.display());
+		return build_occt_from_source(out_dir, &effective_root);
 	}
 
-	// Priority 3: source build into target/occt (default path when OCCT_ROOT unset)
-	let fallback_root = manifest_dir.join("target").join("occt");
-	let lib_dir = find_occt_lib_dir(&fallback_root);
-	println!("cargo:rerun-if-changed={}", lib_dir.display());
-	if lib_dir.exists() {
-		(find_occt_include_dir(&fallback_root), lib_dir)
-	} else {
-		eprintln!("cargo:warning=OCCT not found at {}. Building from source — this may take 10-30 minutes.", fallback_root.display());
-		build_occt_from_source(out_dir, &fallback_root)
+	match try_prebuilt(out_dir, &effective_root, target) {
+		Some(pair) => pair,
+		None => panic!(
+			"\nFailed to download prebuilt OCCT for target `{}`.\n\
+			 A prebuilt tarball for this target may not be published yet.\n\
+			 See README for the list of supported prebuilt targets, or enable\n\
+			 the `source-build` feature to build OCCT from upstream sources:\n\
+			 \n    cargo build --features source-build\n",
+			target
+		),
 	}
 }
 
 /// Attempt to download and extract a prebuilt OCCT tarball for `target` into `dest`.
-/// Returns None on any failure so the caller can fall back to a source build.
-fn try_prebuilt(dest: &Path, target: &str) -> Option<(PathBuf, PathBuf)> {
-	let lib_dir = find_occt_lib_dir(dest);
-	if lib_dir.exists() {
-		return Some((find_occt_include_dir(dest), lib_dir));
-	}
-
+/// Returns None on any failure; the caller decides whether to panic or fall back.
+fn try_prebuilt(out_dir: &Path, dest: &Path, target: &str) -> Option<(PathBuf, PathBuf)> {
 	let slug_ver = slug(OCCT_VERSION);
-	let tarball_name = format!("cadrum-occt-{}-{}.tar.gz", slug_ver, target);
-	let url = env::var("CADRUM_PREBUILT_URL").unwrap_or_else(|_| {
-		format!("https://github.com/lzpel/cadrum/releases/download/{}/{}", OCCT_PREBUILT_TAG, tarball_name)
-	});
+	let top_name = format!("cadrum-occt-{}-{}", slug_ver, target);
+	let tarball_name = format!("{}.tar.gz", top_name);
+	let url = env::var("CADRUM_PREBUILT_URL").unwrap_or_else(|_| format!("https://github.com/lzpel/cadrum/releases/download/{}/{}", OCCT_PREBUILT_TAG, tarball_name));
 
 	eprintln!("cargo:warning=Downloading prebuilt OCCT from {}", url);
 
@@ -108,15 +103,32 @@ fn try_prebuilt(dest: &Path, target: &str) -> Option<(PathBuf, PathBuf)> {
 		}
 	};
 
-	// Extract into the parent of `dest` — the tarball's top-level directory
-	// is `cadrum-occt-<slug>-<triple>/`, so entries land at `<parent>/<dirname>/...`
-	let parent = dest.parent().expect("dest must have a parent");
-	std::fs::create_dir_all(parent).ok()?;
+	// Extract into a staging directory inside OUT_DIR, then move the tarball's
+	// top-level `<top_name>/` into `dest`. Staging decouples the tarball's
+	// layout from the (possibly user-chosen) `OCCT_ROOT` path.
+	let staging = out_dir.join("occt-prebuilt-staging");
+	let _ = std::fs::remove_dir_all(&staging);
+	std::fs::create_dir_all(&staging).ok()?;
 
 	let gz = libflate::gzip::Decoder::new(&bytes[..]).map_err(|e| eprintln!("cargo:warning=gzip decode failed: {}", e)).ok()?;
 	let mut archive = tar::Archive::new(gz);
-	if let Err(e) = archive.unpack(parent) {
+	if let Err(e) = archive.unpack(&staging) {
 		eprintln!("cargo:warning=tar unpack failed: {}", e);
+		return None;
+	}
+
+	let extracted = staging.join(&top_name);
+	if !extracted.is_dir() {
+		eprintln!("cargo:warning=prebuilt tarball missing expected top-level dir `{}`", top_name);
+		return None;
+	}
+
+	if let Some(parent) = dest.parent() {
+		std::fs::create_dir_all(parent).ok()?;
+	}
+	let _ = std::fs::remove_dir_all(dest);
+	if let Err(e) = std::fs::rename(&extracted, dest) {
+		eprintln!("cargo:warning=failed to move extracted OCCT into {}: {}", dest.display(), e);
 		return None;
 	}
 

--- a/docker/Dockerfile_x86_64-unknown-linux-musl
+++ b/docker/Dockerfile_x86_64-unknown-linux-musl
@@ -1,8 +1,8 @@
 # Prebuild OCCT for x86_64-unknown-linux-musl.
 # rust-musl-cross provides a full musl C/C++ cross toolchain
-# (x86_64-linux-musl-gcc / x86_64-linux-musl-g++) plus rustup with the
-# musl target preinstalled. clux/muslrust does not ship a musl C++
-# compiler, so this image is the more reliable choice for OCCT.
+# (x86_64-unknown-linux-musl-gcc / -g++) plus rustup with the musl target
+# preinstalled. clux/muslrust does not ship a musl C++ compiler, so this
+# image is the more reliable choice for OCCT.
 FROM messense/rust-musl-cross:x86_64-musl
 
 RUN apt-get update && apt-get install -y --no-install-recommends cmake && rm -rf /var/lib/apt/lists/*
@@ -12,10 +12,13 @@ ENV TARGET=x86_64-unknown-linux-musl
 # Target-prefixed env vars only — DO NOT set catch-all CC/CXX/AR, otherwise
 # host build dependencies (compiled against the runner's glibc Linux toolchain)
 # pick up the musl cross compiler and fail to link.
-ENV CC_x86_64_unknown_linux_musl=x86_64-linux-musl-gcc
-ENV CXX_x86_64_unknown_linux_musl=x86_64-linux-musl-g++
-ENV AR_x86_64_unknown_linux_musl=x86_64-linux-musl-ar
-ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=x86_64-linux-musl-gcc
+# Tool names in this image are `x86_64-unknown-linux-musl-*` (verified by
+# `ls /usr/local/musl/bin/`). A previous revision used `x86_64-linux-musl-*`
+# which does not exist in the messense image.
+ENV CC_x86_64_unknown_linux_musl=x86_64-unknown-linux-musl-gcc
+ENV CXX_x86_64_unknown_linux_musl=x86_64-unknown-linux-musl-g++
+ENV AR_x86_64_unknown_linux_musl=x86_64-unknown-linux-musl-ar
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=x86_64-unknown-linux-musl-gcc
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,51 @@
+# docker/
+
+各 Rust ターゲット向けに OCCT をプレビルドし、`build.rs` がダウンロードして利用できる tarball を生成するためのディレクトリ。
+
+## 目的
+
+cadrum は OCCT (C++) に依存しており、ソースからのビルドには cmake・C++ コンパイラ・長いコンパイル時間が必要になる。エンドユーザーが `cargo build` するたびにこれを繰り返すのを避けるため、**ターゲット triple ごとに OCCT をビルド済みの tarball として配布する**。`build.rs` はデフォルトでこの tarball を取得して展開し、リンクするだけで済むようにしている。
+
+このディレクトリは、その **tarball を生成するためのクロスビルド環境** を Docker イメージとして定義する場所。
+
+## 構成
+
+- `Dockerfile_<target-triple>` — ターゲットごとのクロスビルド環境を定義する Dockerfile。ファイル名末尾の triple (例: `x86_64-unknown-linux-musl`) がそのまま `TARGET` 環境変数として使われる
+- `entrypoint.sh` — すべてのイメージで共有する薄いラッパ。`cargo build --features source-build,color` で OCCT をソースからビルドし、`build.rs` が `target/cadrum-occt-<slug>-<TARGET>/` に書き出したディレクトリを glob で拾って tarball 化する
+- `Makefile` — `Dockerfile_*` を自動検出して build / run を駆動するドライバ
+
+## 使い方
+
+```sh
+make -C docker run           # すべてのターゲットを build + run し、out/ に tarball を出力
+make -C docker run-<target>  # 単一ターゲットのみ
+make -C docker build         # イメージのビルドだけ
+make -C docker list          # 検出されたターゲット一覧
+make -C docker clean         # out/ を削除
+```
+
+成果物は `../out/` に 2 種類出力される:
+
+- `cadrum-occt-<occt-slug>-<target>.tar.gz` — プレビルド tarball。トップディレクトリ名は `cadrum-occt-<occt-slug>-<target>/` で、`build.rs` がそのままこの名前で `target/` 配下にキャッシュとして展開することを前提にしている
+- `<target>.log` — そのターゲットの完全なビルドログ
+
+命名ロジック (`<occt-slug>` = `OCCT_VERSION` の小文字化＋アンダースコア除去) は `build.rs` が唯一のソース。`entrypoint.sh` は slug を計算せず、`target/cadrum-occt-*-<TARGET>` を glob で拾うだけ。
+
+ここで作られた tarball を GitHub Release (`OCCT_PREBUILT_TAG` = `occt-v800rc5`) にアップロードすると、エンドユーザーの `cargo build` が自動的にこの tarball を落としてきて使う。
+
+## 現在プレビルドを配布している triple
+
+- `x86_64-unknown-linux-musl`
+- `x86_64-pc-windows-gnu`
+- `x86_64-pc-windows-msvc`
+
+ユーザーがこれ以外の triple を使う場合は `cargo build --features source-build` を付けることで、OCCT を upstream からソースビルドする経路を有効化できる。
+
+## 新しいターゲットを追加するには
+
+1. `Dockerfile_<new-target-triple>` を追加する
+2. 先頭で `ENV TARGET=<new-target-triple>` を設定する
+3. そのターゲット用のクロスコンパイラと必要な環境変数 (`CC_<triple>` / `CXX_<triple>` / `CARGO_TARGET_<TRIPLE>_LINKER` など) を設定する
+4. 末尾で `entrypoint.sh` を `ENTRYPOINT` に指定する
+
+`Makefile` は `Dockerfile_*` を自動検出するので、追加側の変更は不要。

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,69 +1,55 @@
-#!/bin/sh
-# docker/entrypoint.sh — shared entrypoint for all docker/Dockerfile_<target> images.
+#!/bin/bash
+# docker/entrypoint.sh — thin wrapper that source-builds OCCT via cargo and
+# packages the resulting target/cadrum-occt-* directory into a tarball.
 #
-# Runs inside the container with:
+# Inside the container:
 #   /src    = cadrum source tree (rw bind mount)
 #   /out    = artifact output directory (rw bind mount)
 #   $TARGET = rust target triple (set by the Dockerfile)
 #
-# Produces /out/cadrum-occt-<slug>-<TARGET>.tar.gz whose top-level directory
-# is `cadrum-occt-<slug>-<TARGET>/`, matching the extraction path used by
-# build.rs's prebuilt download path.
+# Output:
+#   /out/<TARGET>.log                       — full build log
+#   /out/cadrum-occt-<slug>-<TARGET>.tar.gz — prebuilt tarball
 
-set -eu
+set -euo pipefail
 
 : "${TARGET:?TARGET env var must be set by the Dockerfile}"
 
-# 1. Extract OCCT_VERSION from build.rs (single source of truth: the const).
-OCCT_VERSION=$(grep -oE 'OCCT_VERSION: &str = "[^"]+"' /src/build.rs | sed -E 's/.*"([^"]+)".*/\1/')
-if [ -z "$OCCT_VERSION" ]; then
-    echo "entrypoint.sh: failed to extract OCCT_VERSION from /src/build.rs" >&2
-    exit 1
-fi
-OCCT_SLUG=$(echo "$OCCT_VERSION" | tr 'A-Z' 'a-z' | tr -d '_')
+mkdir -p /out
+LOGFILE="/out/${TARGET}.log"
+: > "$LOGFILE"
+exec > >(tee -a "$LOGFILE") 2>&1
 
-DEST="/tmp/cadrum-occt-${OCCT_SLUG}-${TARGET}"
-TARBALL="/out/cadrum-occt-${OCCT_SLUG}-${TARGET}.tar.gz"
-
-export CARGO_TARGET_DIR=/tmp/target
-export OCCT_ROOT="$DEST"
-
-echo "=== Phase 1: building OCCT from source into $DEST ==="
 cd /src
 
-# prebuilt feature is off here — we are the side that produces the tarball.
-case "$TARGET" in
-    *-pc-windows-msvc)
-        cargo xwin build --release --no-default-features --features color --target "$TARGET"
-        ;;
-    *)
-        cargo build --release --no-default-features --features color --target "$TARGET"
-        ;;
-esac
+# Isolate cargo's target dir per container. /src is a bind mount shared by
+# all parallel make-jobs, so writing to /src/target would serialize every
+# container on cargo's file lock and occasionally cross-pollute caches.
+# Using /tmp (inside the container's own writable layer) gives each
+# container a private build dir and makes `make -j` actually parallel.
+# build.rs reads CARGO_TARGET_DIR to decide where to install OCCT.
+export CARGO_TARGET_DIR=/tmp/target-$TARGET
 
-if [ ! -d "$DEST" ]; then
-    echo "entrypoint.sh: expected OCCT install dir $DEST was not created" >&2
+CARGO=(cargo)
+[[ "$TARGET" == *-pc-windows-msvc ]] && CARGO=(cargo xwin)
+
+echo "=== Building OCCT from source for $TARGET ==="
+"${CARGO[@]}" build --release --no-default-features \
+    --features source-build,color --target "$TARGET"
+
+# build.rs installs OCCT into $CARGO_TARGET_DIR/cadrum-occt-<slug>-<TARGET>/.
+# We don't know <slug> here — glob for the directory.
+shopt -s nullglob
+DIRS=("$CARGO_TARGET_DIR"/cadrum-occt-*-"$TARGET")
+if [ ${#DIRS[@]} -ne 1 ]; then
+    echo "entrypoint.sh: expected exactly one $CARGO_TARGET_DIR/cadrum-occt-*-$TARGET dir, found: ${DIRS[*]}" >&2
     exit 1
 fi
+DIR="${DIRS[0]}"
+NAME="$(basename "$DIR")"
+TARBALL="/out/${NAME}.tar.gz"
 
-echo "=== Phase 2: creating tarball $TARBALL ==="
-mkdir -p /out
-tar czf "$TARBALL" -C /tmp "cadrum-occt-${OCCT_SLUG}-${TARGET}"
+echo "=== Creating tarball $TARBALL from $DIR ==="
+tar -czvf "$TARBALL" -C "$CARGO_TARGET_DIR" "$NAME"
 ls -lh "$TARBALL"
-
-echo "=== Phase 3: smoke test (prebuilt download path via file://) ==="
-rm -rf /tmp/target "$DEST"
-unset OCCT_ROOT
-
-# Now cargo check with default features (prebuilt on). build.rs should fetch
-# from the file:// URL, extract into target/cadrum-occt-<slug>-<target>/, and
-# link against it without triggering a source build.
-CADRUM_PREBUILT_URL="file://${TARBALL}" \
-    cargo check --release --target "$TARGET" 2>&1 | tee /tmp/smoke.log
-
-if grep -q "Building from source" /tmp/smoke.log; then
-    echo "entrypoint.sh: smoke test FAILED — build.rs fell back to source build" >&2
-    exit 1
-fi
-
 echo "=== entrypoint.sh: success ==="


### PR DESCRIPTION
## Summary

`docker/entrypoint.sh` が肥大化していたのを発端に、OCCT のキャッシュ／ビルド経路を整理したリファクタ。

### モデル変更

`OCCT_ROOT` を「単一のキャッシュ位置」として扱う新モデルに統一:

1. `OCCT_ROOT` env var、未設定時は `$CARGO_TARGET_DIR/cadrum-occt-<slug>-<target>/`
2. ここに lib/include が揃っていれば **そのまま使う**（`source-build` feature に無関係）
3. キャッシュミス時のみ、埋め方を `source-build` feature で分岐:
   - OFF (default) → GitHub Release からプレビルド tarball をダウンロード
   - ON → OCCT 公式ソースから CMake ビルド

### feature 整理

- `prebuilt` feature を削除（default に含まれていた）
- `source-build` feature を新設（default OFF）
- default は `["color"]` のみ

### build.rs

- `PREBUILT_TARGETS` ハードコード配列を削除。対応 triple は README に移し、`try_prebuilt` は渡された triple でそのまま URL を組み立てる
- `target/occt` への fallback 経路を削除
- `CARGO_TARGET_DIR` を尊重するように（並列 docker 実行時のキャッシュ隔離用）
- プレビルド展開は `OUT_DIR` 配下の staging に展開してから `OCCT_ROOT` へ `std::fs::rename`（ユーザーが `OCCT_ROOT` を別名で明示したケースにも対応）
- ダウンロード失敗時は fallback せず panic。メッセージに README 参照と `--features source-build` 案内を含める

### docker/entrypoint.sh

70 行 → 50 行にスリム化:

- `grep`/`sed` による `OCCT_VERSION` 抽出と slug 再計算を削除（build.rs に一本化）
- Phase 3 のスモークテスト（`CADRUM_PREBUILT_URL=file://…` の再 `cargo check`）を削除
- `cargo` / `cargo xwin` の分岐を 2 行に圧縮
- ログ出力: `/out/${TARGET}.log`（旧: 長い slug 入りファイル名）
- **`CARGO_TARGET_DIR=/tmp/target-$TARGET` を export** → `/src` 配下の bind mount 経由での cargo ファイルロック衝突を回避し、`make -j` で真に並列実行可能に

### Dockerfile バグ修正

`Dockerfile_x86_64-unknown-linux-musl` のクロスコンパイラ env vars が存在しないツール名を指していたのを修正:

- 旧: `x86_64-linux-musl-g++` (存在しない)
- 新: `x86_64-unknown-linux-musl-g++` (messense/rust-musl-cross イメージの実際のパス名)

`ls /usr/local/musl/bin/` で検証済み。これまでのプレビルドパイプラインはこの image 使用になって以降機能していなかった可能性あり。

## How far I got

- [x] Cargo.toml feature 整理 (`prebuilt` 削除、`source-build` 追加)
- [x] build.rs: `resolve_occt` 書き換え、`PREBUILT_TARGETS` 削除、`try_prebuilt` staging-then-rename 化、`CARGO_TARGET_DIR` 尊重
- [x] docker/entrypoint.sh スリム化 + per-container 隔離
- [x] docker/Dockerfile_x86_64-unknown-linux-musl 修正 (tool 名)
- [x] docker/README.md 作成
- [x] README.md の Build セクション更新
- [x] コンパイル検証: `cargo build --features source-build` がコンパイルエラーなくビルド開始することを確認（1 回目は `unwrap_or_else` の closure arity で失敗 → `|_|` で修正済み）
- [x] `make -C docker run` 1 回目: `x86_64-pc-windows-gnu` 成功、`out/cadrum-occt-v800rc5-x86_64-pc-windows-gnu.tar.gz` (55MB) 生成。musl は Dockerfile のツール名バグで失敗、MSVC は走行中にキャンセル

## What's NOT verified yet

**時間切れで途中キャンセル**。以下は次回のセッションで確認が必要:

1. **`make -C docker -j3 run` の 3 ターゲット全成功**
   - 2 回目の run (`/tmp/target-$TARGET` 隔離 + musl tool 名修正込み) は開始直後でキャンセルした
   - 期待値: `out/` に 3 × `.tar.gz` + 3 × `.log` が揃う
   - 期待される tarball 名:
     - `cadrum-occt-v800rc5-x86_64-unknown-linux-musl.tar.gz`
     - `cadrum-occt-v800rc5-x86_64-pc-windows-gnu.tar.gz`
     - `cadrum-occt-v800rc5-x86_64-pc-windows-msvc.tar.gz`

2. **並列化の効果の確認**
   - `/src/target` 共有による cargo file lock で前回は実質シリアル実行になっていた
   - 今回の `CARGO_TARGET_DIR=/tmp/target-$TARGET` で本当に並列で走るか未確認

3. **プレビルド経路 (`source-build` 未指定) のスモークテスト**
   - entrypoint.sh 内の Phase 3 を削除したので、ローカルで手動確認する必要あり
   - コマンド例:
     ```
     CADRUM_PREBUILT_URL=file:///abs/path/to/tarball.tar.gz \
         cargo check --target x86_64-unknown-linux-musl
     ```
   - `try_prebuilt` の新しい staging-then-rename ロジック、特に `file://` URL からのダウンロード → gzip/tar 展開 → `std::fs::rename` が動くかを確認

4. **`OCCT_ROOT` 明示指定での動作**
   - 新モデルだと「OCCT_ROOT 明示」と「デフォルト」が同じ扱いになるよう意図しているが、環境変数で別名ディレクトリを指したときに `try_prebuilt` が rename でそこへ投下できるか、未確認

5. **`cargo check`（例: example の再ビルド）が既存のキャッシュを壊さないか**
   - 新 build.rs は lib+include 両方が揃っていれば cache hit とみなす
   - 既存の `target/occt/` 配下のビルドアーティファクトは使われなくなるので、手元にそれがあるなら一度 `cargo clean` を推奨

## Test plan

- [ ] `make -C docker clean && make -C docker -j3 run` を最後まで回して 3 tarball + 3 log を生成
- [ ] 各 tarball を `tar tzf` で開いてトップディレクトリ名を確認 (`cadrum-occt-v800rc5-<target>/`)
- [ ] `out/<TARGET>.log` それぞれに "entrypoint.sh: success" 行があることを確認
- [ ] 並列走行中に `docker ps` で 3 コンテナが同時に Running になることを目視確認
- [ ] ローカルで `CADRUM_PREBUILT_URL=file://$(pwd)/out/cadrum-occt-v800rc5-x86_64-unknown-linux-musl.tar.gz cargo check --target x86_64-unknown-linux-musl` を実行してプレビルド経路を疎通確認
- [ ] `OCCT_ROOT=/custom/path cargo build --features source-build` で明示キャッシュ位置が機能することを確認
- [ ] GitHub Release `occt-v800rc5` に 3 tarball をアップロードし、fresh clone で `cargo build` がデフォルト経路で動くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)