### PR TITLE
feat(build): add Dockerfile for x86_64-pc-windows-gnu cross-compilation

### DIFF
--- a/docker/Dockerfile_x86_64-pc-windows-gnu
+++ b/docker/Dockerfile_x86_64-pc-windows-gnu
@@ -1,0 +1,40 @@
+# Prebuild OCCT for x86_64-pc-windows-gnu using Debian mingw-w64.
+#
+# Cross-compiles OCCT into static libraries (.a) from a Linux host.
+# The resulting Windows .exe cannot execute inside this container;
+# `cadrum-occt` tolerates the execution failure via `|| true`.
+FROM debian:bookworm-slim
+
+# gcc/g++: HOST compiler for build-dependencies (aws-lc-rs, ring, etc.)
+# gcc-mingw-w64-*: TARGET cross-compiler for OCCT and cxx-build
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl ca-certificates git make cmake \
+    gcc g++ \
+    gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 \
+    && update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix \
+    && update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+ENV PATH=/root/.cargo/bin:$PATH
+
+# control cc crate and cargo command
+#
+# Target-specific CC_<target>/CXX_<target> so that HOST build-dependencies
+# use the native gcc while OCCT cmake and cxx-build use the mingw
+# cross-compiler.
+ENV CC_x86_64_pc_windows_gnu=x86_64-w64-mingw32-gcc
+ENV CXX_x86_64_pc_windows_gnu=x86_64-w64-mingw32-g++
+ENV AR_x86_64_pc_windows_gnu=x86_64-w64-mingw32-ar
+ENV CARGO_BUILD_TARGET=x86_64-pc-windows-gnu
+
+# linker: point rustc at the mingw cross-compiler so final-link flags
+# (-static etc. emitted by build.rs) are interpreted by the correct driver.
+ENV CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER=x86_64-w64-mingw32-gcc
+
+# add cargo target
+RUN rustup target add ${CARGO_BUILD_TARGET}
+
+# copy source and build OCCT prebuilt
+WORKDIR /src
+COPY . /src

--- a/makefile
+++ b/makefile
@@ -1,22 +1,22 @@
 PATH_DOCS=out/markdown
-generate: # 事前準備
+generate: # prepare for deploy
 	mkdir -p out
 	find . -maxdepth 1 -name .gitignore | xargs -IX sed '/^#\s*EOF_DOCKERIGNORE.*/q' X > .dockerignore
-test:
+test: # test all
 	cargo test
 deploy: generate # generate out/markdown from examples, then build out/html
 	cargo install --root out mdbook --version 0.4.50
 	cargo run --example markdown -- $(PATH_DOCS)/SUMMARY.md ./README.md
 	./out/bin/mdbook build
-publish: # --no-verify skips the full OCCT build verification which takes a very long time
-	cargo publish --no-verify
-cadrum-occt: generate # native build
+publish: deploy # publish to crates.io
+	cargo publish
+cadrum-occt: generate # build occt from source natively
 	cargo clean
 	cargo build --example 01_primitives --release --features source-build 2>&1 | tee out/log.txt # colorはdefaultの一部なのでfeature指定不要
 	find target -maxdepth 1 -type d -name 'cadrum*' | xargs -IX sh -c 'tar -czf out/$$(basename X).tar.gz -C $$(dirname X) $$(basename X)'
-cadrum-occt-%: # cross build ( = native build in container ) cadrum-occt-aarch64-unknown-linux-gnu cadrum-occt-x86_64-pc-windows-gnu cadrum-occt-x86_64-unknown-linux-gnu
+cadrum-occt-%: # build occt from source in cross ( = native build in container ) cadrum-occt-aarch64-unknown-linux-gnu cadrum-occt-x86_64-pc-windows-gnu cadrum-occt-x86_64-unknown-linux-gnu
 	docker build -f docker/Dockerfile_$(*) -t cadrum-occt-$(*) .
 	docker run --rm -v $(PWD)/out/$(*):/src/out cadrum-occt-$(*) make cadrum-occt
-check-%: cadrum-occt-% # 
-	find out -maxdepth 2 -type f -name '*.tar.gz' | xargs -IX tar -xzf X target
+check-cadrum-occt-%: cadrum-occt-% # varidate builded occt to run binary which is linked with host's code and container's static occt libraries
+	find out -maxdepth 2 -type f -name '*.tar.gz' | xargs -IX tar -xzf X -C target
 	timeout 300 cargo run --example 01_primitives

--- a/makefile
+++ b/makefile
@@ -10,17 +10,13 @@ deploy: generate # generate out/markdown from examples, then build out/html
 	./out/bin/mdbook build
 publish: # --no-verify skips the full OCCT build verification which takes a very long time
 	cargo publish --no-verify
