### PR TITLE
fix(build): drop *-linux-* → musl prebuilt redirect

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -71,14 +71,7 @@ fn resolve_occt(manifest_dir: &Path, out_dir: &Path, target: &str) -> (PathBuf, 
 		return build_occt_from_source(out_dir, &effective_root);
 	}
 
-	// musl is the only Linux prebuilt published; musl-built static OCCT links
-	// cleanly into a glibc Rust binary, so any *-linux-* target uses musl.
-	let prebuilt_target = match target.rsplit_once("-linux-") {
-		Some((arch_vendor, _)) => format!("{arch_vendor}-linux-musl"),
-		None => target.to_string(),
-	};
-
-	match try_prebuilt(out_dir, &effective_root, &prebuilt_target) {
+	match try_prebuilt(out_dir, &effective_root, target) {
 		Some(pair) => pair,
 		None => panic!(
 			"\nFailed to download prebuilt OCCT for target `{}`.\n\


### PR DESCRIPTION
## Summary

PR #55 の ``*-linux-*`` → ``musl`` 強制リダイレクトロジックを削除します。PR #57 で manylinux 製の ``x86_64-unknown-linux-gnu`` / ``aarch64-unknown-linux-gnu`` tarball が既に Release に上がっているのに、``build.rs`` 側でこの redirect が残っていたため、gnu target でビルドしても **古い musl tarball を落としてきてリンクに失敗** していました。

## Symptom

Ubuntu 24.04 (glibc 2.39) 上の WSL で cadrum を ``cargo run --example 01_primitives`` すると:

\`\`\`
rust-lld: error: undefined symbol: __flt_rounds
>>> referenced by Standard_Strtod.cxx
>>>               Standard_Strtod.cxx.o:(Strtod) in archive
>>>               target/debug/deps/libcadrum-*.rlib
\`\`\`

さらに ``build.rs`` の stderr:

\`\`\`
cargo:warning=Downloading prebuilt OCCT from
https://github.com/lzpel/cadrum/releases/download/occt-v800rc5/cadrum-occt-v800rc5-x86_64-unknown-linux-musl.tar.gz
\`\`\`

target triple は ``x86_64-unknown-linux-gnu`` なのに URL は ``-musl`` になっていました。

## Root cause

PR #55 (``a2fd3e6 build: redirect *-linux-* prebuilt to musl variant``) で追加された次のロジック:

\`\`\`rust
// musl is the only Linux prebuilt published; musl-built static OCCT links
// cleanly into a glibc Rust binary, so any *-linux-* target uses musl.
let prebuilt_target = match target.rsplit_once(\"-linux-\") {
    Some((arch_vendor, _)) => format!(\"{arch_vendor}-linux-musl\"),
    None => target.to_string(),
};
match try_prebuilt(out_dir, &effective_root, &prebuilt_target) {
\`\`\`

> musl-built static OCCT links cleanly into a glibc Rust binary

**この前提が誤り** です。musl でビルドした ``Standard_Strtod.cxx.o`` は ``__flt_rounds`` を undefined reference として含みます。この関数は musl libc が ``libc.so`` にエクスポートしている symbol で、glibc には**存在しません**。従って:

- Alpine (musl) 上で cadrum をビルドする → ``__flt_rounds`` は musl libc にあるので解決する → 成功
- Ubuntu / Fedora / Arch / etc. (glibc) 上で cadrum をビルドする → ``__flt_rounds`` は glibc のどこにもない → **リンクエラー**

PR #57 で docker 側を musl → manylinux_2_28 に切り替えて、``cadrum-occt-v800rc5-x86_64-unknown-linux-gnu.tar.gz`` / ``-aarch64-unknown-linux-gnu.tar.gz`` を Release にアップロードしましたが、**``build.rs`` の redirect を消し忘れていました**。結果として PR #57 以降のユーザーも gnu target では依然として古い musl tarball を掴んでいた状態です。

## Fix

redirect を削除して target をそのまま ``try_prebuilt`` に渡す。

\`\`\`diff
- // musl is the only Linux prebuilt published; musl-built static OCCT links
- // cleanly into a glibc Rust binary, so any *-linux-* target uses musl.
- let prebuilt_target = match target.rsplit_once(\"-linux-\") {
-     Some((arch_vendor, _)) => format!(\"{arch_vendor}-linux-musl\"),
-     None => target.to_string(),
- };
-
- match try_prebuilt(out_dir, &effective_root, &prebuilt_target) {
+ match try_prebuilt(out_dir, &effective_root, target) {
\`\`\`

これで:

- ``x86_64-unknown-linux-gnu`` → manylinux_2_28 x86_64 tarball をダウンロード
- ``aarch64-unknown-linux-gnu`` → manylinux_2_28 aarch64 tarball をダウンロード
- ``x86_64-pc-windows-gnu`` / ``x86_64-pc-windows-msvc`` → 既存の Windows tarball をダウンロード
- musl / macOS / Windows ARM etc. → Release に tarball が無いので panic、``--features source-build`` を案内

## Verification

- ✅ 今回の PR の build.rs 変更は 1 行足し 8 行引きの diff のみ
- ✅ WSL Ubuntu 24.04 (glibc 2.39 / gcc 13.3) で ``__flt_rounds`` が libc/libm/libgcc のどこにも存在しないことを ``nm`` で確認
- ✅ 現在の ``out/cadrum-occt-v800rc5-x86_64-unknown-linux-gnu.tar.gz`` (manylinux_2_28 でビルド) から ``Standard_Strtod.cxx.o`` を取り出して ``nm --undefined-only`` すると undefined は ``__errno_location``, ``free``, ``malloc``, ``memcpy``, ``memset`` のみで ``__flt_rounds`` は**含まれない**ことを確認

## User action required

既存ユーザーは stale な OCCT ディレクトリを削除してから再ビルド:

\`\`\`sh
rm -rf target/cadrum-occt-v800rc5-*
cargo clean                     # 古い musl .o が libcadrum.rlib に bundle 済みなら必要
cargo build
\`\`\`

``cargo clean`` が必要なのは、rust が静的ライブラリの .o 成員を ``libcadrum-*.rlib`` に bundle する動作をするためです。libTKernel.a を差し替えても、cadrum のソースが変わらない限り rlib は再生成されず、古い musl .o が残ります。

## Test plan

- [ ] Ubuntu 24.04 WSL で ``rm -rf target && cargo build --example 01_primitives`` が成功 (gnu tarball を DL してリンク)
- [ ] AWS Graviton / Raspberry Pi 5 で ``cargo build`` が成功 (aarch64 tarball を DL してリンク)
- [ ] 壊れた ``__flt_rounds`` エラーが再現しない
- [ ] Alpine Linux で ``cargo build`` が panic して ``--features source-build`` を案内する
- [ ] ``cargo build --features source-build`` で musl / macOS 上のソースビルドが引き続き動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)