### PR TITLE
refactor(io): flatten IoModule delegation to crate root

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ fn main() {
     ];
 
     let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create file");
-    cadrum::io::write_step(&solids, &mut f).expect("failed to write STEP");
+    cadrum::write_step(&solids, &mut f).expect("failed to write STEP");
 
     let mut svg = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-    cadrum::io::write_svg(&solids, DVec3::new(1.0, 1.0, 1.0), 0.5, true, false, &mut svg).expect("failed to write SVG");
+    cadrum::mesh(&solids, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 1.0), true, false, &mut svg)).expect("failed to write SVG");
 }
 
 ```
@@ -100,24 +100,24 @@ fn main() -> Result<(), cadrum::Error> {
 
     // 0. Original: read colored_box.step
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    let original = cadrum::io::read_step(
+    let original = cadrum::read_step(
         &mut std::fs::File::open(format!("{manifest_dir}/steps/colored_box.step")).expect("open file"),
     )?;
 
     // 1. STEP round-trip: rotate 30° → write → read
     let a_written = original.clone().rotate_x(FRAC_PI_8);
-    cadrum::io::write_step(&a_written, &mut std::fs::File::create(&step_path).expect("create file"))?;
-    let a = cadrum::io::read_step(&mut std::fs::File::open(&step_path).expect("open file"))?;
+    cadrum::write_step(&a_written, &mut std::fs::File::create(&step_path).expect("create file"))?;
+    let a = cadrum::read_step(&mut std::fs::File::open(&step_path).expect("open file"))?;
 
     // 2. BRep text round-trip: rotate another 30° → write → read
     let b_written = a.clone().rotate_x(FRAC_PI_8);
-    cadrum::io::write_brep_text(&b_written, &mut std::fs::File::create(&text_path).expect("create file"))?;
-    let b = cadrum::io::read_brep_text(&mut std::fs::File::open(&text_path).expect("open file"))?;
+    cadrum::write_brep_text(&b_written, &mut std::fs::File::create(&text_path).expect("create file"))?;
+    let b = cadrum::read_brep_text(&mut std::fs::File::open(&text_path).expect("open file"))?;
 
     // 3. BRep binary round-trip: rotate another 30° → write → read
     let c_written = b.clone().rotate_x(FRAC_PI_8);
-    cadrum::io::write_brep_binary(&c_written, &mut std::fs::File::create(&brep_path).expect("create file"))?;
-    let c = cadrum::io::read_brep_binary(&mut std::fs::File::open(&brep_path).expect("open file"))?;
+    cadrum::write_brep_binary(&c_written, &mut std::fs::File::create(&brep_path).expect("create file"))?;
+    let c = cadrum::read_brep_binary(&mut std::fs::File::open(&brep_path).expect("open file"))?;
 
     // 4. Arrange side by side and export SVG + STL
     let [min, max] = original[0].bounding_box();
@@ -128,10 +128,10 @@ fn main() -> Result<(), cadrum::Error> {
         .collect();
 
     let mut svg = std::fs::File::create(format!("{example_name}.svg")).expect("create file");
-    cadrum::io::write_svg(&all, DVec3::new(1.0, 1.0, 2.0), 0.5, true, false, &mut svg)?;
+    cadrum::mesh(&all, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), true, false, &mut svg))?;
 
     let mut stl = std::fs::File::create(format!("{example_name}.stl")).expect("create file");
-    cadrum::io::write_stl(&all, 0.1, &mut stl)?;
+    cadrum::mesh(&all, 0.1).and_then(|m| m.write_stl(&mut stl))?;
 
     // 5. Print summary
     let stl_path = format!("{example_name}.stl");
@@ -199,10 +199,10 @@ fn main() {
     ];
 
     let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create file");
-    cadrum::io::write_step(&solids, &mut f).expect("failed to write STEP");
+    cadrum::write_step(&solids, &mut f).expect("failed to write STEP");
 
     let mut svg = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-    cadrum::io::write_svg(&solids, DVec3::new(1.0, 1.0, 1.0), 0.5, true, false, &mut svg).expect("failed to write SVG");
+    cadrum::mesh(&solids, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 1.0), true, false, &mut svg)).expect("failed to write SVG");
 }
 
 ```
@@ -252,10 +252,10 @@ fn main() -> Result<(), cadrum::Error> {
     let shapes: Vec<Solid> = [union, subtract, intersect].concat();
 
     let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create file");
-    cadrum::io::write_step(&shapes, &mut f).expect("failed to write STEP");
+    cadrum::write_step(&shapes, &mut f).expect("failed to write STEP");
 
     let mut svg = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-    cadrum::io::write_svg(&shapes, DVec3::new(1.0, 1.0, 2.0), 0.5, true, false, &mut svg).expect("failed to write SVG");
+    cadrum::mesh(&shapes, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), true, false, &mut svg)).expect("failed to write SVG");
 
     Ok(())
 }
