### PR TITLE
fix(build): MSVC に /utf-8 を渡して UTF-8 の wrapper.cpp を正しく読ませる

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -231,6 +231,14 @@ fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path) {
 	let mut build = cxx_build::bridge("src/occt/ffi.rs");
 	build.file("cpp/wrapper.cpp").include(occt_include).std("c++17").define("_USE_MATH_DEFINES", None);
 
+	// wrapper.cpp は UTF-8 (日本語コメント含む)。MSVC は既定でシステム既定コードページ
+	// (日本語環境なら CP932) で読むため、マルチバイトの末尾バイトが `\` などと解釈されて
+	// 行が結合され、パースがずれる (例: `const int n = ...;` が消えて `n` undeclared)。
+	// `/utf-8` を付けてソース/実行文字集合を UTF-8 に固定する。
+	if std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc") {
+		build.flag("/utf-8");
+	}
+
 	// Define CADRUM_COLOR for C++ when the "color" feature is enabled.
 	#[cfg(feature = "color")]
 	build.define("CADRUM_COLOR", None);


### PR DESCRIPTION
## 概要
- `cxx_build` の MSVC ターゲット時のみ `/utf-8` フラグを追加し、`cpp/wrapper.cpp` (UTF-8、日本語コメント含む) が native `cl.exe` の既定コードページ (日本語ロケールでは CP932) で誤デコードされるのを防ぎます。
- `cpp/wrapper.cpp` 自体には一切変更を入れません。

## 症状
日本語ロケールの Windows 11 + VS 2022 (cl.exe 14.44.35207) で `cargo build --example 01_primitives` を実行すると、wrapper.cpp のコンパイル段階で次のような偽エラーが出ます:

```
cpp/wrapper.cpp(1): warning C4819: The file contains a character that cannot
  be represented in the current code page (932). Save the file in Unicode
  format to prevent data loss
cpp/wrapper.cpp(966): error C2065: 'HPntArray': undeclared identifier
cpp/wrapper.cpp(966): error C2923: 'opencascade::handle': 'HPntArray' is not
  a valid template type argument for parameter 'T'
```

`using HPntArray = NCollection_HArray1<gp_Pnt>;` はエラー行の直前に書かれており、C++ 文法上も完全に valid です。

## 原因
`cl.exe` が UTF-8 バイト列を CP932 として読むため、日本語コメント内の 2 バイト文字の末尾バイトがたまたま `0x5C` (`\`) になっている場合、プリプロセッサがそれを行継続として扱い直後の行をコメントに飲み込みます。結果、`using HPntArray = ...;` や `const int n = ...;` といった**ソース上は確かに存在する宣言がトークンストリームから消失**し、それらを参照する識別子が `undeclared` になる、という一見不可解なエラーになります。`warning C4819` はそのサインです。

## 修正
`CARGO_CFG_TARGET_ENV == "msvc"` のときのみ `cxx_build` に `/utf-8` を渡し、ソース文字集合と実行文字集合の両方を UTF-8 に固定します。他ツールチェイン (gnu / linux / musl など) には影響しません。

```rust
if std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc") {
    build.flag("/utf-8");
}
```

## Test plan
- [x] 日本語ロケールの Windows 11 + VS 2022 上で、`cpp/wrapper.cpp` を無改変のまま `cargo build --example 01_primitives` を実行し、wrapper.cpp のコンパイルがクリーンに通ることを確認
- [ ] 他ターゲット (windows-gnu, x86_64-unknown-linux-musl 等) に影響がないこと (フラグは msvc 限定で guard 済み)

## 備考
この PR は wrapper.cpp のコンパイルエラーのみを解消します。同じ `cargo build --example 01_primitives` は、その後リンク段階で **prebuilt OCCT 8.0.0-rc5 の `.obj` に対する `std::_Variant_storage_<...>::~_Variant_storage_()` の未解決シンボル 72 件** で失敗します。これは `docker/Dockerfile_x86_64-pc-windows-msvc` 経由の cargo-xwin/clang-cl プリビルドと、ユーザ側 native `cl.exe` + `link.exe` の ABI ギャップに起因する別系統の問題で、別 issue として報告予定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)