### PR TITLE
fix(build): parse OCCT signatures to stub void/non-void correctly on MSVC

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -528,6 +528,168 @@ fn stub_out_methods(path: &Path, keep_signatures: bool) {
 	eprintln!("Stubbed {}", path.file_name().unwrap().to_string_lossy());
 }
 
+/// Choose the stub body for a function/method signature `sig` (text from the
+/// previous statement terminator up to — but not including — the opening `{`).
+///
+/// Returns `"{}"` for void returns, constructors, and destructors; returns
+/// `"{ return {}; }"` otherwise so MSVC does not emit C4716.
+///
+/// OCCT uses `Class :: method` spacing around `::`, so we normalise that
+/// whitespace before parsing.
+fn stub_body_for_sig(sig: &str) -> &'static str {
+	// If `sig` starts inside a block comment (outer scanner landed on a
+	// `}` that was itself inside `/* ... }*/`), skip everything up to the
+	// first orphan `*/`.
+	let sig_orphan_fixed = match sig.find("*/") {
+		Some(pos) if !sig[..pos].contains("/*") => &sig[pos + 2..],
+		_ => sig,
+	};
+
+	// Strip C/C++ comments — a trailing `// end ctor (1)` on the previous
+	// function would otherwise pollute `find('(')` below.
+	let sig_no_comments = {
+		let bytes = sig_orphan_fixed.as_bytes();
+		let mut out = String::with_capacity(sig_orphan_fixed.len());
+		let mut i = 0;
+		while i < bytes.len() {
+			if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'/' {
+				while i < bytes.len() && bytes[i] != b'\n' {
+					i += 1;
+				}
+			} else if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'*' {
+				i += 2;
+				while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+					i += 1;
+				}
+				if i + 1 < bytes.len() {
+					i += 2;
+				}
+			} else {
+				out.push(bytes[i] as char);
+				i += 1;
+			}
+		}
+		out
+	};
+
+	// Strip preprocessor lines — `#if defined(__CYGWIN32__)` contains `(`
+	// and would otherwise be mistaken for the function's parameter list.
+	let sig_stripped: String = sig_no_comments
+		.lines()
+		.filter(|l| !l.trim_start().starts_with('#'))
+		.collect::<Vec<_>>()
+		.join("\n");
+
+	// Normalise `A :: B` → `A::B` so walk-back can treat qualified ids as
+	// one token.
+	let sig_norm: String = {
+		let mut s = sig_stripped;
+		loop {
+			let next = s.replace(" ::", "::").replace(":: ", "::");
+			if next == s {
+				break s;
+			}
+			s = next;
+		}
+	};
+
+	// Find the `(` that belongs to the target function's parameter list,
+	// skipping macro invocations like `IMPLEMENT_STANDARD_RTTIEXT(...)`.
+	// Heuristic: if the identifier immediately before a `(` is entirely
+	// uppercase (macro convention), walk past its matching `)` and keep
+	// searching. Drop everything from the real `(` onward.
+	let paren_pos = {
+		let bytes = sig_norm.as_bytes();
+		let mut cursor = 0;
+		loop {
+			let Some(off) = sig_norm[cursor..].find('(') else { return "{}"; };
+			let pos = cursor + off;
+			let before = sig_norm[..pos].trim_end();
+			let id_start = before
+				.rfind(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+				.map(|p| p + 1)
+				.unwrap_or(0);
+			let ident = &before[id_start..];
+			let is_macro = !ident.is_empty()
+				&& ident.chars().all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+				&& ident.chars().any(|c| c.is_ascii_uppercase());
+			if !is_macro {
+				break pos;
+			}
+			// Skip to the matching close paren.
+			let mut depth = 1;
+			let mut j = pos + 1;
+			while j < bytes.len() && depth > 0 {
+				match bytes[j] {
+					b'(' => depth += 1,
+					b')' => depth -= 1,
+					_ => {}
+				}
+				j += 1;
+			}
+			cursor = j;
+		}
+	};
+	let head_full = sig_norm[..paren_pos].trim();
+	let head = head_full.rsplit('\n').next().unwrap_or(head_full).trim();
+	if head.is_empty() {
+		return "{}";
+	}
+
+	// Walk back from the end collecting the trailing qualified-id (function
+	// name, possibly `Class::method` or `~Class`).
+	let hb = head.as_bytes();
+	let mut start = hb.len();
+	while start > 0 {
+		let c = hb[start - 1];
+		if c.is_ascii_alphanumeric() || c == b'_' || c == b':' || c == b'~' {
+			start -= 1;
+		} else {
+			break;
+		}
+	}
+	let name = &head[start..];
+	let return_part = head[..start].trim();
+
+	// Destructor: `~Foo` or `Foo::~Foo`.
+	if name.contains('~') {
+		return "{}";
+	}
+	// Constructor: last two `::`-segments are identical (`Foo::Foo`), or the
+	// name has no return-type prefix at all.
+	let segs: Vec<&str> = name.split("::").collect();
+	if segs.len() >= 2 && segs[segs.len() - 1] == segs[segs.len() - 2] {
+		return "{}";
+	}
+	if return_part.is_empty() {
+		return "{}";
+	}
+
+	// Look for `void` as a whole word in the return-type portion, and make
+	// sure it is not `void*` / `void&`.
+	let rb = return_part.as_bytes();
+	let is_ident = |c: u8| c.is_ascii_alphanumeric() || c == b'_';
+	let mut idx = 0;
+	while let Some(off) = return_part[idx..].find("void") {
+		let pos = idx + off;
+		let end = pos + 4;
+		let before_ok = pos == 0 || !is_ident(rb[pos - 1]);
+		let after_ok = end >= rb.len() || !is_ident(rb[end]);
+		if before_ok && after_ok {
+			let mut j = end;
+			while j < rb.len() && rb[j].is_ascii_whitespace() {
+				j += 1;
+			}
+			if j >= rb.len() || (rb[j] != b'*' && rb[j] != b'&') {
+				return "{}";
+			}
+		}
+		idx = end;
+	}
+
+	"{ return {}; }"
+}
+
 /// Replace every top-level (brace depth 0) `{ … }` block in `content` with
 /// `{}` or `{ return {}; }` and return the result.
 ///