@@ -346,12 +346,12 @@ fn main() -> Result<(), Error> {
 
 	let step_path = format!("{example_name}.step");
 	let mut f = std::fs::File::create(&step_path).expect("failed to create STEP file");
-	cadrum::io::write_step(&result, &mut f).expect("failed to write STEP");
+	cadrum::write_step(&result, &mut f).expect("failed to write STEP");
 	println!("wrote {step_path}");
 
 	let svg_path = format!("{example_name}.svg");
 	let mut f = std::fs::File::create(&svg_path).expect("failed to create SVG file");
-	cadrum::io::write_svg(&result, DVec3::new(1.0, 1.0, 1.0), 0.5, true, false, &mut f).expect("failed to write SVG");
+	cadrum::mesh(&result, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 1.0), true, false, &mut f)).expect("failed to write SVG");
 	println!("wrote {svg_path}");
 
 	Ok(())
@@ -425,12 +425,12 @@ fn main() -> Result<(), Error> {
 
 	let step_path = format!("{example_name}.step");
 	let mut f = std::fs::File::create(&step_path).expect("failed to create STEP file");
-	cadrum::io::write_step(&result, &mut f).expect("failed to write STEP");
+	cadrum::write_step(&result, &mut f).expect("failed to write STEP");
 	println!("wrote {step_path}");
 
 	let svg_path = format!("{example_name}.svg");
 	let mut f = std::fs::File::create(&svg_path).expect("failed to create SVG file");
-	cadrum::io::write_svg(&result, DVec3::new(1.0, 1.0, 1.0), 0.5, true, false, &mut f).expect("failed to write SVG");
+	cadrum::mesh(&result, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 1.0), true, false, &mut f)).expect("failed to write SVG");
 	println!("wrote {svg_path}");
 
 	Ok(())
@@ -569,10 +569,10 @@ fn main() {
 	}
 
 	let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create STEP file");
-	cadrum::io::write_step(&all, &mut f).expect("failed to write STEP");
+	cadrum::write_step(&all, &mut f).expect("failed to write STEP");
 	let mut f_svg = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
 	// Helical threads have dense hidden lines that clutter the SVG; disable them.
-	cadrum::io::write_svg(&all, DVec3::new(1.0, 1.0, -1.0), 0.5, false, false, &mut f_svg).expect("failed to write SVG");
+	cadrum::mesh(&all, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, -1.0), false, false, &mut f_svg)).expect("failed to write SVG");
 	println!("wrote {example_name}.step / {example_name}.svg ({} solids)", all.len());
 }
 
@@ -633,9 +633,9 @@ fn main() {
 	let plasma = Solid::bspline(grid, true).expect("2-period bspline torus should succeed");
 	let objects = [plasma.color("cyan")];
 	let mut f = std::fs::File::create(format!("{example_name}.step")).unwrap();
-	cadrum::io::write_step(&objects, &mut f).unwrap();
+	cadrum::write_step(&objects, &mut f).unwrap();
 	let mut f_svg = std::fs::File::create(format!("{example_name}.svg")).unwrap();
-	cadrum::io::write_svg(&objects, DVec3::new(0.05, 0.05, 1.0), 0.1, false, true, &mut f_svg).unwrap();
+	cadrum::mesh(&objects, 0.1).and_then(|m| m.write_svg(DVec3::new(0.05, 0.05, 1.0), false, true, &mut f_svg)).unwrap();
 	eprintln!("wrote {0}.step / {0}.svg", example_name);
 }
 

--- a/build_delegation.rs
+++ b/build_delegation.rs
@@ -6,7 +6,9 @@
 //!
 //! How it works / 仕組み:
 //!   - "Struct" suffix (e.g. SolidStruct → crate::Solid): generates `impl crate::Solid { pub fn ... }`
-//!   - "Module" suffix (e.g. IoModule → mod io): generates `pub mod io { pub fn ... }`
+//!   - "Module" suffix (e.g. IoModule → crate root): generates `pub fn ...` at crate root
+//!     (module name is intentionally discarded — the suffix is a developer-facing
+//!     organizational marker only, not part of the public API surface)
 //!   - その他のサフィックス (e.g. SolidExt) はトップレベル委譲を生成しないが、
 //!     "Struct" トレイトのスーパートレイトとして参照された場合は、その中の
 //!     メソッドも inherent impl に取り込まれる
