### PR TITLE
ci(prebuilt): unshadow MSVC link.exe before the windows-msvc build

### DIFF
--- a/.github/workflows/prebuilt.yaml
+++ b/.github/workflows/prebuilt.yaml
@@ -56,6 +56,14 @@ jobs:
       - name: install make
         run: choco install make -y
 
+      # Git for Windows ships a GNU coreutils `link.exe` at /usr/bin/link.exe
+      # which shadows MSVC's `link.exe` when rustc drives the linker from a
+      # bash shell (bash prepends /usr/bin to PATH before msvc-dev-cmd's
+      # additions take effect). Remove it so rustc resolves MSVC's linker.
+      - name: unshadow MSVC link.exe
+        shell: bash
+        run: rm -f /usr/bin/link /usr/bin/link.exe
+
       - name: build
         shell: bash
         env:


### PR DESCRIPTION
Git for Windows ships a GNU coreutils `link` at /usr/bin/link.exe that resolves ahead of MSVC's link.exe when rustc drives the linker from a bash shell on the windows-2022 runner. The symptom was rustc invoking `/usr/bin/link` on proc-macro2's build-script link step and getting `/usr/bin/link: extra operand '...'` back. Remove the GNU link shim in a pre-build step so msvc-dev-cmd's PATH addition resolves first.