@@ -547,14 +709,36 @@ fn stub_all_top_level_bodies(content: &str) -> String {
 			b'{' if depth == 0 => {
 				let prefix = &content[last_end..i];
 
-				// Detect brace-initialised variables: if the non-whitespace
-				// character immediately before '{' is '=' or the prefix since
-				// the last statement terminator contains no '(' (i.e. it is
-				// not a function/method signature), treat as variable init
-				// and skip the block without stubbing.
+				// Distinguish a function body from non-function brace blocks
+				// (class/struct/union/enum/namespace definitions, aggregate
+				// initialisers). Heuristic: after stripping trailing function
+				// qualifiers (`const`, `noexcept`, `override`, `final`,
+				// `= 0`, etc.), a function signature ends with `)` — the
+				// close of its parameter list or a constructor init-list
+				// entry. Class/struct/namespace headers end with an
+				// identifier or `>`; `T x = { ... }` ends with `=`.
+				// Preprocessor directives in `sig` (e.g. `#elif defined(X)`)
+				// can contain stray `)`, so we only inspect the last line.
 				let sig = prefix.rfind(|c| c == ';' || c == '}').map(|p| &prefix[p + 1..]).unwrap_or(prefix);
 				let trimmed = sig.trim_end();
-				let is_var_init = trimmed.ends_with('=') || !sig.contains('(');
+				let last_line = trimmed.rsplit('\n').next().unwrap_or(trimmed).trim();
+				let is_function = {
+					let mut t = last_line;
+					loop {
+						let prev_len = t.len();
+						for kw in ["const", "override", "final", "noexcept", "mutable", "volatile", "= 0", "=0"] {
+							if t.ends_with(kw) {
+								t = t[..t.len() - kw.len()].trim_end();
+								break;
+							}
+						}
+						if t.len() == prev_len {
+							break;
+						}
+					}
+					t.ends_with(')')
+				};
+				let is_var_init = trimmed.ends_with('=') || !is_function;
 
 				if is_var_init {
 					// Walk forward to find the matching '}' and preserve verbatim.
@@ -572,10 +756,11 @@ fn stub_all_top_level_bodies(content: &str) -> String {
 					continue;
 				}
 
-				// Function/method body: stub it.
-				// Always use "{}" — "{ return {}; }" would fail on constructors,
-				// and the CMake build uses -w to suppress missing-return warnings.
-				let stub_body = "{}";
+				// Function/method body: stub it. MSVC's C4716 ("must return
+				// a value") is an error, not a suppressible warning, so a
+				// bare `{}` fails for non-void returns. Use `{ return {}; }`
+				// for non-void and `{}` for void / constructor / destructor.
+				let stub_body = stub_body_for_sig(sig);
 
 				// Walk forward with brace counting to find the matching closing brace.
 				depth = 1;

--- a/notes/20260416-occt_cxx_stub_edge_cases.md
+++ b/notes/20260416-occt_cxx_stub_edge_cases.md
@@ -1,0 +1,139 @@
+# OCCT ソーススタブ化 parser のエッジケース (Windows MSVC native build)
+
+## 背景
+
+`build.rs::patch_occt_sources` は Windows MSVC ターゲットで OCCT の OS 抽象レイヤ (`OSD_*.cxx` ほか) の関数本体をテキスト置換で空スタブ化している (`advapi32` / `user32` リンクを避ける目的)。従来は本体を一律 `{}` に置き換えていたが、これは
+
+- Linux の GCC では missing-return 警告で済む
+- MSVC では **C4716 ("must return a value") がエラー扱い** で `/W0` でも抑止不可
+
+という理由で MSVC native build を追加した時点で破綻した。
+
+修正方針は「void 関数・コンストラクタ・デストラクタ → `{}` / それ以外 → `{ return {}; }`」という単純なルールで、戻り値型ごとの value-initialization に委ねる。ただしシグネチャを正確に parse しないと誤判定で別種のコンパイルエラー (`C2534` / `C2562` / `C4716`) が続出する。本 note は実際に破綻した OCCT のソース片を列挙し、`build.rs::stub_body_for_sig` がどの段階でそれを吸収するかを記録する。
+
+## 破綻事例と対策
+
+### 1. `A :: B` 形式 (OCCT 古典スタイルの `::` 前後空白)
+
+```cpp
+OSD_Protection ::OSD_Protection()
+{}
+
+OSD_Protection ::OSD_Protection(const OSD_SingleProtection System,
+                                const OSD_SingleProtection User, ...)
+{ ... }
+
+void OSD_Protection ::Values(OSD_SingleProtection& System, ...)
+{ ... }
+```
+
+- `::` の前後に空白が入る OCCT 独自スタイル。
+- walk-back で関数名を拾うとき `name = "OSD_Protection"` 単一セグメントになり、`Foo::Foo` パターンでのコンストラクタ検出が外れて `{ return {}; }` を出力 → `error C2534: constructor cannot return a value` (+ `C2562: 'void' function returning a value`)。
+- **対策**: parse の前段で `" ::"` → `"::"`、`":: "` → `"::"` を収束まで繰り返し、`A::B` に正規化する。
+
+### 2. 直前の関数の trailing コメントに `(` が混入
+
+```cpp
+OSD_Protection ::OSD_Protection()
+{} // end constructor ( 1 )
+
+OSD_Protection ::OSD_Protection(const OSD_SingleProtection System, ...)
+```
+
+- 2 個目のコンストラクタを parse するとき、`sig` は直前の `}` 以降を含むので `// end constructor ( 1 )` が入る。
+- `sig.find('(')` がコメント内の `(` をヒットし、head が `// end constructor ` となる。結果 `name = "constructor"`, `return_part = "// end"` で、constructor 判定に失敗して `{ return {}; }`。
+- **対策**: parse 前に `//...\n` と `/* ... */` を除去する。
+
+### 3. ブロックコメント内のコード片 (`}` が sig 境界に漏れる)
+
+```cpp
+/*void OSD_File::Link (const TCollection_AsciiString& theToFile)
+{}*/
+
+#if defined(__CYGWIN32__) || defined(__MINGW32__)
+  ...
+#endif
+
+void OSD_File::SetLock(const OSD_LockType theLock)
+{ ... }
+```
+
+- `stub_all_top_level_bodies` の sig 抽出は raw content 上で `rfind(';' | '}')` する。`{}*/` の中の `}` は **コメント内だが raw 走査ではただの `}`** なので、ここが sig の開始点として採用される。
+- 結果 sig が `*/\n\n#if defined(__CYGWIN32__)...\n\nvoid OSD_File::SetLock(...)` で始まる。
+- stub_body_for_sig 内の comment stripper は `/* ... */` のペアを探すが、この `sig` には対応する `/*` が無く `*/` が孤児として残る。その後ろの `#if defined(` の `(` が最初の `(` として採用され、head が `*/` 付きの壊れた文字列になる。
+- **対策**: sig 先頭に孤児 `*/` を検出したら (その前に `/*` が無い場合)、そこまでを一括で切り落とす。これでコメント途中から sig が始まるケースを無害化する。
+
+### 4. Preprocessor 行の `(`
+
+```cpp
+#if defined(__CYGWIN32__) || defined(__MINGW32__)
+  #define __try
+#endif
+```
+
+- 上記 3 のようにコメント境界から sig が入るケース、あるいは単に関数間に `#if` がある場合、`sig.find('(')` が `defined(` などの `(` を拾って head を壊す。
+- **対策**: parse 前に sig を行単位で走査し、trim 後に `#` で始まる行を一括削除。
+
+### 5. マクロ呼び出し `IMPLEMENT_STANDARD_RTTIEXT(...)` を関数シグネチャと誤認
+
+```cpp
+IMPLEMENT_STANDARD_RTTIEXT(XCAFDoc_VisMaterial, TDF_Attribute)
+
+//=================================================================================================
+
+const Standard_GUID& XCAFDoc_VisMaterial::GetID()
+{ ... }
+```
+
+- ファイル先頭近くには `IMPLEMENT_STANDARD_RTTIEXT(...)` のような展開後型情報を登録する OCCT 標準マクロがある。セミコロンを伴わず、かつ `(` を含む。
+- sig は `last_end=0` (ファイル先頭) から始まるので、`strip_comments` → `strip_preprocessor` を通した後も `IMPLEMENT_STANDARD_RTTIEXT(XCAFDoc_VisMaterial, TDF_Attribute)\n\nconst Standard_GUID& XCAFDoc_VisMaterial::GetID()` が残る。
+- `find('(')` が最初の `(` = `IMPLEMENT_STANDARD_RTTIEXT(` を拾い、head が `IMPLEMENT_STANDARD_RTTIEXT` だけになって、`name = "IMPLEMENT_STANDARD_RTTIEXT"` / `return_part = ""` → 「return type 無し = ctor/operator 扱い」で `{}` が出力される。GetID は実際には `const Standard_GUID&` を返すので、非 void に対する `{}` となり `error C4716`。
+- **対策**: `(` を前から順に探し、**直前の識別子が全大文字 (`[A-Z0-9_]+` かつ 1 文字以上大文字)** ならマクロ呼び出しとみなしてその対応する `)` までスキップ、次の `(` を探す。全大文字は OCCT/C++ のマクロ命名規則に合致するが、関数・クラス名とは衝突しない (例: `OSD_Protection` には小文字 `rotection` が含まれるので誤判定しない)。
+
+### 6. `class Standard_DbgHelper { ... };` を関数本体と誤認 (Standard_StackTrace.cxx)
+
+```cpp
+#elif defined(_WIN32) && !defined(OCCT_UWP)
+
+  #include <windows.h>
+  #include <dbghelp.h>
+
+class Standard_DbgHelper
+{
+  // ... static members and helpers ...
+};
+
+#endif
+```
+
+- `class Standard_DbgHelper { ... };` はクラス定義で関数ではないが、stub_all_top_level_bodies の旧 `is_var_init` 判定は `!sig.contains('(')` だった。直前行の `#elif defined(_WIN32)` に `(` があるため条件が偽になり、この class 本体が関数本体として stub 化されていた。
+- 結果 `class Standard_DbgHelper { throw 0; };` や `class Standard_DbgHelper { return {}; };` のような構文エラー (C2059: `syntax error: 'throw'/'return'`) を生む。
+- **対策**: 関数本体判定を「**sig の末尾行から `const` / `override` / `final` / `noexcept` / `mutable` / `volatile` / `= 0` を剥いだ残りが `)` で終わる**」方式に変更。関数定義は必ず `)` (params の閉じ、あるいは init-list 要素の `)`) で終わり、class / struct / namespace ヘッダは識別子か `>` で終わるため、両者を確実に区別できる。preprocessor 行の `(` や `)` は末尾行だけ見ることで影響を排除する。
+
+## 最終的な stub_body_for_sig のパイプライン
+
+1. sig がブロックコメント途中から始まる (先頭に孤児 `*/`) なら先頭を切り落とす
+2. `//` と `/* */` をテキストから除去
+3. `#` で始まる行 (preprocessor) を削除
+4. `A :: B` → `A::B` の空白正規化
+5. マクロ呼び出し (`[A-Z_][A-Z0-9_]*` + `(`) をスキップしつつ関数の `(` を探す
+6. 得られた `(` の前を head として walk-back で関数名を抽出
+7. name に `~` → デストラクタ / `Foo::Foo` セグメント一致 → コンストラクタ → `{}`
+8. return_part に whole-word の `void` (後ろに `*` / `&` が付かない) → `{}`
+9. それ以外 → `{ return {}; }`
+
+関数本体判定 (`is_function`) は別途、`stub_all_top_level_bodies` 側で「sig 末尾行が `)` で終わる」で行う。両者は役割が異なるので分離している。
+
+## 実行時への副次効果
+
+`{ return {}; }` は各戻り値型を value-initialization するので、ほとんどの OCCT OSD 関数について実用上無害な値 (`false` / `0` / 空文字列 / デフォルト構築値) を返す。従来の `{}` + 非 void (UB) や `throw 0;` (foreign exception で Rust 側 abort) ではいずれも 01_primitives 実行時に crash していたが、`{ return {}; }` 方針では **実行時も通って `.step` / `.svg` が生成されるようになった** (想定外の副産物)。ただしこれは OCCT が戻り値を緩くチェックしているだけで保証された挙動ではないので、本命の解としては issue #80 (「スタブをやめて advapi32 / user32 を素直にリンクする」) の方針を引き続き検討する価値がある。
+
+## 参考
+
+- 関連 issue: #80
+- 対象コミット: 本 note と同じ PR
+- OCCT ソース参照 (V8_0_0_rc5):
+  - `src/FoundationClasses/TKernel/OSD/OSD_Protection.cxx` — 事例 1, 2
+  - `src/FoundationClasses/TKernel/OSD/OSD_File.cxx` — 事例 3, 4
+  - `src/DataExchange/TKXCAF/XCAFDoc/XCAFDoc_VisMaterial.cxx` — 事例 5
+  - `src/FoundationClasses/TKernel/Standard/Standard_StackTrace.cxx` — 事例 6


### PR DESCRIPTION
## Summary

- Windows MSVC native build of OCCT was failing with `error C4716: must return a value` because `build.rs` stubbed every OSD function body with a bare `{}`, which MSVC rejects for non-void returns (C4716 is a hard error, not a suppressible warning).
- Replace the blanket stub with a signature-aware rule: `void` / constructor / destructor → `{}`, everything else → `{ return {}; }`.
- Document every OCCT-specific edge case the parser had to absorb in \`notes/20260416-occt_cxx_stub_edge_cases.md\`.

## Edge cases handled by \`stub_body_for_sig\`

1. \`A :: B\` spacing (OCCT古典スタイル) — normalised to \`A::B\` before walk-back.
2. Trailing \`// end constructor (1)\` style comments polluting \`find('(')\` — stripped.
3. Sig starting mid-block-comment (outer scanner picks a \`}\` inside \`/* ... }*/\`) — orphan \`*/\` detection truncates the sig.
4. \`#if defined(__CYGWIN32__)\` preprocessor lines — filtered.
5. \`IMPLEMENT_STANDARD_RTTIEXT(...)\` and other ALL_CAPS macro invocations — skipped over to find the real function's \`(\`.
6. \`class Standard_DbgHelper { ... };\` mis-stubbed as a function body — the \`is_var_init\` heuristic was rewritten to treat \"last line of sig ends with \`)\` (after stripping \`const\`/\`noexcept\`/\`override\`/\`final\`/\`=0\`)\" as the function predicate, so class/struct/namespace headers are preserved verbatim.

## Side effect

\`01_primitives.exe\` now **runs to completion** on Windows MSVC (release, 6m54s) and produces \`01_primitives.step\` / \`01_primitives.svg\`. Value-initialised returns from the stubbed OSD functions (\`false\` / \`0\` / empty string / default-constructed value) happen to be benign for every codepath OCCT enters. Previously the \`{}\`→UB path and the interim \`{ throw 0; }\` attempt both crashed at runtime with \`Rust cannot catch foreign exceptions\`.

This isn't a guaranteed property — OCCT may tighten return-value checks in the future — so issue #80 (\"stop stubbing OSD and link \`advapi32\`/\`user32\` directly\") stays open as the preferred long-term solution.

## Test plan

- [x] \`cargo check\` — build.rs compiles
- [x] \`cargo clean && cargo run --example 01_primitives --release --features source-build\` on Windows MSVC native — OCCT builds from source, example runs to completion, \`01_primitives.step\` / \`01_primitives.svg\` generated
- [ ] CI: Linux / musl / windows-gnu / windows-msvc (docker) targets still build

Refs #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)