@@ -25,8 +27,9 @@ use std::path::Path;
 enum DelegationKind {
 	/// FooStruct → impl crate::Foo { pub fn ... { <Self as FooStruct>::... } }
 	InherentImpl { concrete_type: String },
-	/// FooModule → pub mod foo { pub fn ... { <crate::Foo as FooModule>::... } }
-	ModBlock { mod_name: String, struct_path: String },
+	/// FooModule → pub fn ... at crate root { <crate::Foo as FooModule>::... }
+	/// The `Foo` name is developer-facing only and does not leak into the user API.
+	FreeFn { struct_path: String },
 }
 
 fn delegation_kind(trait_name: &str) -> Option<DelegationKind> {
@@ -35,8 +38,7 @@ fn delegation_kind(trait_name: &str) -> Option<DelegationKind> {
 		Some(DelegationKind::InherentImpl { concrete_type: format!("crate::{}", type_name) })
 	} else if trait_name.ends_with("Module") {
 		let base = &trait_name[..trait_name.len() - 6];
-		let mod_name = base[..1].to_lowercase() + &base[1..];
-		Some(DelegationKind::ModBlock { mod_name, struct_path: format!("crate::{}", base) })
+		Some(DelegationKind::FreeFn { struct_path: format!("crate::{}", base) })
 	} else {
 		None // skip traits with unrecognized suffix (e.g. SolidExt) — only used as supertraits
 	}
@@ -48,7 +50,8 @@ fn delegation_kind(trait_name: &str) -> Option<DelegationKind> {
 /// `Self::Edge` / `Self::Face` (from `SolidStruct`) and `Self::Solid` (from
 /// `IoModule`) become bare type names, which resolve to the active backend's
 /// concrete types via `pub use` re-exports in `lib.rs`. This keeps `traits.rs`
-/// itself free of backend-specific type references.
+/// itself free of backend-specific type references. `*Module` traits emit their
+/// methods as free functions at the crate root.
 const TYPE_MAP: &[(&str, &str)] = &[("Self::Face", "Face"), ("Self::Edge", "Edge"), ("Self::Solid", "Solid")];
 
 struct Method {
@@ -99,13 +102,11 @@ pub fn build_delegation(traits_src: &str, out_dir: &Path) {
 				}
 				output.push_str("}\n\n");
 			}
-			DelegationKind::ModBlock { mod_name, struct_path } => {
-				output.push_str(&format!("pub mod {} {{\n", mod_name));
-				output.push_str("    use super::*;\n");
+			DelegationKind::FreeFn { struct_path } => {
 				for method in &collected {
 					emit_method(&mut output, method, struct_path, true);
 				}
-				output.push_str("}\n\n");
+				output.push_str("\n");
 			}
 		}
 	}

--- a/examples/01_primitives.rs
+++ b/examples/01_primitives.rs
@@ -24,8 +24,8 @@ fn main() {
     ];
 
     let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create file");
-    cadrum::io::write_step(&solids, &mut f).expect("failed to write STEP");
+    cadrum::write_step(&solids, &mut f).expect("failed to write STEP");
 
     let mut svg = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-    cadrum::io::write_svg(&solids, DVec3::new(1.0, 1.0, 1.0), 0.5, true, false, &mut svg).expect("failed to write SVG");
+    cadrum::mesh(&solids, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 1.0), true, false, &mut svg)).expect("failed to write SVG");
 }

--- a/examples/02_write_read.rs
+++ b/examples/02_write_read.rs
@@ -12,24 +12,24 @@ fn main() -> Result<(), cadrum::Error> {
 
     // 0. Original: read colored_box.step
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    let original = cadrum::io::read_step(
+    let original = cadrum::read_step(
         &mut std::fs::File::open(format!("{manifest_dir}/steps/colored_box.step")).expect("open file"),
     )?;
 
     // 1. STEP round-trip: rotate 30° → write → read
     let a_written = original.clone().rotate_x(FRAC_PI_8);
-    cadrum::io::write_step(&a_written, &mut std::fs::File::create(&step_path).expect("create file"))?;
-    let a = cadrum::io::read_step(&mut std::fs::File::open(&step_path).expect("open file"))?;
+    cadrum::write_step(&a_written, &mut std::fs::File::create(&step_path).expect("create file"))?;
+    let a = cadrum::read_step(&mut std::fs::File::open(&step_path).expect("open file"))?;
 
     // 2. BRep text round-trip: rotate another 30° → write → read
     let b_written = a.clone().rotate_x(FRAC_PI_8);
-    cadrum::io::write_brep_text(&b_written, &mut std::fs::File::create(&text_path).expect("create file"))?;
-    let b = cadrum::io::read_brep_text(&mut std::fs::File::open(&text_path).expect("open file"))?;
+    cadrum::write_brep_text(&b_written, &mut std::fs::File::create(&text_path).expect("create file"))?;
+    let b = cadrum::read_brep_text(&mut std::fs::File::open(&text_path).expect("open file"))?;
 
     // 3. BRep binary round-trip: rotate another 30° → write → read
     let c_written = b.clone().rotate_x(FRAC_PI_8);
-    cadrum::io::write_brep_binary(&c_written, &mut std::fs::File::create(&brep_path).expect("create file"))?;
-    let c = cadrum::io::read_brep_binary(&mut std::fs::File::open(&brep_path).expect("open file"))?;
+    cadrum::write_brep_binary(&c_written, &mut std::fs::File::create(&brep_path).expect("create file"))?;
+    let c = cadrum::read_brep_binary(&mut std::fs::File::open(&brep_path).expect("open file"))?;
 
     // 4. Arrange side by side and export SVG + STL
     let [min, max] = original[0].bounding_box();
@@ -40,10 +40,10 @@ fn main() -> Result<(), cadrum::Error> {
         .collect();
 
     let mut svg = std::fs::File::create(format!("{example_name}.svg")).expect("create file");
-    cadrum::io::write_svg(&all, DVec3::new(1.0, 1.0, 2.0), 0.5, true, false, &mut svg)?;
+    cadrum::mesh(&all, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), true, false, &mut svg))?;
 
     let mut stl = std::fs::File::create(format!("{example_name}.stl")).expect("create file");
-    cadrum::io::write_stl(&all, 0.1, &mut stl)?;
+    cadrum::mesh(&all, 0.1).and_then(|m| m.write_stl(&mut stl))?;
 
     // 5. Print summary
     let stl_path = format!("{example_name}.stl");

--- a/examples/03_transform.rs
+++ b/examples/03_transform.rs
@@ -35,8 +35,8 @@ fn main() {
     ];
 
     let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create file");
-    cadrum::io::write_step(&solids, &mut f).expect("failed to write STEP");
+    cadrum::write_step(&solids, &mut f).expect("failed to write STEP");
 
     let mut svg = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-    cadrum::io::write_svg(&solids, DVec3::new(1.0, 1.0, 1.0), 0.5, true, false, &mut svg).expect("failed to write SVG");
+    cadrum::mesh(&solids, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 1.0), true, false, &mut svg)).expect("failed to write SVG");
 }