-cadrum-occt-%: # cross build ( = native build in container )
+cadrum-occt: generate # native build
+	cargo clean
+	cargo build --example 01_primitives --release --features source-build 2>&1 | tee out/log.txt # colorはdefaultの一部なのでfeature指定不要
+	find target -maxdepth 1 -type d -name 'cadrum*' | xargs -IX sh -c 'tar -czf out/$$(basename X).tar.gz -C $$(dirname X) $$(basename X)'
+cadrum-occt-%: # cross build ( = native build in container ) cadrum-occt-aarch64-unknown-linux-gnu cadrum-occt-x86_64-pc-windows-gnu cadrum-occt-x86_64-unknown-linux-gnu
 	docker build -f docker/Dockerfile_$(*) -t cadrum-occt-$(*) .
 	docker run --rm -v $(PWD)/out/$(*):/src/out cadrum-occt-$(*) make cadrum-occt
-cadrum-occt-all: # cross all build
-	make -j3 cadrum-occt-aarch64-unknown-linux-gnu cadrum-occt-x86_64-pc-windows-gnu cadrum-occt-x86_64-unknown-linux-gnu
-cadrum-occt: generate # native build (01_primitivesのテストも兼ねる)
-	cargo run --example 01_primitives --release --features source-build 2>&1 | tee out/log.txt || true # colorはdefaultの一部なのでfeature指定不要
-	echo "is is ok that 01_primitives fails in windows-gnu target." >> out/log.txt
-	find target -maxdepth 1 -type d -name 'cadrum*' | xargs -IX sh -c 'tar -czvf out/$$(basename X).tar.gz -C $$(dirname X) $$(basename X)'
-check-%: # cross build ( = native build in container )
-	$(MAKE) cadrum-occt-$(*)
-	find target -type d -name "cadrum-*" -delete
-	find out -type f -name '*-windows-gnu.tar.gz' | xargs -IX tar -xzf X target
-	cargo run --example 01_primitives
+check-%: cadrum-occt-% # 
+	find out -maxdepth 2 -type f -name '*.tar.gz' | xargs -IX tar -xzf X target
+	timeout 300 cargo run --example 01_primitives


### PR DESCRIPTION
## Summary
- `docker/Dockerfile_x86_64-pc-windows-gnu` を新規作成: debian:bookworm-slim + mingw-w64 (posix スレッドモデル) で OCCT を Linux からクロスコンパイル
- `CC_x86_64_pc_windows_gnu` 等のターゲット固有 env var で HOST (aws-lc-rs 等) と TARGET (OCCT cmake, cxx-build) のコンパイラを分離
- makefile: `tar -xzf X -C target` 修正、コメント整理、`check-cadrum-occt-%` バリデーションターゲット追加

## DLL dependencies
ビルドされた exe (`target/debug/examples/01_primitives.exe`) の DLL 依存を `objdump -p` で確認。全て Windows OS 標準 DLL で、MinGW ランタイム DLL は依存なし — exe 単体で配布可能（Windows 10 以降）。

| DLL | 提供元 |
|---|---|
| `KERNEL32.dll` | Windows NT カーネル（全 Windows） |
| `ntdll.dll` | Windows NT カーネル（全 Windows） |
| `WS2_32.dll` | Winsock（全 Windows） |
| `USERENV.dll` | ユーザー環境（全 Windows） |
| `bcryptprimitives.dll` | 暗号基盤（Vista 以降） |
| `api-ms-win-core-synch-l1-2-0.dll` | カーネル同期 API set（Windows 8 以降） |
| `api-ms-win-crt-convert-l1-1-0.dll` | UCRT（Windows 10 以降は OS 同梱） |
| `api-ms-win-crt-environment-l1-1-0.dll` | UCRT |
| `api-ms-win-crt-filesystem-l1-1-0.dll` | UCRT |
| `api-ms-win-crt-heap-l1-1-0.dll` | UCRT |
| `api-ms-win-crt-locale-l1-1-0.dll` | UCRT |
| `api-ms-win-crt-math-l1-1-0.dll` | UCRT |
| `api-ms-win-crt-private-l1-1-0.dll` | UCRT |
| `api-ms-win-crt-runtime-l1-1-0.dll` | UCRT |
| `api-ms-win-crt-stdio-l1-1-0.dll` | UCRT |
| `api-ms-win-crt-string-l1-1-0.dll` | UCRT |
| `api-ms-win-crt-time-l1-1-0.dll` | UCRT |
| `api-ms-win-crt-utility-l1-1-0.dll` | UCRT |

`libstdc++-6.dll`, `libgcc_s_seh-1.dll`, `libwinpthread-1.dll` は build.rs の `cargo:rustc-link-arg=-static` により静的吸収済み。

## Test plan
- [x] `make check-cadrum-occt-x86_64-pc-windows-gnu` が Windows (x86_64-pc-windows-gnu) ホストで exit 0
- [x] Docker 内 OCCT cmake ビルド成功 (posix thread model で `std::mutex` 解決)
- [x] ホスト側で prebuilt `.a` とリンクして `01_primitives` が実行完了
- [x] `objdump -p` で MinGW ランタイム DLL 非依存を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)