### PR TITLE
fix(build): gate OSD_* stubs to Windows targets only

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -405,6 +405,20 @@ fn patch_occt_sources(source_dir: &Path) {
 	}
 
 	// --- Eliminate advapi32 / user32 dependencies from TKernel's OSD package ---
+	//
+	// These stubs are only needed when building OCCT for a Windows target: the
+	// advapi32/user32 symbols they reference (GetUserNameW, MessageBoxA, etc.)
+	// are Windows-only. On Linux the very same source files compile to real,
+	// working POSIX implementations via `#ifdef _WIN32`, so stubbing them on
+	// Linux deletes those implementations and — because `stub_out_methods`
+	// replaces non-void bodies with `{}` which is UB — GCC -O3 emits trap
+	// instructions that crash the moment any STEP/threadpool code path reaches
+	// `OSD_Process::SystemDate`, `OSD::SignalMode`, etc.
+	let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+	if target_os != "windows" {
+		return;
+	}
+
 	let osd = |name: &str| [
 		format!("src/FoundationClasses/TKernel/OSD/{name}"),
 		format!("src/OSD/{name}"),

--- a/build.rs
+++ b/build.rs
@@ -394,6 +394,14 @@ fn patch_occt_sources(source_dir: &Path) {
 
 	let find = |candidates: &[&str]| candidates.iter().map(|p| source_dir.join(p)).find(|p| p.exists());
 
+	let osd = |name: &str| [
+		format!("src/FoundationClasses/TKernel/OSD/{name}"),
+		format!("src/OSD/{name}"),
+	];
+	let find_osd = |name: &str| {
+		let candidates = osd(name);
+		candidates.into_iter().map(|p| source_dir.join(p)).find(|p| p.exists())
+	};
 	// Stub method bodies only: keep #includes and signatures, empty the bodies.
 	if let Some(path) = find(&vis_material) {
 		stub_out_methods(&path, true);
@@ -403,7 +411,6 @@ fn patch_occt_sources(source_dir: &Path) {
 	if let Some(path) = find(&prs_texture) {
 		stub_out_methods(&path, false);
 	}
-
 	// --- Eliminate advapi32 / user32 dependencies from TKernel's OSD package ---
 	//
 	// These stubs are only needed when building OCCT for a Windows target: the
@@ -414,44 +421,32 @@ fn patch_occt_sources(source_dir: &Path) {
 	// replaces non-void bodies with `{}` which is UB — GCC -O3 emits trap
 	// instructions that crash the moment any STEP/threadpool code path reaches
 	// `OSD_Process::SystemDate`, `OSD::SignalMode`, etc.
-	let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
-	if target_os != "windows" {
-		return;
-	}
-
-	let osd = |name: &str| [
-		format!("src/FoundationClasses/TKernel/OSD/{name}"),
-		format!("src/OSD/{name}"),
-	];
-	let find_osd = |name: &str| {
-		let candidates = osd(name);
-		candidates.into_iter().map(|p| source_dir.join(p)).find(|p| p.exists())
-	};
-
-	// OSD_WNT.cxx: static initialiser calls AllocateAndInitializeSid (advapi32).
-	// Module-internal only — no external interface needed.
-	if let Some(path) = find_osd("OSD_WNT.cxx") {
-		stub_out_methods(&path, false);
-	}
-	// OSD_File.cxx: OpenProcessToken, SetSecurityDescriptorDacl, etc. (advapi32).
-	if let Some(path) = find_osd("OSD_File.cxx") {
-		stub_out_methods(&path, true);
-	}
-	// OSD_Protection.cxx: EqualSid, LookupAccountNameW, etc. (advapi32).
-	if let Some(path) = find_osd("OSD_Protection.cxx") {
-		stub_out_methods(&path, true);
-	}
-	// OSD_signal.cxx: MessageBoxA / MessageBeep (user32) on MSVC.
-	if let Some(path) = find_osd("OSD_signal.cxx") {
-		stub_out_methods(&path, true);
-	}
-	// OSD_FileNode.cxx: SetFileSecurityW (advapi32) + OSD_WNT helpers.
-	if let Some(path) = find_osd("OSD_FileNode.cxx") {
-		stub_out_methods(&path, true);
-	}
-	// OSD_Process.cxx: OpenProcessToken, GetUserNameW, EqualSid (advapi32).
-	if let Some(path) = find_osd("OSD_Process.cxx") {
-		stub_out_methods(&path, true);
+	if env::var("CARGO_CFG_TARGET_OS").unwrap_or_default().contains("windows") {
+		// OSD_WNT.cxx: static initialiser calls AllocateAndInitializeSid (advapi32).
+		// Module-internal only — no external interface needed.
+		if let Some(path) = find_osd("OSD_WNT.cxx") {
+			stub_out_methods(&path, false);
+		}
+		// OSD_File.cxx: OpenProcessToken, SetSecurityDescriptorDacl, etc. (advapi32).
+		if let Some(path) = find_osd("OSD_File.cxx") {
+			stub_out_methods(&path, true);
+		}
+		// OSD_Protection.cxx: EqualSid, LookupAccountNameW, etc. (advapi32).
+		if let Some(path) = find_osd("OSD_Protection.cxx") {
+			stub_out_methods(&path, true);
+		}
+		// OSD_signal.cxx: MessageBoxA / MessageBeep (user32) on MSVC.
+		if let Some(path) = find_osd("OSD_signal.cxx") {
+			stub_out_methods(&path, true);
+		}
+		// OSD_FileNode.cxx: SetFileSecurityW (advapi32) + OSD_WNT helpers.
+		if let Some(path) = find_osd("OSD_FileNode.cxx") {
+			stub_out_methods(&path, true);
+		}
+		// OSD_Process.cxx: OpenProcessToken, GetUserNameW, EqualSid (advapi32).
+		if let Some(path) = find_osd("OSD_Process.cxx") {
+			stub_out_methods(&path, true);
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

`patch_occt_sources()` が OSD_WNT/File/Protection/signal/FileNode/Process.cxx を**全プラットフォームで**スタブ化しているが、`stub_out_methods()` は非 void 関数本体を `{}` に置換するため UB となり、GCC -O3 が fall-through にトラップ命令を埋め込む。Linux 上では OSD_Process::SystemDate や OSD::SignalMode / OSD::ToCatchFloatingSignals を経由するコードパスが即座に SIGTRAP で落ちる。

このスタブは Windows の advapi32/user32 依存を切るためのもので、Linux では OSD_*.cxx が `#ifdef _WIN32` で POSIX 実装を提供しているため、スタブは必要ないどころか動いているコードを消してしまっている。`CARGO_CFG_TARGET_OS == "windows"` のときだけスタブを適用するようゲート。

## 具体的な症状 (fix 前)

`cargo run --example 01_primitives` が `Trace/breakpoint trap (core dumped)` で落ちる。gdb でのスタック:

```
Program received signal SIGTRAP, Trace/breakpoint trap.
0x...b73 in OSD_Process::SystemDate() / UserName()  (stub fall-through)
#1  Interface_MSG::TDate(...)
#2  APIHeaderSection_MakeHeader::Init(char const*)
#3  APIHeaderSection_MakeHeader::APIHeaderSection_MakeHeader(int)
#4  STEPControl_Writer::Transfer(...)
#5  cadrum::write_step_color_stream (cpp/wrapper.cpp)
```

`04_boolean` / `07_sweep` は `OSD_ThreadPool::Launcher::run` → `OSD::SignalMode` / `OSD::ToCatchFloatingSignals` で同じ系統のトラップ。

STEP 書き出しを使う example (01, 02, 03, 04, 05, 07, chijin) と並列ブーリアンを使う example が全滅。SVG 専用経路は生き残る (mesh しか触らないため)。

## 修正方針

1. `patch_occt_sources()` の OSD セクション先頭で target_os を確認し、Windows 以外では early return
2. XCAFDoc_VisMaterial / XCAFPrs_Texture の 2 つは `BUILD_MODULE_Visualization=OFF` のためのもので OS 非依存なので無条件のまま

短期的には既存のスタブ入り OCCT キャッシュをユーザー環境で再ビルドしてもらう必要がある (`rm -rf target/occt* target/cadrum-occt-*`)。

## Test plan

- [x] クリーンな OCCT 再ビルド後、`cargo run --example 01_primitives` ～ `08_bspline` 全て exit=0 で `*.step` + `*.svg` 生成
- [x] `02_write_read` の STEP/BRep text/BRep binary 往復と STL が成功
- [x] 01_primitives.step のヘッダを目視確認: `time_stamp='YYYY-MM-DDThh:mm:ss'` (現在時刻) が正しく入る
- [ ] Windows (`x86_64-pc-windows-gnu`, `x86_64-pc-windows-msvc`) 側のビルドが regression していないこと (このブランチでは触らないので期待上は影響なし、ただし CI / docker ビルドで念のため確認)

関連: #52 のレビューコメントで原因を共有した案件。

🤖 Generated with [Claude Code](https://claude.com/claude-code)