--- a/examples/04_boolean.rs
+++ b/examples/04_boolean.rs
@@ -29,10 +29,10 @@ fn main() -> Result<(), cadrum::Error> {
     let shapes: Vec<Solid> = [union, subtract, intersect].concat();
 
     let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create file");
-    cadrum::io::write_step(&shapes, &mut f).expect("failed to write STEP");
+    cadrum::write_step(&shapes, &mut f).expect("failed to write STEP");
 
     let mut svg = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-    cadrum::io::write_svg(&shapes, DVec3::new(1.0, 1.0, 2.0), 0.5, true, false, &mut svg).expect("failed to write SVG");
+    cadrum::mesh(&shapes, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), true, false, &mut svg)).expect("failed to write SVG");
 
     Ok(())
 }

--- a/examples/05_extrude.rs
+++ b/examples/05_extrude.rs
@@ -68,12 +68,12 @@ fn main() -> Result<(), Error> {
 
 	let step_path = format!("{example_name}.step");
 	let mut f = std::fs::File::create(&step_path).expect("failed to create STEP file");
-	cadrum::io::write_step(&result, &mut f).expect("failed to write STEP");
+	cadrum::write_step(&result, &mut f).expect("failed to write STEP");
 	println!("wrote {step_path}");
 
 	let svg_path = format!("{example_name}.svg");
 	let mut f = std::fs::File::create(&svg_path).expect("failed to create SVG file");
-	cadrum::io::write_svg(&result, DVec3::new(1.0, 1.0, 1.0), 0.5, true, false, &mut f).expect("failed to write SVG");
+	cadrum::mesh(&result, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 1.0), true, false, &mut f)).expect("failed to write SVG");
 	println!("wrote {svg_path}");
 
 	Ok(())

--- a/examples/06_loft.rs
+++ b/examples/06_loft.rs
@@ -50,12 +50,12 @@ fn main() -> Result<(), Error> {
 
 	let step_path = format!("{example_name}.step");
 	let mut f = std::fs::File::create(&step_path).expect("failed to create STEP file");
-	cadrum::io::write_step(&result, &mut f).expect("failed to write STEP");
+	cadrum::write_step(&result, &mut f).expect("failed to write STEP");
 	println!("wrote {step_path}");
 
 	let svg_path = format!("{example_name}.svg");
 	let mut f = std::fs::File::create(&svg_path).expect("failed to create SVG file");
-	cadrum::io::write_svg(&result, DVec3::new(1.0, 1.0, 1.0), 0.5, true, false, &mut f).expect("failed to write SVG");
+	cadrum::mesh(&result, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 1.0), true, false, &mut f)).expect("failed to write SVG");
 	println!("wrote {svg_path}");
 
 	Ok(())

--- a/examples/07_sweep.rs
+++ b/examples/07_sweep.rs
@@ -115,9 +115,9 @@ fn main() {
 	}
 
 	let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create STEP file");
-	cadrum::io::write_step(&all, &mut f).expect("failed to write STEP");
+	cadrum::write_step(&all, &mut f).expect("failed to write STEP");
 	let mut f_svg = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
 	// Helical threads have dense hidden lines that clutter the SVG; disable them.
