### PR TITLE
fix(build): include top-level dir in prebuilt tarball

### DIFF
--- a/makefile
+++ b/makefile
@@ -18,4 +18,4 @@ cadrum-occt-all: # cross all build
 cadrum-occt: generate # native build (01_primitivesのテストも兼ねる)
 	cargo run --example 01_primitives --release --features source-build 2>&1 | tee out/log.txt || true # colorはdefaultの一部なのでfeature指定不要
 	echo "is is ok that 01_primitives fails in windows-gnu target." >> out/log.txt
-	find target -maxdepth 1 -type d -name 'cadrum*' | xargs -IX sh -c 'tar -czvf out/$$(basename X).tar.gz -C X .'
+	find target -maxdepth 1 -type d -name 'cadrum*' | xargs -IX sh -c 'tar -czvf out/$$(basename X).tar.gz -C $$(dirname X) $$(basename X)'


### PR DESCRIPTION
## Summary
- `cadrum-occt` make target の `tar` コマンドが `-C X .` でフラットなアーカイブを生成していたため、`build.rs` が期待するトップレベルディレクトリ `cadrum-occt-<slug>-<target>/` が存在せず、prebuilt ダウンロード時に `prebuilt tarball missing expected top-level dir` で panic していた
- `tar -C $(dirname X) $(basename X)` に変更し、tarball 内にトップレベルディレクトリを含めるようにした

## Test plan
- [ ] `prebuilt` ブランチで prebuilt を再ビルドし、tarball 内のディレクトリ構造を `tar tzf` で確認
- [ ] Linux 環境で prebuilt tarball からのビルドが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)