-	cadrum::io::write_svg(&all, DVec3::new(1.0, 1.0, -1.0), 0.5, false, false, &mut f_svg).expect("failed to write SVG");
+	cadrum::mesh(&all, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, -1.0), false, false, &mut f_svg)).expect("failed to write SVG");
 	println!("wrote {example_name}.step / {example_name}.svg ({} solids)", all.len());
 }

--- a/examples/08_bspline.rs
+++ b/examples/08_bspline.rs
@@ -41,8 +41,8 @@ fn main() {
 	let plasma = Solid::bspline(grid, true).expect("2-period bspline torus should succeed");
 	let objects = [plasma.color("cyan")];
 	let mut f = std::fs::File::create(format!("{example_name}.step")).unwrap();
-	cadrum::io::write_step(&objects, &mut f).unwrap();
+	cadrum::write_step(&objects, &mut f).unwrap();
 	let mut f_svg = std::fs::File::create(format!("{example_name}.svg")).unwrap();
-	cadrum::io::write_svg(&objects, DVec3::new(0.05, 0.05, 1.0), 0.1, false, true, &mut f_svg).unwrap();
+	cadrum::mesh(&objects, 0.1).and_then(|m| m.write_svg(DVec3::new(0.05, 0.05, 1.0), false, true, &mut f_svg)).unwrap();
 	eprintln!("wrote {0}.step / {0}.svg", example_name);
 }

--- a/examples/chijin.rs
+++ b/examples/chijin.rs
@@ -60,12 +60,12 @@ fn main() -> Result<(), cadrum::Error> {
 
 	let step_path = format!("{example_name}.step");
 	let mut f = std::fs::File::create(&step_path).expect("failed to create STEP file");
-	cadrum::io::write_step(&result, &mut f).expect("failed to write STEP");
+	cadrum::write_step(&result, &mut f).expect("failed to write STEP");
 	println!("wrote {step_path}");
 
 	let svg_path = format!("{example_name}.svg");
 	let mut f = std::fs::File::create(&svg_path).expect("failed to create SVG file");
-	cadrum::io::write_svg(&result, DVec3::new(1.0, 1.0, 1.0), 0.5, true, false, &mut f).expect("failed to write SVG");
+	cadrum::mesh(&result, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 1.0), true, false, &mut f)).expect("failed to write SVG");
 	println!("wrote {svg_path}");
 
 	Ok(())

--- a/sandbox-wasm/src/lib.rs
+++ b/sandbox-wasm/src/lib.rs
@@ -7,5 +7,5 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 pub fn box_svg() -> String {
 	let solid = Solid::cube(10.0, 20.0, 30.0).color("#4a90d9");
-	cadrum::io::mesh(&[solid], 0.5).unwrap().to_svg(DVec3::new(1.0, 1.0, 1.0), false).unwrap();
+	cadrum::mesh(&[solid], 0.5).unwrap().to_svg(DVec3::new(1.0, 1.0, 1.0), false).unwrap();
 }

--- a/src/common/mesh.rs
+++ b/src/common/mesh.rs
@@ -108,6 +108,10 @@ impl Mesh {
 	/// 2. Detects silhouette edges from mesh adjacency
 	/// 3. Classifies edges as visible or hidden (only when `hidden_lines`)
 	/// 4. Renders colored triangles, visible edges (black), and optionally hidden edges
+	pub fn write_svg<W: std::io::Write>(&self, direction: DVec3, hidden_lines: bool, shading: bool, writer: &mut W) -> Result<(), super::error::Error> {
+		writer.write_all(self.to_svg(direction, hidden_lines, shading).as_bytes()).map_err(|_| super::error::Error::SvgExportFailed)
+	}
+
 	pub fn to_svg(&self, direction: DVec3, hidden_lines: bool, shading: bool) -> String {
 		let dir = direction.normalize();
 		let (u, v) = projection_basis(dir);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -666,6 +666,4 @@ pub trait IoModule {
 	fn write_brep_binary<'a, W: std::io::Write>(solids: impl IntoIterator<Item = &'a Self::Solid>, writer: &mut W) -> Result<(), Error> where Self::Solid: 'a;
 	fn write_brep_text<'a, W: std::io::Write>(solids: impl IntoIterator<Item = &'a Self::Solid>, writer: &mut W) -> Result<(), Error> where Self::Solid: 'a;
 	fn mesh<'a>(solids: impl IntoIterator<Item = &'a Self::Solid>, tolerance: f64) -> Result<Mesh, Error> where Self::Solid: 'a;
-	fn write_svg<'a, W: std::io::Write>(solids: impl IntoIterator<Item = &'a Self::Solid>, direction: DVec3, tolerance: f64, hidden_lines: bool, shading: bool, writer: &mut W) -> Result<(), Error> where Self::Solid: 'a { writer.write_all(Self::mesh(solids, tolerance)?.to_svg(direction, hidden_lines, shading).as_bytes()).map_err(|_| Error::SvgExportFailed) }
-	fn write_stl<'a, W: std::io::Write>(solids: impl IntoIterator<Item = &'a Self::Solid>, tolerance: f64, writer: &mut W) -> Result<(), Error> where Self::Solid: 'a { Self::mesh(solids, tolerance)?.write_stl(writer) }
 }

--- a/tests/brep.rs
+++ b/tests/brep.rs
@@ -17,7 +17,7 @@ fn read_brep_binary_with_trailing_garbage() {
 
 	// Write valid BRep binary
 	let mut buf = Vec::new();
-	cadrum::io::write_brep_binary(&shape, &mut buf).expect("write_brep_binary should succeed");
+	cadrum::write_brep_binary(&shape, &mut buf).expect("write_brep_binary should succeed");
 	let brep_len = buf.len();
 	assert!(brep_len > 0);
 
@@ -26,7 +26,7 @@ fn read_brep_binary_with_trailing_garbage() {
 	assert_eq!(buf.len(), brep_len + 1024);
 
 	// Read back — should succeed despite trailing garbage
-	let result = cadrum::io::read_brep_binary(&mut buf.as_slice());
+	let result = cadrum::read_brep_binary(&mut buf.as_slice());
 	match &result {
 		Ok(solids) => {
 			assert!(!solids.is_empty(), "should read at least one solid");
@@ -48,7 +48,7 @@ fn read_brep_text_with_trailing_garbage() {
 
 	// Write valid BRep text
 	let mut buf = Vec::new();
-	cadrum::io::write_brep_text(&shape, &mut buf).expect("write_brep_text should succeed");
+	cadrum::write_brep_text(&shape, &mut buf).expect("write_brep_text should succeed");
 	let brep_len = buf.len();
 	assert!(brep_len > 0);
 
@@ -57,7 +57,7 @@ fn read_brep_text_with_trailing_garbage() {
 	assert_eq!(buf.len(), brep_len + 1024);
 
 	// Read back — should succeed despite trailing garbage
-	let result = cadrum::io::read_brep_text(&mut buf.as_slice());
+	let result = cadrum::read_brep_text(&mut buf.as_slice());
 	match &result {
 		Ok(solids) => {
 			assert!(!solids.is_empty(), "should read at least one solid");

--- a/tests/bspline.rs
+++ b/tests/bspline.rs
@@ -14,11 +14,11 @@ use std::f64::consts::TAU;
 fn write_outputs(solids: &[Solid], name: &str) {
 	std::fs::create_dir_all("out").unwrap();
 	let mut f = std::fs::File::create(format!("out/{name}.step")).unwrap();
-	cadrum::io::write_step(solids, &mut f).expect("step write");
+	cadrum::write_step(solids, &mut f).expect("step write");
 	let mut f = std::fs::File::create(format!("out/{name}.stl")).unwrap();
-	cadrum::io::write_stl(solids, 0.1, &mut f).expect("stl write");
+	cadrum::mesh(solids, 0.1).and_then(|m| m.write_stl(&mut f)).expect("stl write");
 	let mut f = std::fs::File::create(format!("out/{name}.svg")).unwrap();
-	cadrum::io::write_svg(solids, DVec3::new(1.0, 1.0, 2.0), 0.5, true, false, &mut f).expect("svg write");
+	cadrum::mesh(solids, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), true, false, &mut f)).expect("svg write");
 }
 
 /// XZ 平面(法線 Y)と YZ 平面(法線 X)で 4 象限に分割し、180° 回転対称

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -35,7 +35,7 @@ fn test_box_3() -> Solid {
 /// Helper: write shape to BRep binary bytes
 fn shape_to_brep_bytes<'a>(shape: impl IntoIterator<Item = &'a Solid>) -> Vec<u8> {
 	let mut buf = Vec::new();
-	cadrum::io::write_brep_binary(shape, &mut buf).unwrap();
+	cadrum::write_brep_binary(shape, &mut buf).unwrap();
 	buf
 }
 
@@ -109,7 +109,7 @@ fn test_t02_multiple_reads_no_crash() {
 	let original = test_box();
 	let brep_data = shape_to_brep_bytes(&[original]);
 	for _ in 0..5 {
-		let _shape = cadrum::io::read_brep_binary(&mut brep_data.as_slice()).unwrap();
+		let _shape = cadrum::read_brep_binary(&mut brep_data.as_slice()).unwrap();
 	}
 }
 
@@ -120,7 +120,7 @@ fn test_t02_multiple_reads_no_crash() {
 #[test]
 fn test_t03_mesh_normals_count() {
 	let shape = test_box();
-	let mesh = cadrum::io::mesh(&[shape], 0.1).unwrap();
+	let mesh = cadrum::mesh(&[shape], 0.1).unwrap();
 	assert_eq!(mesh.normals.len(), mesh.vertices.len());
 }
 
@@ -152,9 +152,9 @@ fn test_t05_translated_compound() {
 	let b = test_box_2();
 	let compound = a.union([&b]).unwrap();
 	let v = dvec3(100.0, 0.0, 0.0);
-	let orig_mesh = cadrum::io::mesh(&compound, 0.1).unwrap();
+	let orig_mesh = cadrum::mesh(&compound, 0.1).unwrap();
 	let shifted: Vec<Solid> = compound.into_iter().map(|s| s.translate(v)).collect();
-	let shifted_mesh = cadrum::io::mesh(&shifted, 0.1).unwrap();
+	let shifted_mesh = cadrum::mesh(&shifted, 0.1).unwrap();
 
 	assert_eq!(orig_mesh.vertices.len(), shifted_mesh.vertices.len());
 	for (o, s) in orig_mesh.vertices.iter().zip(shifted_mesh.vertices.iter()) {
@@ -170,11 +170,11 @@ fn test_t05_translated_compound() {
 #[test]
 fn test_t06_brep_roundtrip() {
 	let original = test_box();
-	let orig_mesh = cadrum::io::mesh([&original], 0.1).unwrap();
+	let orig_mesh = cadrum::mesh([&original], 0.1).unwrap();
 
 	let brep_data = shape_to_brep_bytes([&original]);
-	let restored = cadrum::io::read_brep_binary(&mut brep_data.as_slice()).unwrap();
-	let rest_mesh = cadrum::io::mesh(&restored, 0.1).unwrap();
+	let restored = cadrum::read_brep_binary(&mut brep_data.as_slice()).unwrap();
+	let rest_mesh = cadrum::mesh(&restored, 0.1).unwrap();
 
 	assert_eq!(orig_mesh.vertices.len(), rest_mesh.vertices.len());
 	for (o, r) in orig_mesh.vertices.iter().zip(rest_mesh.vertices.iter()) {
@@ -207,7 +207,7 @@ fn test_hollow_cube_write_step() {
 
 	std::fs::create_dir_all("out").unwrap();
 	let mut file = std::fs::File::create("out/hollow_cube.step").unwrap();
-	cadrum::io::write_step(&hollow_cube, &mut file).unwrap();
+	cadrum::write_step(&hollow_cube, &mut file).unwrap();
 }
 
 // half_space は仕様書 §2.1 で定義されたプリミティブ。intersect との組み合わせ確認。
@@ -233,11 +233,11 @@ fn test_brep_text_roundtrip() {
 	let original = test_box();
 
 	let mut text_data = Vec::new();
-	cadrum::io::write_brep_text([&original], &mut text_data).unwrap();
+	cadrum::write_brep_text([&original], &mut text_data).unwrap();
 	assert!(!text_data.is_empty());
 
-	let restored = cadrum::io::read_brep_text(&mut text_data.as_slice()).unwrap();
-	let orig_mesh = cadrum::io::mesh([&original], 0.1).unwrap();
-	let rest_mesh = cadrum::io::mesh(&restored, 0.1).unwrap();
+	let restored = cadrum::read_brep_text(&mut text_data.as_slice()).unwrap();
+	let orig_mesh = cadrum::mesh([&original], 0.1).unwrap();
+	let rest_mesh = cadrum::mesh(&restored, 0.1).unwrap();
 	assert_eq!(orig_mesh.vertices.len(), rest_mesh.vertices.len());
 }

--- a/tests/integration_color_brep.rs
+++ b/tests/integration_color_brep.rs
@@ -10,7 +10,7 @@ const COLORED_BOX_STEP: &str = "steps/colored_box.step";
 
 fn read_colored_box() -> Vec<Solid> {
 	let data = fs::read(COLORED_BOX_STEP).expect("steps/colored_box.step should exist");
-	cadrum::io::read_step(&mut data.as_slice()).expect("read_step should succeed")
+	cadrum::read_step(&mut data.as_slice()).expect("read_step should succeed")
 }
 
 fn colormap_len(shape: &[Solid]) -> usize {
@@ -19,14 +19,14 @@ fn colormap_len(shape: &[Solid]) -> usize {
 
 fn roundtrip_bin(shape: &[Solid]) -> Vec<Solid> {
 	let mut buf = Vec::new();
-	cadrum::io::write_brep_binary(shape, &mut buf).expect("write_brep_binary should succeed");
-	cadrum::io::read_brep_binary(&mut buf.as_slice()).expect("read_brep_binary should succeed")
+	cadrum::write_brep_binary(shape, &mut buf).expect("write_brep_binary should succeed");
+	cadrum::read_brep_binary(&mut buf.as_slice()).expect("read_brep_binary should succeed")
 }
 
 fn roundtrip_text(shape: &[Solid]) -> Vec<Solid> {
 	let mut buf = Vec::new();
-	cadrum::io::write_brep_text(shape, &mut buf).expect("write_brep_text should succeed");
-	cadrum::io::read_brep_text(&mut buf.as_slice()).expect("read_brep_text should succeed")
+	cadrum::write_brep_text(shape, &mut buf).expect("write_brep_text should succeed");
+	cadrum::read_brep_text(&mut buf.as_slice()).expect("read_brep_text should succeed")
 }
 
 // ── binary tests ─────────────────────────────────────────────────────────────

--- a/tests/integration_color_step.rs
+++ b/tests/integration_color_step.rs
@@ -14,7 +14,7 @@ const COLORED_BOX_STEP: &str = "steps/colored_box.step";
 /// Read `colored_box.step` and return the shape.  Panics if reading fails.
 fn read_colored_box() -> Vec<Solid> {
 	let data = fs::read(COLORED_BOX_STEP).expect("steps/colored_box.step should exist");
-	cadrum::io::read_step(&mut data.as_slice()).expect("read_step should succeed")
+	cadrum::read_step(&mut data.as_slice()).expect("read_step should succeed")
 }
 
 fn colormap_len(shape: &[Solid]) -> usize {
@@ -26,7 +26,7 @@ fn colormap_len(shape: &[Solid]) -> usize {
 fn write_colored(shape: &[Solid], path: &str) {
 	fs::create_dir_all("out").unwrap();
 	let mut buf = Vec::new();
-	cadrum::io::write_step(shape, &mut buf).expect("write_step should succeed");
+	cadrum::write_step(shape, &mut buf).expect("write_step should succeed");
 	fs::write(path, &buf).expect("should write output file");
 }
 
@@ -55,7 +55,7 @@ fn write_then_read_preserves_colors() {
 	write_colored(&original, path);
 
 	let data = fs::read(path).unwrap();
-	let reloaded = cadrum::io::read_step(&mut data.as_slice()).expect("re-read should succeed");
+	let reloaded = cadrum::read_step(&mut data.as_slice()).expect("re-read should succeed");
 
 	assert!(colormap_len(&reloaded) >= 6, "re-read shape should have at least 6 colored faces, got {}", colormap_len(&reloaded));
 }

--- a/tests/loft.rs
+++ b/tests/loft.rs
@@ -14,11 +14,11 @@ use std::f64::consts::PI;
 fn write_outputs(solids: &[Solid], name: &str) {
 	std::fs::create_dir_all("out").unwrap();
 	let mut f = std::fs::File::create(format!("out/{name}.step")).unwrap();
-	cadrum::io::write_step(solids, &mut f).expect("step write");
+	cadrum::write_step(solids, &mut f).expect("step write");
 	let mut f = std::fs::File::create(format!("out/{name}.stl")).unwrap();
-	cadrum::io::write_stl(solids, 0.1, &mut f).expect("stl write");
+	cadrum::mesh(solids, 0.1).and_then(|m| m.write_stl(&mut f)).expect("stl write");
 	let mut f = std::fs::File::create(format!("out/{name}.svg")).unwrap();
-	cadrum::io::write_svg(solids, DVec3::new(1.0, 1.0, 2.0), 0.5, true, false, &mut f).expect("svg write");
+	cadrum::mesh(solids, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), true, false, &mut f)).expect("svg write");
 }
 
 // ==================== (1) 数値検証: 円錐台 ====================

--- a/tests/svg.rs
+++ b/tests/svg.rs
@@ -7,7 +7,7 @@ fn dvec3(x: f64, y: f64, z: f64) -> DVec3 {
 
 fn svg_string(shape: &[Solid], direction: DVec3, tol: f64) -> String {
 	let mut buf = Vec::new();
-	cadrum::io::write_svg(shape, direction, tol, true, false, &mut buf).unwrap();
+	cadrum::mesh(shape, tol).and_then(|m| m.write_svg(direction, true, false, &mut buf)).unwrap();
 	String::from_utf8(buf).unwrap()
 }
 


### PR DESCRIPTION
## Summary
- `build_delegation.rs` の `*Module` サフィックスを crate ルート直下の自由関数生成に変更。`pub mod io { ... }` ラップを廃止し、利用者は `cadrum::write_step(...)` のように書ける。`Io` / `IoModule` は開発者向けの組織化マーカーとしてのみ意味を持つ。
- `IoModule` から `write_svg` / `write_stl` の default impl を削除。これらは `Self::mesh()` の結果を直列化するだけでバックエンド境界を越えていなかったため、責務がトレイトから浮いていた。
- `Mesh::write_svg` を追加（既存の `Mesh::write_stl` と対称）。呼び出し側は `cadrum::mesh(...).and_then(|m| m.write_svg(...))` という「メッシュ化 → 出力」の 2 段構造が明示的になる。
- examples / tests / sandbox-wasm / README を新 API に一括書き換え。

## Test plan
- [x] `cargo build --all-targets`
- [x] `cargo test`
- [x] `cargo run --example markdown -- out/markdown/SUMMARY.md ./README.md` で README の Examples 節を再生成

🤖 Generated with [Claude Code](https://claude.com/claude-code)