### PR TITLE
refactor(build): gate cmake/walkdir behind source-build, simplify README

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ pure = []
 # Build OCCT from upstream sources when the cache is empty, instead of
 # downloading a prebuilt tarball. Off by default — most users will use the
 # prebuilt binary path.
-source-build = []
+source-build = ["dep:cmake", "dep:walkdir"]
 
 [dependencies]
 cxx = "1"
@@ -28,13 +28,13 @@ glam = { version = "0.29", features = ["std"] }
 
 [build-dependencies]
 cxx-build = "1"
-# download OpenCASCADE
+# download and extract prebuilt OCCT tarball
 minreq = { version = "2", features = ["https-rustls"] }
-# extract tar.gz
 libflate = "2"
 tar = "0.4"
-cmake = "0.1"
-walkdir = "2"
+# source-build only: build OCCT from upstream sources
+cmake = { version = "0.1", optional = true }
+walkdir = { version = "2", optional = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu"]

--- a/README.md
+++ b/README.md
@@ -467,14 +467,15 @@ fn main() -> Result<(), Error> {
 
 #### Sweep
 
-Sweep showcase: M2 screw (helix spine) + U-shaped pipe (line+arc+line spine).
+Sweep showcase: M2 screw (helix spine) + U-shaped pipe (line+arc+line spine)
 
 ```sh
 cargo run --example 07_sweep
 ```
 
 ```rust
-//! Sweep showcase: M2 screw (helix spine) + U-shaped pipe (line+arc+line spine).
+//! Sweep showcase: M2 screw (helix spine) + U-shaped pipe (line+arc+line spine)
+//! + twisted ribbon (`Auxiliary` aux-spine mode).
 //!
 //! `ProfileOrient` controls how the profile is oriented as it travels along the spine:
 //!
@@ -490,6 +491,9 @@ cargo run --example 07_sweep
 //!   tangent–`axis` plane. Suited for roads/rails/pipes that must preserve a
 //!   gravity direction. On a helix, `Up(helix_axis)` is equivalent to `Torsion`.
 //!   Fails when the tangent becomes parallel to `axis`.
+//! - `Auxiliary(aux_spine)`: profile's tracked axis points from the main spine
+//!   toward a parallel auxiliary spine. Arbitrary twist control — e.g. a
+//!   helical `aux_spine` on a straight `spine` produces a twisted ribbon.
 
 use cadrum::{Compound, Edge, Error, ProfileOrient, Solid, Transform};
 use glam::DVec3;
@@ -524,9 +528,9 @@ fn build_m2_screw() -> Result<Vec<Solid>, Error> {
 	let crest = Solid::cylinder(r - r_delta / 8.0, DVec3::Z, h_thread);
 	let thread_shaft = thread.union([&shaft])?.intersect([&crest])?;
 
-	// Stack the flat head on top.
+	// Stack the flat head on top. Screw ends up centered on the origin.
 	let head = Solid::cylinder(r_head, DVec3::Z, h_head).translate(DVec3::Z * h_thread);
-	thread_shaft.union([&head])
+	Ok(thread_shaft.union([&head])?.color("red"))
 }
 
 // ==================== Component 2: U-shaped pipe ====================
@@ -535,67 +539,69 @@ fn build_u_pipe() -> Result<Vec<Solid>, Error> {
 	let pipe_radius = 0.4;
 	let leg_length = 6.0;
 	let gap = 3.0;
-	let bend_radius = gap / 2.0;
+	let half_gap = gap / 2.0;
+	let bend_radius = half_gap;
 
-	// U-shaped path in the XZ plane: A↑B ⌒ C↓D
-	let a = DVec3::ZERO;
-	let b = DVec3::new(0.0, 0.0, leg_length);
-	let arc_mid = DVec3::new(bend_radius, 0.0, leg_length + bend_radius);
-	let c = DVec3::new(gap, 0.0, leg_length);
-	let d = DVec3::new(gap, 0.0, 0.0);
+	// U-shaped path in the XZ plane, centered on origin in X: A↑B ⌒ C↓D.
+	let a = DVec3::new(-half_gap, 0.0, 0.0);
+	let b = DVec3::new(-half_gap, 0.0, leg_length);
+	let arc_mid = DVec3::new(0.0, 0.0, leg_length + bend_radius);
+	let c = DVec3::new(half_gap, 0.0, leg_length);
+	let d = DVec3::new(half_gap, 0.0, 0.0);
 
 	// Spine wire: line → semicircle → line.
 	let up_leg = Edge::line(a, b)?;
 	let bend = Edge::arc_3pts(b, arc_mid, c)?;
 	let down_leg = Edge::line(c, d)?;
 
-	// Circular profile in XY (normal +Z) — already aligned with the spine start tangent.
-	let profile = Edge::circle(pipe_radius, DVec3::Z)?;
+	// Circular profile in XY (normal +Z) translated to the spine start `a`.
+	// Spine tangent at `a` is +Z, so the XY-plane circle is already aligned.
+	let profile = Edge::circle(pipe_radius, DVec3::Z)?.translate(a);
 
 	// Up(+Y) fixes the binormal to the path-plane normal, avoiding Frenet
 	// degeneracy on the straight segments.
 	let pipe = Solid::sweep(&[profile], &[up_leg, bend, down_leg], ProfileOrient::Up(DVec3::Y))?;
-	Ok(vec![pipe])
+	Ok(vec![pipe].translate(DVec3::X * 6.0).color("blue"))
+}
+
+// ==================== Component 3: Auxiliary-spine twisted ribbon ====================
+
+// 直線 spine を `Auxiliary(&[helix])` で掃引すると、各点で profile の tracked 軸が
+// 対応するヘリックス点を向くように回転される。pitch=h のヘリックスは [0, h] の
+// あいだにちょうど 360° 一周するので、平たい長方形 profile は 1 回捻れた
+// リボンになる — `Fixed` や `Torsion` だと直線 spine では profile は全く
+// 回転しないので、ねじれが見えれば Auxiliary が効いている証拠。
+fn build_twisted_ribbon() -> Result<Vec<Solid>, Error> {
+	let h = 8.0;
+	let aux_r = 3.0;
+
+	let spine = Edge::line(DVec3::ZERO, DVec3::Z * h)?;
+	let aux = Edge::helix(aux_r, h, h, DVec3::Z, DVec3::X)?;
+
+	// 平たい長方形 (10:1 アスペクト) — 円や正方形ではねじれが見えない。
+	let profile = Edge::polygon(&[DVec3::new(-2.0, -0.2, 0.0), DVec3::new(2.0, -0.2, 0.0), DVec3::new(2.0, 0.2, 0.0), DVec3::new(-2.0, 0.2, 0.0)])?;
+
+	let ribbon = Solid::sweep(&profile, &[spine], ProfileOrient::Auxiliary(&[aux]))?;
+	Ok(vec![ribbon].translate(DVec3::X * 12.0).color("green"))
 }
 
 // ==================== main: side-by-side layout ====================
+//
+// Each builder places its component at its final world position (screw at
+// origin, U-pipe at x=6, ribbon at x=12) and applies its color, so main
+// just concatenates them.
 
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let example_name = std::path::Path::new(file!()).file_stem().unwrap().to_str().unwrap();
+	let all: Vec<Solid> = [build_m2_screw()?, build_u_pipe()?, build_twisted_ribbon()?].concat();
 
-	// Screw at origin, U-pipe offset along +X.
-	let x_offset = 6.0;
-
-	let mut all: Vec<Solid> = Vec::new();
-
-	match build_m2_screw() {
-		Ok(screw) => {
-			all.extend(screw.color("red"));
-			println!("✓ screw built (red, centered at origin)");
-		}
-		Err(e) => eprintln!("✗ screw failed: {e}"),
-	}
-
-	match build_u_pipe() {
-		Ok(pipe) => {
-			let placed: Vec<Solid> = pipe.translate(DVec3::X * x_offset).color("blue");
-			all.extend(placed);
-			println!("✓ U-pipe built (blue, offset x={x_offset})");
-		}
-		Err(e) => eprintln!("✗ U-pipe failed: {e}"),
-	}
-
-	if all.is_empty() {
-		eprintln!("nothing to write");
-		return;
-	}
-
-	let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create STEP file");
-	cadrum::write_step(&all, &mut f).expect("failed to write STEP");
-	let mut f_svg = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
+	let mut f = std::fs::File::create(format!("{example_name}.step"))?;
+	cadrum::write_step(&all, &mut f)?;
+	let mut f_svg = std::fs::File::create(format!("{example_name}.svg"))?;
 	// Helical threads have dense hidden lines that clutter the SVG; disable them.
-	cadrum::mesh(&all, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, -1.0), false, false, &mut f_svg)).expect("failed to write SVG");
+	cadrum::mesh(&all, 0.5)?.write_svg(DVec3::new(1.0, 1.0, -1.0), false, false, &mut f_svg)?;
 	println!("wrote {example_name}.step / {example_name}.svg ({} solids)", all.len());
+	Ok(())
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,28 @@ Add this to your `Cargo.toml`:
 cadrum = "^0.5"
 ```
 
+## Build
+
+`cargo build` automatically downloads a prebuilt OCCT 8.0.0-rc5 binary for the targets below.
+
+| | Target | Prebuilt |
+|--|--------|----------|
+| <img src="figure/linux.svg" width="16"> | `x86_64-unknown-linux-gnu` | ✅ |
+| <img src="figure/linux.svg" width="16"> | `aarch64-unknown-linux-gnu` | ✅ |
+| <img src="figure/windows.svg" width="16"> | `x86_64-pc-windows-msvc` | ✅ |
+| <img src="figure/windows.svg" width="16"> | `x86_64-pc-windows-gnu` | ✅ |
+
+For other targets, build OCCT from source:
+
+    OCCT_ROOT=/path/to/occt cargo build --features source-build
+
+If `OCCT_ROOT` is not set, built binaries are cached under `target/`.
+
+#### Requirements when building OpenCASCADE from source
+
+- C++17 compiler (GCC, Clang, or MSVC)
+- CMake
+
 ## Examples
 
 #### Primitives
@@ -647,68 +669,12 @@ fn main() {
 </p>
 
 
-## Requirements
-
-- A C++17 compiler (GCC, Clang, or MSVC)
-- CMake
-
-Tested with GCC 15.2.0 (MinGW-w64) and CMake 3.31.11 on Windows.
-
-## Build
-
-By default, `cargo build` downloads a **prebuilt OCCT 8.0.0-rc5 binary** from GitHub Releases
-matching the current target triple, and extracts it to `target/cadrum-occt-v800rc5-<triple>/`.
-First-time builds finish in seconds instead of the 10–30 minutes a source build would take.
-
-Prebuilts are published for these targets:
-- `x86_64-unknown-linux-gnu` — built on manylinux_2_28 (AlmaLinux 8, glibc 2.28); works on Ubuntu 18.10+, Debian 10+, RHEL/Rocky/AlmaLinux 8+, Fedora 29+, Arch, openSUSE Leap 15.1+
-- `aarch64-unknown-linux-gnu` — built on manylinux_2_28_aarch64; works on Raspberry Pi 4/5 (64-bit OS), AWS Graviton, Oracle Ampere, Apple Silicon Linux VMs
-- `x86_64-pc-windows-gnu`
-- `x86_64-pc-windows-msvc`
-
-Other triples — Alpine (musl), macOS (x86_64/arm64), Windows on ARM — are not
-currently published. Users on those platforms should enable the `source-build`
-feature to build OCCT from upstream sources locally:
-
-```sh
-cargo build --features source-build
-```
-
-Resolution model (build.rs):
-
-1. `OCCT_ROOT` defines the single cache location. If unset, it defaults to
-   `target/cadrum-occt-v800rc5-<triple>/`. Whether explicit or default, the
-   semantics are the same: if the directory already contains OCCT headers
-   and libs, link directly.
-2. **Cache miss** — populate the cache:
-   - Without `source-build` feature (default): download the prebuilt tarball
-     for `<triple>` from GitHub Release and extract into the cache dir.
-     If the target is not in the supported list, `build.rs` panics with a
-     pointer back here.
-   - With `source-build` feature: download OCCT source from upstream and
-     build with CMake into the cache dir (10–30 minutes).
-
-To build on an unsupported triple, or to patch OCCT locally:
-
-```sh
-cargo build --features source-build
-```
-
-To pin OCCT to a persistent location across `cargo clean`:
-
-```sh
-export OCCT_ROOT=~/occt
-cargo build
-```
-
 ## Features
 
-- `color` (default): Colored STEP I/O via XDE (`STEPCAFControl`). Enables `write_step_with_colors`,
+- `color` (default): Colored STEP I/O via XDE. Enables `write_step_with_colors`,
   `read_step_with_colors`, and per-face color on `Solid`.
-  Colors are preserved through boolean operations and other transformations.
-- `source-build` (default OFF): Build OCCT from upstream sources via CMake when the cache is
-  empty, instead of downloading a prebuilt tarball. Enable this if you are on a triple with no
-  published prebuilt, or if you want to patch OCCT locally.
+- `source-build`: Download and build OCCT from upstream sources via CMake.
+  Enable this on triples without a published prebuilt.
 
 ## Showcase
 

--- a/build.rs
+++ b/build.rs
@@ -18,7 +18,6 @@ fn slug(version: &str) -> String {
 
 fn main() {
 	println!("cargo:rerun-if-env-changed=OCCT_ROOT");
-	println!("cargo:rerun-if-env-changed=CARGO_TARGET_DIR");
 	println!("cargo:rerun-if-env-changed=CADRUM_PREBUILT_URL");
 	println!("cargo:rerun-if-changed=src/traits.rs");
 	println!("cargo:rerun-if-changed=build_delegation.rs");
@@ -30,128 +29,75 @@ fn main() {
 	let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 	build_delegation::build_delegation(include_str!("src/traits.rs"), &out_dir);
 
-	let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
 	let target = env::var("TARGET").unwrap();
 
-	let (occt_include, occt_lib_dir) = resolve_occt(&manifest_dir, &out_dir, &target);
+	let [occt_include, occt_lib_dir] = resolve_occt(&out_dir, &target);
 
 	link_occt_libraries(&occt_include, &occt_lib_dir);
 }
 
-/// Resolve (include_dir, lib_dir) for OCCT.
+/// Derive the cargo target directory from `OUT_DIR`.
 ///
-/// Model: `OCCT_ROOT` is the single cache location. If unset, it defaults to
-/// `target/cadrum-occt-<slug>-<target>/`. The `source-build` feature only
-/// changes how a cache miss is populated; it does nothing on a cache hit.
+/// `OUT_DIR` layout:
+///   `<target_dir>/<profile>/build/<pkg>-<hash>/out`            (no `--target`)
+///   `<target_dir>/<triple>/<profile>/build/<pkg>-<hash>/out`   (with `--target`)
 ///
-///   1. Compute `effective_root = OCCT_ROOT or default`
-///   2. If `effective_root` already has both lib and include → use it
-///   3. Otherwise, populate it:
-///        - `source-build` feature ON  → build from upstream OCCT sources
-///        - `source-build` feature OFF → download prebuilt tarball (panic on failure)
-fn resolve_occt(manifest_dir: &Path, out_dir: &Path, target: &str) -> (PathBuf, PathBuf) {
-	// Default cache dir lives alongside other cargo build artifacts. Honor
-	// `CARGO_TARGET_DIR` if set so that isolated-per-container builds (docker)
-	// don't all collide on the same OCCT install path.
-	let target_dir: PathBuf = env::var("CARGO_TARGET_DIR").map(PathBuf::from).unwrap_or_else(|_| manifest_dir.join("target"));
+/// Walking up 4 levels from `out` lands on either `<triple>` or `<target_dir>`.
+/// If it matches `TARGET`, one more parent gives the real target dir.
+fn target_dir_from_out_dir(out_dir: &Path, target: &str) -> PathBuf {
+	let above_profile = out_dir.ancestors().nth(4).expect("unexpected OUT_DIR layout");
+	if above_profile.file_name().map_or(false, |n| n == target) {
+		above_profile.parent().unwrap().to_path_buf()
+	} else {
+		above_profile.to_path_buf()
+	}
+}
+
+/// Resolve `[include_dir, lib_dir]` for OCCT.
+///
+///   1. Cache hit → use it
+///   2. Cache miss + `source-build` → build from upstream sources
+///   3. Cache miss otherwise → download prebuilt tarball
+fn resolve_occt(out_dir: &Path, target: &str) -> [PathBuf; 2] {
+	let target_dir = target_dir_from_out_dir(out_dir, target);
 	let default_root = target_dir.join(format!("cadrum-occt-{}-{}", slug(OCCT_VERSION), target));
-	let effective_root: PathBuf = env::var("OCCT_ROOT").map(PathBuf::from).unwrap_or_else(|_| default_root.clone());
+	let effective_root = env::var("OCCT_ROOT").map(PathBuf::from).unwrap_or(default_root);
 
 	println!("cargo:rerun-if-changed={}", effective_root.display());
 
-	let [include_dir, lib_dir] = find_occt_dirs(&effective_root);
-	if lib_dir.exists() && include_dir.exists() {
-		return (include_dir, lib_dir);
-	}
-
-	// Cache miss: populate effective_root.
-	if cfg!(feature = "source-build") {
-		eprintln!("cargo:warning=OCCT cache miss at {} — building from source (this may take 10-30 minutes)", effective_root.display());
-		return build_occt_from_source(out_dir, &effective_root);
-	}
-
-	match try_prebuilt(out_dir, &effective_root, target) {
-		Some(pair) => pair,
-		None => panic!(
-			"\nFailed to download prebuilt OCCT for target `{}`.\n\
-			 A prebuilt tarball for this target may not be published yet.\n\
-			 See README for the list of supported prebuilt targets, or enable\n\
-			 the `source-build` feature to build OCCT from upstream sources:\n\
-			 \n    cargo build --features source-build\n",
-			target
-		),
+	match find_occt_dirs(&effective_root) {
+		Some(dirs) => return dirs,
+		None => {
+			#[cfg(feature = "source-build")]
+			{
+				eprintln!("cargo:warning=OCCT cache miss at {} — building from source (this may take 10-30 minutes)", effective_root.display());
+				return source::build_from_source(out_dir, &effective_root)
+					.expect("Failed to build OCCT from source");
+			}
+			#[cfg(not(feature = "source-build"))]
+			{
+				return download_prebuilt(out_dir, &effective_root, target)
+					.unwrap_or_else(|| panic!(
+						"\nFailed to download prebuilt OCCT for target `{}`.\n\
+						 See README for the list of supported prebuilt targets, or enable\n\
+						 the `source-build` feature to build OCCT from upstream sources:\n\
+						 \n    cargo build --features source-build\n",
+						target
+					));
+			}
+		}
 	}
 }
 
-/// Attempt to download and extract a prebuilt OCCT tarball for `target` into `dest`.
-/// Returns None on any failure; the caller decides whether to panic or fall back.
-fn try_prebuilt(out_dir: &Path, dest: &Path, target: &str) -> Option<(PathBuf, PathBuf)> {
-	let slug_ver = slug(OCCT_VERSION);
-	let top_name = format!("cadrum-occt-{}-{}", slug_ver, target);
-	let tarball_name = format!("{}.tar.gz", top_name);
-	let url = env::var("CADRUM_PREBUILT_URL").unwrap_or_else(|_| format!("https://github.com/lzpel/cadrum/releases/download/{}/{}", OCCT_PREBUILT_TAG, tarball_name));
-
-	eprintln!("cargo:warning=Downloading prebuilt OCCT from {}", url);
-
-	// Extract into a staging directory inside OUT_DIR, then move the tarball's
-	// top-level `<top_name>/` into `dest`. Staging decouples the tarball's
-	// layout from the (possibly user-chosen) `OCCT_ROOT` path.
-	let staging = out_dir.join("occt-prebuilt-staging");
-	let _ = std::fs::remove_dir_all(&staging);
-	std::fs::create_dir_all(&staging).ok()?;
-
-	if let Err(e) = download_and_extract_tar_gz(&url, &staging) {
-		eprintln!("cargo:warning=prebuilt fetch failed: {}", e);
-		return None;
-	}
-
-	let extracted = staging.join(&top_name);
-	if !extracted.is_dir() {
-		eprintln!("cargo:warning=prebuilt tarball missing expected top-level dir `{}`", top_name);
-		return None;
-	}
-
-	if let Some(parent) = dest.parent() {
-		std::fs::create_dir_all(parent).ok()?;
-	}
-	let _ = std::fs::remove_dir_all(dest);
-	if let Err(e) = std::fs::rename(&extracted, dest) {
-		eprintln!("cargo:warning=failed to move extracted OCCT into {}: {}", dest.display(), e);
-		return None;
-	}
-
-	let [include_dir, lib_dir] = find_occt_dirs(dest);
-	if !lib_dir.exists() {
-		eprintln!("cargo:warning=prebuilt extraction did not produce expected lib dir at {}", lib_dir.display());
-		return None;
-	}
-	Some((include_dir, lib_dir))
-}
-
-/// Download `url` (a `.tar.gz`), gunzip, and untar into `dest`.
-/// `dest` must already exist.
-fn download_and_extract_tar_gz(url: &str, dest: &Path) -> Result<(), String> {
-	let bytes = fetch_bytes(url)?;
-	let gz = libflate::gzip::Decoder::new(&bytes[..]).map_err(|e| format!("gzip decode failed: {e}"))?;
-	tar::Archive::new(gz).unpack(dest).map_err(|e| format!("tar unpack failed: {e}"))?;
-	Ok(())
-}
-
-/// Fetch a URL into a byte vector. Supports `http(s)://` via minreq and
-/// `file://` via the local filesystem (used by CI smoke tests).
-fn fetch_bytes(url: &str) -> Result<Vec<u8>, String> {
-	if let Some(rest) = url.strip_prefix("file://") {
-		// Handle both POSIX (`file:///tmp/x`) and Windows (`file:///C:/x`) forms.
-		let path: PathBuf = if rest.len() >= 3 && rest.starts_with('/') && rest.as_bytes()[2] == b':' {
-			PathBuf::from(&rest[1..])
-		} else {
-			PathBuf::from(rest)
-		};
-		std::fs::read(&path).map_err(|e| format!("read {}: {}", path.display(), e))
-	} else {
-		let resp = minreq::get(url).send().map_err(|e| e.to_string())?;
-		Ok(resp.into_bytes())
-	}
+/// Probe `occt_root` for include and lib directories.
+/// Returns `Some([include_dir, lib_dir])` if both exist, `None` otherwise.
+/// Handles Linux (`include`,`lib`), MinGW-gcc (`inc`,`win64/gcc/lib`),
+/// llvm-mingw (`win64/clang/lib`), and MSVC (`win64/vc14/lib`) layouts.
+fn find_occt_dirs(occt_root: &Path) -> Option<[PathBuf; 2]> {
+	let pick = |cands: &[PathBuf]| cands.iter().find(|p| p.exists()).cloned();
+	let inc = pick(&[occt_root.join("include").join("opencascade"), occt_root.join("inc"), occt_root.join("include")])?;
+	let lib = pick(&[occt_root.join("lib"), occt_root.join("win64").join("gcc").join("lib"), occt_root.join("win64").join("clang").join("lib"), occt_root.join("win64").join("vc14").join("lib")])?;
+	Some([inc, lib])
 }
 
 /// OCCT toolkits to link against (OCCT 7.8+ / 8.x naming). In 7.8+,
@@ -182,10 +128,6 @@ fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path) {
 		println!("cargo:rustc-link-lib=static={}", lib);
 	}
 
-	// Safety-net: suppress any residual duplicate-symbol errors when linking
-	// against OCCT static libraries on MinGW.  The primary fix is the
-	// OCC_CONVERT_SIGNALS define added below to the cxx_build step.
-	// Guard to GNU only: -Wl,... is GCC/ld syntax and is invalid on MSVC link.exe.
 	let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
 	let is_mingw_like = target_env == "gnu" || target_env == "gnullvm";
 	if is_mingw_like {
@@ -198,31 +140,9 @@ fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path) {
 	// via cxx — no libstdc++ types cross the boundary, so downstream's
 	// libstdc++ version cannot conflict with the one frozen inside our
 	// objects.
-	//
-	// `-static` as a link-arg covers libgcc and libwinpthread cleanly: gcc
-	// driver rewrites `-lgcc`/`-lwinpthread` to their static .a variants.
-	// libstdc++ is NOT absorbed by this flag alone — rustc hardcodes
-	// `-Wl,-Bdynamic` before the native-library block and link-cplusplus
-	// emits plain `-lstdc++` there, so ld resolves it against
-	// libstdc++.dll.a regardless of a trailing `-static`. Fully absorbing
-	// libstdc++ additionally requires the build environment to set
-	//   CXXSTDLIB_x86_64_pc_windows_gnu=static=stdc++
-	//   RUSTFLAGS=-L <dir containing libstdc++.a>
-	// The first flips link-cplusplus to static-mode emission; the second
-	// satisfies rustc's compile-time check on link-cplusplus itself (which
-	// runs long before this build.rs, so a cargo:rustc-link-search from
-	// here would arrive too late). `docker/Dockerfile_x86_64-pc-windows-gnu`
-	// does both for the prebuilt Docker build; downstream consumers on
-	// windows-gnu need to replicate them (see README).
-	//
-	// Gated to windows+gnu because `-static` on linux-gnu would try to
-	// statically link glibc, which is neither shipped as a .a nor desired.
 	if env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") && is_mingw_like {
 		println!("cargo:rustc-link-arg=-static");
 	}
-
-	// advapi32 / user32: no longer needed — patch_occt_sources() stubs the OSD
-	// files (OSD_WNT, OSD_File, OSD_Protection, OSD_signal) that reference them.
 
 	// Build cxx bridge + C++ wrapper
 	let mut build = cxx_build::bridge("src/occt/ffi.rs");
@@ -230,16 +150,14 @@ fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path) {
 
 	// wrapper.cpp は UTF-8 (日本語コメント含む)。MSVC は既定でシステム既定コードページ
 	// (日本語環境なら CP932) で読むため、マルチバイトの末尾バイトが `\` などと解釈されて
-	// 行が結合され、パースがずれる (例: `const int n = ...;` が消えて `n` undeclared)。
-	// `/utf-8` を付けてソース/実行文字集合を UTF-8 に固定する。
+	// 行が結合され、パースがずれる。`/utf-8` でソース/実行文字集合を UTF-8 に固定。
 	if std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc") {
 		build.flag("/utf-8");
 	}
 
-	// Define CADRUM_COLOR for C++ when the "color" feature is enabled.
 	#[cfg(feature = "color")]
 	build.define("CADRUM_COLOR", None);
-	
+
 	build.compile("cadrum_cpp");
 
 	println!("cargo:rerun-if-changed=src/occt/ffi.rs");
@@ -247,63 +165,121 @@ fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path) {
 	println!("cargo:rerun-if-changed=cpp/wrapper.cpp");
 }
 
-/// Download OCCT source, patch, and build with CMake into `install_prefix`.
-fn build_occt_from_source(out_dir: &Path, install_prefix: &Path) -> (PathBuf, PathBuf) {
-	let occt_version = OCCT_VERSION;
-	let occt_url = format!("https://github.com/Open-Cascade-SAS/OCCT/archive/refs/tags/{}.tar.gz", occt_version);
+/// Download a prebuilt OCCT tarball for `target` into `dest`.
+fn download_prebuilt(out_dir: &Path, dest: &Path, target: &str) -> Option<[PathBuf; 2]> {
+	let slug_ver = slug(OCCT_VERSION);
+	let top_name = format!("cadrum-occt-{}-{}", slug_ver, target);
+	let tarball_name = format!("{}.tar.gz", top_name);
+	let url = env::var("CADRUM_PREBUILT_URL").unwrap_or_else(|_| format!("https://github.com/lzpel/cadrum/releases/download/{}/{}", OCCT_PREBUILT_TAG, tarball_name));
 
-	let download_dir = out_dir.join("occt-source");
+	eprintln!("cargo:warning=Downloading prebuilt OCCT from {}", url);
 
-	// Use a sentinel file to track successful extraction.
-	let extraction_sentinel = download_dir.join(".extraction_done");
+	let staging = out_dir.join("occt-prebuilt-staging");
+	let _ = std::fs::remove_dir_all(&staging);
+	std::fs::create_dir_all(&staging).ok()?;
 
-	if !extraction_sentinel.exists() {
-		std::fs::create_dir_all(&download_dir).unwrap();
-
-		// Clean up any partial extraction from a previous failed attempt
-		if let Ok(entries) = std::fs::read_dir(&download_dir) {
-			for entry in entries.flatten() {
-				let name = entry.file_name();
-				if name.to_string_lossy().starts_with("OCCT") && entry.path().is_dir() {
-					eprintln!("Removing partial OCCT extraction: {:?}", name);
-					let _ = std::fs::remove_dir_all(entry.path());
-				}
-			}
-		}
-
-		eprintln!("Downloading OCCT {} from {} ...", occt_version, occt_url);
-		download_and_extract_tar_gz(&occt_url, &download_dir).expect("Failed to download/extract OCCT source tarball");
-
-		// Write sentinel to mark successful extraction
-		std::fs::write(&extraction_sentinel, "done").unwrap();
-		eprintln!("OCCT source extracted successfully.");
+	if let Err(e) = download_and_extract_tar_gz(&url, &staging) {
+		eprintln!("cargo:warning=prebuilt fetch failed: {}", e);
+		return None;
 	}
 
-	// Auto-detect the extracted OCCT directory name
-	// (GitHub archives name it OCCT-{tag}, e.g. OCCT-V8_0_0_rc5)
-	let source_dir = std::fs::read_dir(&download_dir).expect("Failed to read occt-source directory").flatten().find(|e| e.file_name().to_string_lossy().starts_with("OCCT") && e.path().is_dir()).map(|e| e.path()).expect("OCCT source directory not found after extraction");
+	let extracted = staging.join(&top_name);
+	if !extracted.is_dir() {
+		eprintln!("cargo:warning=prebuilt tarball missing expected top-level dir `{}`", top_name);
+		return None;
+	}
 
-	// Patch OCCT sources to remove TKService (Visualization) dependencies.
-	// XCAFDoc_VisMaterial.cxx and XCAFPrs_Texture.cxx reference Graphic3d_* symbols
-	// that live in TKService, which we don't build (BUILD_MODULE_Visualization=OFF).
-	// The non-visualization TDF_Attribute methods (GetID, Restore, Paste, …) are
-	// kept intact; only FillMaterialAspect / FillAspect are emptied.
-	patch_occt_sources(&source_dir);
+	if let Some(parent) = dest.parent() {
+		std::fs::create_dir_all(parent).ok()?;
+	}
+	let _ = std::fs::remove_dir_all(dest);
+	if let Err(e) = std::fs::rename(&extracted, dest) {
+		eprintln!("cargo:warning=failed to move extracted OCCT into {}: {}", dest.display(), e);
+		return None;
+	}
 
-	let occt_root = install_prefix;
+	find_occt_dirs(dest)
+}
 
-	// Determine lib path (CMake on Windows/MinGW installs to win64/gcc/lib)
-	let [_, lib_dir] = find_occt_dirs(&occt_root);
+fn download_and_extract_tar_gz(url: &str, dest: &Path) -> Result<(), String> {
+	let bytes = fetch_bytes(url)?;
+	let gz = libflate::gzip::Decoder::new(&bytes[..]).map_err(|e| format!("gzip decode failed: {e}"))?;
+	tar::Archive::new(gz).unpack(dest).map_err(|e| format!("tar unpack failed: {e}"))?;
+	Ok(())
+}
 
-	// Build with CMake only if not already installed
-	if !lib_dir.exists() {
+fn fetch_bytes(url: &str) -> Result<Vec<u8>, String> {
+	if let Some(rest) = url.strip_prefix("file://") {
+		let path: PathBuf = if rest.len() >= 3 && rest.starts_with('/') && rest.as_bytes()[2] == b':' {
+			PathBuf::from(&rest[1..])
+		} else {
+			PathBuf::from(rest)
+		};
+		std::fs::read(&path).map_err(|e| format!("read {}: {}", path.display(), e))
+	} else {
+		let resp = minreq::get(url).send().map_err(|e| e.to_string())?;
+		Ok(resp.into_bytes())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// source-build: build OCCT from upstream sources.
+// Dependencies on cmake and walkdir live here only.
+// ---------------------------------------------------------------------------
+#[cfg(feature = "source-build")]
+mod source {
+	use super::{download_and_extract_tar_gz, find_occt_dirs, OCCT_VERSION};
+	use std::env;
+	use std::path::{Path, PathBuf};
+
+	/// Download OCCT source, patch, and build with CMake into `install_prefix`.
+	pub fn build_from_source(out_dir: &Path, install_prefix: &Path) -> Option<[PathBuf; 2]> {
+		// Already built?
+		if find_occt_dirs(install_prefix).is_some() {
+			return find_occt_dirs(install_prefix);
+		}
+
+		let occt_version = OCCT_VERSION;
+		let occt_url = format!("https://github.com/Open-Cascade-SAS/OCCT/archive/refs/tags/{}.tar.gz", occt_version);
+
+		let download_dir = out_dir.join("occt-source");
+		let extraction_sentinel = download_dir.join(".extraction_done");
+
+		if !extraction_sentinel.exists() {
+			std::fs::create_dir_all(&download_dir).unwrap();
+
+			if let Ok(entries) = std::fs::read_dir(&download_dir) {
+				for entry in entries.flatten() {
+					let name = entry.file_name();
+					if name.to_string_lossy().starts_with("OCCT") && entry.path().is_dir() {
+						eprintln!("Removing partial OCCT extraction: {:?}", name);
+						let _ = std::fs::remove_dir_all(entry.path());
+					}
+				}
+			}
+
+			eprintln!("Downloading OCCT {} from {} ...", occt_version, occt_url);
+			download_and_extract_tar_gz(&occt_url, &download_dir).expect("Failed to download/extract OCCT source tarball");
+
+			std::fs::write(&extraction_sentinel, "done").unwrap();
+			eprintln!("OCCT source extracted successfully.");
+		}
+
+		let source_dir = std::fs::read_dir(&download_dir)
+			.expect("Failed to read occt-source directory")
+			.flatten()
+			.find(|e| e.file_name().to_string_lossy().starts_with("OCCT") && e.path().is_dir())
+			.map(|e| e.path())
+			.expect("OCCT source directory not found after extraction");
+
+		patch_occt_sources(&source_dir);
+
 		eprintln!("Building OCCT with CMake (this may take a while)...");
 
 		let built = cmake::Config::new(&source_dir)
 			.profile("Release")
 			.define("BUILD_LIBRARY_TYPE", "Static")
-			.define("CMAKE_INSTALL_PREFIX", occt_root.to_str().unwrap())
-			// Disable optional dependencies we don't need
+			.define("CMAKE_INSTALL_PREFIX", install_prefix.to_str().unwrap())
 			.define("USE_FREETYPE", "OFF")
 			.define("USE_FREEIMAGE", "OFF")
 			.define("USE_OPENVR", "OFF")
@@ -319,7 +295,6 @@ fn build_occt_from_source(out_dir: &Path, install_prefix: &Path) -> (PathBuf, Pa
 			.define("USE_GLES2", "OFF")
 			.define("USE_EGL", "OFF")
 			.define("USE_D3D", "OFF")
-			// Only build the modules we need
 			.define("BUILD_MODULE_FoundationClasses", "ON")
 			.define("BUILD_MODULE_ModelingData", "ON")
 			.define("BUILD_MODULE_ModelingAlgorithms", "ON")
@@ -335,527 +310,377 @@ fn build_occt_from_source(out_dir: &Path, install_prefix: &Path) -> (PathBuf, Pa
 			.define("BUILD_SAMPLES_QT", "OFF")
 			.define("BUILD_Inspector", "OFF")
 			.define("BUILD_ENABLE_FPE_SIGNAL_HANDLER", "OFF")
-			// llvm-rc (cargo-xwin MSVC path) defaults to codepage 0 (ASCII only)
-			// and rejects any non-ASCII byte in narrow string literals. OCCT's
-			// .rc files are cp1252-encoded (the © character arrives as a single
-			// 0xA9 byte, per the error's "codepoint (169)"), so tell llvm-rc to
-			// interpret narrow strings as cp1252.
-			//
-			// We pass this via CMAKE_RC_FLAGS_INIT, NOT CMAKE_RC_FLAGS, because
-			// cargo-xwin's override.cmake contains this line:
-			//   string(REPLACE "/D" "-D" CMAKE_RC_FLAGS "${CMAKE_RC_FLAGS_INIT}")
-			// which unconditionally overwrites whatever we set in CMAKE_RC_FLAGS.
-			// CMAKE_RC_FLAGS_INIT survives the overwrite and flows through the
-			// REPLACE into CMAKE_RC_FLAGS. Harmless on Unix targets (no RC step).
 			.define("CMAKE_RC_FLAGS_INIT", "-C 1252")
 			.build();
 
 		eprintln!("OCCT built at: {}", built.display());
+
+		find_occt_dirs(install_prefix)
 	}
 
-	// Re-resolve dirs after build (in case they were just created)
-	let [include_dir, lib_dir] = find_occt_dirs(&occt_root);
+	/// Patch OCCT source files to remove unwanted link dependencies.
+	///
+	/// 1. TKService (Visualization) — stub XCAFDoc_VisMaterial.cxx, empty XCAFPrs_Texture.cxx
+	/// 2. advapi32 / user32 (Windows) — stub OSD_WNT/File/Protection/signal/FileNode/Process
+	/// 3. glibc-only headers (musl) — stub Standard_StackTrace.cxx, comment out <execinfo.h>
+	/// 4. OCC_CONVERT_SIGNALS — comment out to avoid mingw _setjmp ABI issues
+	fn patch_occt_sources(source_dir: &Path) {
+		let is_windows = env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows");
 
-	(include_dir, lib_dir)
-}
-
-/// Returns `[include_dir, lib_dir]`. Each entry is the first existing
-/// candidate, or the first candidate as fallback. Handles Linux
-/// (`include`,`lib`), MinGW-gcc (`inc`,`win64/gcc/lib`), llvm-mingw
-/// (`win64/clang/lib`), and MSVC (`win64/vc14/lib`) install layouts.
-fn find_occt_dirs(occt_root: &Path) -> [PathBuf; 2] {
-	let pick = |cands: &[PathBuf]| cands.iter().find(|p| p.exists()).cloned().unwrap_or_else(|| cands[0].clone());
-	[
-		pick(&[occt_root.join("include").join("opencascade"), occt_root.join("inc"), occt_root.join("include")]),
-		pick(&[occt_root.join("lib"), occt_root.join("win64").join("gcc").join("lib"), occt_root.join("win64").join("clang").join("lib"), occt_root.join("win64").join("vc14").join("lib")]),
-	]
-}
-
-/// Patch OCCT source files to work around unwanted link dependencies and
-/// platform-specific toolchain quirks:
-///
-/// 1. TKService (Visualization) — even with BUILD_MODULE_Visualization=OFF:
-///    - XCAFDoc_VisMaterial.cxx: stub bodies that use Graphic3d_* types.
-///    - XCAFPrs_Texture.cxx: empty entirely (inherits Graphic3d_Texture2D).
-///
-/// 2. advapi32 / user32 (Windows system libs) — TKernel's OSD package:
-///    - OSD_WNT.cxx: empty entirely (static initialiser calls AllocateAndInitializeSid).
-///    - OSD_File.cxx: stub bodies (OpenProcessToken, SetSecurityDescriptorDacl, etc.).
-///    - OSD_Protection.cxx: stub bodies (EqualSid, LookupAccountNameW, etc.).
-///    - OSD_signal.cxx: stub bodies (MessageBoxA / MessageBeep on MSVC).
-///    - OSD_FileNode.cxx: stub bodies (SetFileSecurityW + OSD_WNT helpers).
-///    - OSD_Process.cxx: stub bodies (OpenProcessToken, GetUserNameW, EqualSid).
-///
-/// 3. glibc-only headers (musl target):
-///    - Standard_StackTrace.cxx: stub bodies (backtrace, backtrace_symbols)
-///      and comment out `<execinfo.h>` which musl does not ship.
-///
-/// Note on the llvm-rc non-ASCII issue (cargo-xwin MSVC target): this is
-/// NOT patched here. It is handled at the CMake layer by passing
-/// `CMAKE_RC_FLAGS=-C 1252` so llvm-rc interprets narrow RC string literals
-/// as cp1252, accepting the whole range of Latin-1 characters instead of
-/// rejecting any byte above 0x7F.
-fn patch_occt_sources(source_dir: &Path) {
-	// OSD stubs are Windows-only. On Linux the same files compile to real
-	// POSIX implementations via `#ifdef _WIN32`; stubbing them on Linux turns
-	// non-void bodies into UB (`{}` with no return) and crashes at runtime
-	// the moment OCCT enters `OSD_Process::SystemDate`, `OSD::SignalMode`, etc.
-	let is_windows = env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows");
-
-	for entry in [source_dir.join("src"), source_dir.join("adm")]
-		.into_iter()
-		.flat_map(walkdir::WalkDir::new)
-		.flatten()
-	{
-		if !entry.file_type().is_file() {
-			continue;
-		}
-		let path = entry.path();
-		let Some(name) = path.file_name().and_then(|s| s.to_str()) else { continue };
-		match name {
-			// TKService (Visualization) cut: stub bodies only, keep signatures.
-			"XCAFDoc_VisMaterial.cxx" => stub_out_methods(path, true),
-			// Initializer list references the base class — body stubs alone
-			// cannot cut the dependency, so empty the whole file.
-			"XCAFPrs_Texture.cxx" => stub_out_methods(path, false),
-
-			// musl: <execinfo.h> is a glibc extension. Stub backtrace() bodies
-			// then comment out the include so the preprocessor stops looking.
-			"Standard_StackTrace.cxx" => {
-				stub_out_methods(path, true);
-				comment_out_include(path, "execinfo.h");
+		for entry in [source_dir.join("src"), source_dir.join("adm")]
+			.into_iter()
+			.flat_map(walkdir::WalkDir::new)
+			.flatten()
+		{
+			if !entry.file_type().is_file() {
+				continue;
 			}
+			let path = entry.path();
+			let Some(name) = path.file_name().and_then(|s| s.to_str()) else { continue };
+			match name {
+				"XCAFDoc_VisMaterial.cxx" => stub_out_methods(path, true),
+				"XCAFPrs_Texture.cxx" => stub_out_methods(path, false),
 
-			// Windows OSD: cut advapi32 / user32 symbol references.
-			// OSD_WNT.cxx has a static init calling AllocateAndInitializeSid —
-			// must be emptied wholesale, not body-stubbed.
-			"OSD_WNT.cxx" if is_windows => stub_out_methods(path, false),
-			"OSD_File.cxx"
-			| "OSD_Protection.cxx"
-			| "OSD_signal.cxx"
-			| "OSD_FileNode.cxx"
-			| "OSD_Process.cxx"
-				if is_windows =>
-			{
-				stub_out_methods(path, true);
-			}
+				"Standard_StackTrace.cxx" => {
+					stub_out_methods(path, true);
+					comment_out_include(path, "execinfo.h");
+				}
 
-			// Note on `OCC_CONVERT_SIGNALS`: OCCT's `adm/cmake/occt_defs_flags.cmake`
-			// auto-defines this on every non-MSVC build, which enables OCCT's
-			// `OCC_CATCH_SIGNALS` macro to emit `setjmp()` calls that convert C
-			// signals into C++ exceptions. For mingw-w64 that path emits calls to
-			// the 2-arg SEH `_setjmp`, whose libmingwex export name varies across
-			// mingw-w64 versions — the resulting prebuilt .a fails to link on
-			// downstream users who have a different mingw-w64 than we built with.
-			"occt_defs_flags.cmake" if is_windows => {
-				let needle = "add_definitions(-DOCC_CONVERT_SIGNALS)";
-				let replacement = "# add_definitions(-DOCC_CONVERT_SIGNALS)  # patched out by cadrum build.rs";
-				if let Ok(content) = std::fs::read_to_string(path) {
-					if content.contains(needle) && !content.contains(replacement) {
-						let patched = content.replace(needle, replacement);
-						if let Err(e) = std::fs::write(path, patched) {
-							eprintln!("warning: failed to patch {}: {}", path.display(), e);
-						} else {
-							eprintln!("patched out OCC_CONVERT_SIGNALS in {}", path.display());
+				"OSD_WNT.cxx" if is_windows => stub_out_methods(path, false),
+				"OSD_File.cxx" | "OSD_Protection.cxx" | "OSD_signal.cxx" | "OSD_FileNode.cxx" | "OSD_Process.cxx"
+					if is_windows =>
+				{
+					stub_out_methods(path, true);
+				}
+
+				"occt_defs_flags.cmake" if is_windows => {
+					let needle = "add_definitions(-DOCC_CONVERT_SIGNALS)";
+					let replacement = "# add_definitions(-DOCC_CONVERT_SIGNALS)  # patched out by cadrum build.rs";
+					if let Ok(content) = std::fs::read_to_string(path) {
+						if content.contains(needle) && !content.contains(replacement) {
+							let patched = content.replace(needle, replacement);
+							if let Err(e) = std::fs::write(path, patched) {
+								eprintln!("warning: failed to patch {}: {}", path.display(), e);
+							} else {
+								eprintln!("patched out OCC_CONVERT_SIGNALS in {}", path.display());
+							}
 						}
 					}
 				}
-			}
 
-			_ => {}
+				_ => {}
+			}
 		}
 	}
-}
 
-/// Comment out a `#include <name>` directive in `path`. Used to sever the
-/// dependency on platform-specific headers (e.g. `execinfo.h` on musl) after
-/// the referring method bodies have been stubbed out.
-fn comment_out_include(path: &Path, header: &str) {
-	if !path.exists() {
-		return;
-	}
-	let content = std::fs::read_to_string(path).expect("Failed to read file for include patching");
-	let needle = format!("#include <{}>", header);
-	if !content.contains(&needle) {
-		return;
-	}
-	let replacement = format!("// {} (patched out by cadrum build.rs)", needle);
-	let patched = content.replace(&needle, &replacement);
-	std::fs::write(path, patched).expect("Failed to write patched include file");
-	eprintln!("Patched out <{}> in {}", header, path.file_name().unwrap().to_string_lossy());
-}
-
-/// Neutralize a C++ source file at `path`.
-///
-/// # Arguments
-/// - `keep_signatures` — `true`: keep `#include`s and signatures, replace only the
-///   top-level method bodies with empty stubs. Use when the signature types are still
-///   needed by the compiler.
-///   `false`: empty the entire file (header comment only). Use when the initializer
-///   list references a base class and body stubs alone cannot cut the dependency.
-///
-/// Stub body rules:
-/// - `void` return / constructor / destructor → `{}`
-/// - anything else → `{ return {}; }` (value-initialize)
-///
-/// # Note
-/// `keep_signatures: true` cannot be used on files that have top-level
-/// `namespace {}` or `extern "C" {}` blocks. Intended for `.cxx` implementation files only.
-fn stub_out_methods(path: &Path, keep_signatures: bool) {
-	if !path.exists() {
-		return;
-	}
-
-	// Header line records the stub op + unix timestamp so old/new stubs are
-	// distinguishable when inspecting a cached source tree.
-	let unix = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).map(|d| d.as_secs().to_string()).unwrap_or_else(|_| "unknown".to_string());
-	let description = if keep_signatures { "method bodies stubbed" } else { "file emptied" };
-	let header = format!("// Stubbed by cadrum build.rs at unix={unix}: {description}.\n");
-
-	let patched = if keep_signatures {
-		let content = std::fs::read_to_string(path).expect("Failed to read file for stubbing");
-		// Replace all top-level brace blocks with empty stubs.
-		header + &stub_all_top_level_bodies(&content)
-	} else {
-		// Empty the file (header comment only).
-		header
-	};
-
-	std::fs::write(path, patched).expect("Failed to write stubbed file");
-	eprintln!("Stubbed {}", path.file_name().unwrap().to_string_lossy());
-}
-
-/// Lexically normalise `content` so the brace-depth scanner sees a clean
-/// view: comments, string/char literals, and preprocessor directives are
-/// replaced with same-length whitespace. Newlines are preserved so line
-/// numbers (and downstream offsets) stay aligned with the original file.
-///
-/// The returned string has the same byte length as the input, which means
-/// byte offsets computed on the normalised view can be used to slice the
-/// original content verbatim.
-fn lex_normalize(content: &str) -> String {
-	let bytes = content.as_bytes();
-	let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
-	let mut i = 0;
-	let mut at_line_start = true;
-
-	let push_blank = |out: &mut Vec<u8>, b: u8| {
-		out.push(if b == b'\n' { b'\n' } else { b' ' });
-	};
-
-	while i < bytes.len() {
-		let c = bytes[i];
-
-		// Line comment `// ... \n`
-		if c == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'/' {
-			while i < bytes.len() && bytes[i] != b'\n' {
-				out.push(b' ');
-				i += 1;
-			}
-			continue;
+	fn comment_out_include(path: &Path, header: &str) {
+		if !path.exists() {
+			return;
 		}
-		// Block comment `/* ... */`
-		if c == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'*' {
-			out.push(b' ');
-			out.push(b' ');
-			i += 2;
-			while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
-				push_blank(&mut out, bytes[i]);
-				i += 1;
+		let content = std::fs::read_to_string(path).expect("Failed to read file for include patching");
+		let needle = format!("#include <{}>", header);
+		if !content.contains(&needle) {
+			return;
+		}
+		let replacement = format!("// {} (patched out by cadrum build.rs)", needle);
+		let patched = content.replace(&needle, &replacement);
+		std::fs::write(path, patched).expect("Failed to write patched include file");
+		eprintln!("Patched out <{}> in {}", header, path.file_name().unwrap().to_string_lossy());
+	}
+
+	fn stub_out_methods(path: &Path, keep_signatures: bool) {
+		if !path.exists() {
+			return;
+		}
+
+		let unix = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).map(|d| d.as_secs().to_string()).unwrap_or_else(|_| "unknown".to_string());
+		let description = if keep_signatures { "method bodies stubbed" } else { "file emptied" };
+		let header = format!("// Stubbed by cadrum build.rs at unix={unix}: {description}.\n");
+
+		let patched = if keep_signatures {
+			let content = std::fs::read_to_string(path).expect("Failed to read file for stubbing");
+			header + &stub_all_top_level_bodies(&content)
+		} else {
+			header
+		};
+
+		std::fs::write(path, patched).expect("Failed to write stubbed file");
+		eprintln!("Stubbed {}", path.file_name().unwrap().to_string_lossy());
+	}
+
+	fn lex_normalize(content: &str) -> String {
+		let bytes = content.as_bytes();
+		let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+		let mut i = 0;
+		let mut at_line_start = true;
+
+		let push_blank = |out: &mut Vec<u8>, b: u8| {
+			out.push(if b == b'\n' { b'\n' } else { b' ' });
+		};
+
+		while i < bytes.len() {
+			let c = bytes[i];
+
+			if c == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'/' {
+				while i < bytes.len() && bytes[i] != b'\n' {
+					out.push(b' ');
+					i += 1;
+				}
+				continue;
 			}
-			if i + 1 < bytes.len() {
+			if c == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'*' {
 				out.push(b' ');
 				out.push(b' ');
 				i += 2;
-			} else {
+				while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+					push_blank(&mut out, bytes[i]);
+					i += 1;
+				}
+				if i + 1 < bytes.len() {
+					out.push(b' ');
+					out.push(b' ');
+					i += 2;
+				} else {
+					while i < bytes.len() {
+						push_blank(&mut out, bytes[i]);
+						i += 1;
+					}
+				}
+				continue;
+			}
+			if c == b'"' {
+				out.push(b' ');
+				i += 1;
+				while i < bytes.len() && bytes[i] != b'"' {
+					if bytes[i] == b'\\' && i + 1 < bytes.len() {
+						out.push(b' ');
+						push_blank(&mut out, bytes[i + 1]);
+						i += 2;
+					} else {
+						push_blank(&mut out, bytes[i]);
+						i += 1;
+					}
+				}
+				if i < bytes.len() {
+					out.push(b' ');
+					i += 1;
+				}
+				continue;
+			}
+			if c == b'\'' {
+				out.push(b' ');
+				i += 1;
+				while i < bytes.len() && bytes[i] != b'\'' {
+					if bytes[i] == b'\\' && i + 1 < bytes.len() {
+						out.push(b' ');
+						out.push(b' ');
+						i += 2;
+					} else {
+						out.push(b' ');
+						i += 1;
+					}
+				}
+				if i < bytes.len() {
+					out.push(b' ');
+					i += 1;
+				}
+				continue;
+			}
+			if at_line_start && c == b'#' {
 				while i < bytes.len() {
-					push_blank(&mut out, bytes[i]);
-					i += 1;
-				}
-			}
-			continue;
-		}
-		// String literal `"..."`
-		if c == b'"' {
-			out.push(b' ');
-			i += 1;
-			while i < bytes.len() && bytes[i] != b'"' {
-				if bytes[i] == b'\\' && i + 1 < bytes.len() {
-					out.push(b' ');
-					push_blank(&mut out, bytes[i + 1]);
-					i += 2;
-				} else {
-					push_blank(&mut out, bytes[i]);
-					i += 1;
-				}
-			}
-			if i < bytes.len() {
-				out.push(b' ');
-				i += 1;
-			}
-			continue;
-		}
-		// Char literal `'...'`
-		if c == b'\'' {
-			out.push(b' ');
-			i += 1;
-			while i < bytes.len() && bytes[i] != b'\'' {
-				if bytes[i] == b'\\' && i + 1 < bytes.len() {
-					out.push(b' ');
-					out.push(b' ');
-					i += 2;
-				} else {
-					out.push(b' ');
-					i += 1;
-				}
-			}
-			if i < bytes.len() {
-				out.push(b' ');
-				i += 1;
-			}
-			continue;
-		}
-		// Preprocessor directive `# ... \n` (honoring `\`-line-continuation)
-		if at_line_start && c == b'#' {
-			while i < bytes.len() {
-				if bytes[i] == b'\n' {
-					// Check for `\`-continuation: preceding non-space char.
-					let mut k = i;
-					while k > 0 && (bytes[k - 1] == b' ' || bytes[k - 1] == b'\t') {
-						k -= 1;
+					if bytes[i] == b'\n' {
+						let mut k = i;
+						while k > 0 && (bytes[k - 1] == b' ' || bytes[k - 1] == b'\t') {
+							k -= 1;
+						}
+						let continued = k > 0 && bytes[k - 1] == b'\\';
+						out.push(b'\n');
+						i += 1;
+						if !continued {
+							break;
+						}
+					} else {
+						out.push(b' ');
+						i += 1;
 					}
-					let continued = k > 0 && bytes[k - 1] == b'\\';
-					out.push(b'\n');
-					i += 1;
-					if !continued {
-						break;
+				}
+				at_line_start = true;
+				continue;
+			}
+
+			if c == b'\n' {
+				at_line_start = true;
+			} else if !c.is_ascii_whitespace() {
+				at_line_start = false;
+			}
+			out.push(c);
+			i += 1;
+		}
+
+		debug_assert_eq!(out.len(), bytes.len(), "lex_normalize must preserve byte length");
+		String::from_utf8(out).expect("lex_normalize produced invalid utf-8")
+	}
+
+	fn stub_body_for_sig(sig: &str) -> &'static str {
+		let sig_norm: String = {
+			let mut s = sig.to_string();
+			loop {
+				let next = s.replace(" ::", "::").replace(":: ", "::");
+				if next == s {
+					break s;
+				}
+				s = next;
+			}
+		};
+
+		let paren_pos = {
+			let bytes = sig_norm.as_bytes();
+			let mut cursor = 0;
+			loop {
+				let Some(off) = sig_norm[cursor..].find('(') else { return "{}"; };
+				let pos = cursor + off;
+				let before = sig_norm[..pos].trim_end();
+				let id_start = before.rfind(|c: char| !(c.is_ascii_alphanumeric() || c == '_')).map(|p| p + 1).unwrap_or(0);
+				let ident = &before[id_start..];
+				let is_macro = !ident.is_empty()
+					&& ident.chars().all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+					&& ident.chars().any(|c| c.is_ascii_uppercase());
+				if !is_macro {
+					break pos;
+				}
+				let mut depth = 1;
+				let mut j = pos + 1;
+				while j < bytes.len() && depth > 0 {
+					match bytes[j] {
+						b'(' => depth += 1,
+						b')' => depth -= 1,
+						_ => {}
 					}
-				} else {
-					out.push(b' ');
-					i += 1;
+					j += 1;
+				}
+				cursor = j;
+			}
+		};
+		let head_full = sig_norm[..paren_pos].trim();
+		let head = head_full.rsplit('\n').next().unwrap_or(head_full).trim();
+		if head.is_empty() {
+			return "{}";
+		}
+
+		let hb = head.as_bytes();
+		let mut start = hb.len();
+		while start > 0 {
+			let c = hb[start - 1];
+			if c.is_ascii_alphanumeric() || c == b'_' || c == b':' || c == b'~' {
+				start -= 1;
+			} else {
+				break;
+			}
+		}
+		let name = &head[start..];
+		let return_part = head[..start].trim();
+
+		if name.contains('~') {
+			return "{}";
+		}
+		let segs: Vec<&str> = name.split("::").collect();
+		if segs.len() >= 2 && segs[segs.len() - 1] == segs[segs.len() - 2] {
+			return "{}";
+		}
+		if return_part.is_empty() {
+			return "{}";
+		}
+
+		let rb = return_part.as_bytes();
+		let is_ident = |c: u8| c.is_ascii_alphanumeric() || c == b'_';
+		let mut idx = 0;
+		while let Some(off) = return_part[idx..].find("void") {
+			let pos = idx + off;
+			let end = pos + 4;
+			let before_ok = pos == 0 || !is_ident(rb[pos - 1]);
+			let after_ok = end >= rb.len() || !is_ident(rb[end]);
+			if before_ok && after_ok {
+				let mut j = end;
+				while j < rb.len() && rb[j].is_ascii_whitespace() {
+					j += 1;
+				}
+				if j >= rb.len() || (rb[j] != b'*' && rb[j] != b'&') {
+					return "{}";
 				}
 			}
-			at_line_start = true;
-			continue;
+			idx = end;
 		}
 
-		if c == b'\n' {
-			at_line_start = true;
-		} else if !c.is_ascii_whitespace() {
-			at_line_start = false;
-		}
-		out.push(c);
-		i += 1;
+		"{ return {}; }"
 	}
 
-	debug_assert_eq!(out.len(), bytes.len(), "lex_normalize must preserve byte length");
-	String::from_utf8(out).expect("lex_normalize produced invalid utf-8")
-}
+	fn stub_all_top_level_bodies(content: &str) -> String {
+		let normalized = lex_normalize(content);
+		let nb = normalized.as_bytes();
+		let mut result = String::new();
+		let mut depth = 0usize;
+		let mut i = 0;
+		let mut last_end = 0;
 
-/// Choose the stub body for a function/method signature `sig`, which is the
-/// text from the previous statement terminator up to (but not including) the
-/// opening `{`. `sig` is expected to already be lexically normalised via
-/// `lex_normalize`, so comments, string literals, and preprocessor lines
-/// are whitespace.
-///
-/// Returns `"{}"` for void returns, constructors, and destructors; returns
-/// `"{ return {}; }"` otherwise so MSVC does not emit C4716.
-fn stub_body_for_sig(sig: &str) -> &'static str {
-	// Normalise `A :: B` → `A::B` so walk-back treats qualified ids as one
-	// token. This is a semantic concern that survives lex_normalize.
-	let sig_norm: String = {
-		let mut s = sig.to_string();
-		loop {
-			let next = s.replace(" ::", "::").replace(":: ", "::");
-			if next == s {
-				break s;
-			}
-			s = next;
-		}
-	};
+		while i < nb.len() {
+			match nb[i] {
+				b'{' if depth == 0 => {
+					let brace_pos = i;
+					let prefix_norm = &normalized[last_end..brace_pos];
+					let sig = prefix_norm.rfind(|c| c == ';' || c == '}').map(|p| &prefix_norm[p + 1..]).unwrap_or(prefix_norm);
 
-	// Find the `(` that belongs to the target function's parameter list,
-	// skipping macro invocations like `IMPLEMENT_STANDARD_RTTIEXT(...)`.
-	// Heuristic: if the identifier immediately before a `(` is entirely
-	// uppercase (macro convention), walk past its matching `)` and keep
-	// searching.
-	let paren_pos = {
-		let bytes = sig_norm.as_bytes();
-		let mut cursor = 0;
-		loop {
-			let Some(off) = sig_norm[cursor..].find('(') else { return "{}"; };
-			let pos = cursor + off;
-			let before = sig_norm[..pos].trim_end();
-			let id_start = before
-				.rfind(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
-				.map(|p| p + 1)
-				.unwrap_or(0);
-			let ident = &before[id_start..];
-			let is_macro = !ident.is_empty()
-				&& ident.chars().all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
-				&& ident.chars().any(|c| c.is_ascii_uppercase());
-			if !is_macro {
-				break pos;
-			}
-			let mut depth = 1;
-			let mut j = pos + 1;
-			while j < bytes.len() && depth > 0 {
-				match bytes[j] {
-					b'(' => depth += 1,
-					b')' => depth -= 1,
-					_ => {}
-				}
-				j += 1;
-			}
-			cursor = j;
-		}
-	};
-	let head_full = sig_norm[..paren_pos].trim();
-	let head = head_full.rsplit('\n').next().unwrap_or(head_full).trim();
-	if head.is_empty() {
-		return "{}";
-	}
-
-	// Walk back from the end collecting the trailing qualified-id (function
-	// name, possibly `Class::method` or `~Class`).
-	let hb = head.as_bytes();
-	let mut start = hb.len();
-	while start > 0 {
-		let c = hb[start - 1];
-		if c.is_ascii_alphanumeric() || c == b'_' || c == b':' || c == b'~' {
-			start -= 1;
-		} else {
-			break;
-		}
-	}
-	let name = &head[start..];
-	let return_part = head[..start].trim();
-
-	// Destructor: `~Foo` or `Foo::~Foo`.
-	if name.contains('~') {
-		return "{}";
-	}
-	// Constructor: last two `::`-segments are identical (`Foo::Foo`), or the
-	// name has no return-type prefix at all.
-	let segs: Vec<&str> = name.split("::").collect();
-	if segs.len() >= 2 && segs[segs.len() - 1] == segs[segs.len() - 2] {
-		return "{}";
-	}
-	if return_part.is_empty() {
-		return "{}";
-	}
-
-	// Look for `void` as a whole word in the return-type portion, and make
-	// sure it is not `void*` / `void&`.
-	let rb = return_part.as_bytes();
-	let is_ident = |c: u8| c.is_ascii_alphanumeric() || c == b'_';
-	let mut idx = 0;
-	while let Some(off) = return_part[idx..].find("void") {
-		let pos = idx + off;
-		let end = pos + 4;
-		let before_ok = pos == 0 || !is_ident(rb[pos - 1]);
-		let after_ok = end >= rb.len() || !is_ident(rb[end]);
-		if before_ok && after_ok {
-			let mut j = end;
-			while j < rb.len() && rb[j].is_ascii_whitespace() {
-				j += 1;
-			}
-			if j >= rb.len() || (rb[j] != b'*' && rb[j] != b'&') {
-				return "{}";
-			}
-		}
-		idx = end;
-	}
-
-	"{ return {}; }"
-}
-
-/// Replace every top-level (brace depth 0) function body in `content` with
-/// `{}` or `{ return {}; }` and return the result.
-///
-/// Walks a lexically normalised view of `content` so that comments, string
-/// literals, and preprocessor directives cannot confuse the brace/sig
-/// scanner. Because `lex_normalize` preserves byte offsets, slices computed
-/// on the normalised view map one-to-one onto the original content, which
-/// is what we write out verbatim outside the stubbed bodies.
-///
-/// Non-function brace blocks (class/struct/namespace definitions, aggregate
-/// initialisers) are detected by checking whether the end of the preceding
-/// signature — after stripping trailing function qualifiers — is `)`.
-fn stub_all_top_level_bodies(content: &str) -> String {
-	let normalized = lex_normalize(content);
-	let nb = normalized.as_bytes();
-	let mut result = String::new();
-	let mut depth = 0usize;
-	let mut i = 0;
-	let mut last_end = 0;
-
-	while i < nb.len() {
-		match nb[i] {
-			b'{' if depth == 0 => {
-				let brace_pos = i;
-				let prefix_norm = &normalized[last_end..brace_pos];
-				let sig = prefix_norm
-					.rfind(|c| c == ';' || c == '}')
-					.map(|p| &prefix_norm[p + 1..])
-					.unwrap_or(prefix_norm);
-
-				let trimmed = sig.trim_end();
-				let last_line = trimmed.rsplit('\n').next().unwrap_or(trimmed).trim();
-				let is_function = {
-					let mut t = last_line;
-					loop {
-						let prev_len = t.len();
-						for kw in ["const", "override", "final", "noexcept", "mutable", "volatile", "= 0", "=0"] {
-							if t.ends_with(kw) {
-								t = t[..t.len() - kw.len()].trim_end();
+					let trimmed = sig.trim_end();
+					let last_line = trimmed.rsplit('\n').next().unwrap_or(trimmed).trim();
+					let is_function = {
+						let mut t = last_line;
+						loop {
+							let prev_len = t.len();
+							for kw in ["const", "override", "final", "noexcept", "mutable", "volatile", "= 0", "=0"] {
+								if t.ends_with(kw) {
+									t = t[..t.len() - kw.len()].trim_end();
+									break;
+								}
+							}
+							if t.len() == prev_len {
 								break;
 							}
 						}
-						if t.len() == prev_len {
-							break;
-						}
-					}
-					t.ends_with(')')
-				};
-				let is_var_init = trimmed.ends_with('=') || !is_function;
+						t.ends_with(')')
+					};
+					let is_var_init = trimmed.ends_with('=') || !is_function;
 
-				// Walk to the matching closing brace on the normalised view.
-				depth = 1;
-				i += 1;
-				while i < nb.len() && depth > 0 {
-					match nb[i] {
-						b'{' => depth += 1,
-						b'}' => depth -= 1,
-						_ => {}
-					}
+					depth = 1;
 					i += 1;
-				}
+					while i < nb.len() && depth > 0 {
+						match nb[i] {
+							b'{' => depth += 1,
+							b'}' => depth -= 1,
+							_ => {}
+						}
+						i += 1;
+					}
 
-				if is_var_init {
-					// Leave the block untouched — continue without writing.
+					if is_var_init {
+						continue;
+					}
+
+					let stub_body = stub_body_for_sig(sig);
+					result.push_str(&content[last_end..brace_pos]);
+					result.push_str(stub_body);
+					last_end = i;
 					continue;
 				}
-
-				// Function body: write original prefix verbatim, then the
-				// stub. `last_end` advances past the original closing brace.
-				let stub_body = stub_body_for_sig(sig);
-				result.push_str(&content[last_end..brace_pos]);
-				result.push_str(stub_body);
-				last_end = i;
-				continue;
-			}
-			b'{' => depth += 1,
-			b'}' => {
-				if depth > 0 {
-					depth -= 1;
+				b'{' => depth += 1,
+				b'}' => {
+					if depth > 0 {
+						depth -= 1;
+					}
 				}
+				_ => {}
 			}
-			_ => {}
+			i += 1;
 		}
-		i += 1;
+		result.push_str(&content[last_end..]);
+		result
 	}
-	result.push_str(&content[last_end..]);
-	result
 }
-

--- a/build.rs
+++ b/build.rs
@@ -222,13 +222,12 @@ mod source {
 		let occt_version = OCCT_VERSION;
 		let occt_url = format!("https://github.com/Open-Cascade-SAS/OCCT/archive/refs/tags/{}.tar.gz", occt_version);
 
-		let download_dir = effective_root.join("occt-source");
-		let extraction_sentinel = download_dir.join(".extraction_done");
+		let extraction_sentinel = effective_root.join(".occt_extraction_done");
 
 		if !extraction_sentinel.exists() {
-			std::fs::create_dir_all(&download_dir).unwrap();
+			std::fs::create_dir_all(effective_root).unwrap();
 
-			if let Ok(entries) = std::fs::read_dir(&download_dir) {
+			if let Ok(entries) = std::fs::read_dir(effective_root) {
 				for entry in entries.flatten() {
 					let name = entry.file_name();
 					if name.to_string_lossy().starts_with("OCCT") && entry.path().is_dir() {
@@ -239,14 +238,14 @@ mod source {
 			}
 
 			eprintln!("Downloading OCCT {} from {} ...", occt_version, occt_url);
-			download_and_extract_tar_gz(&occt_url, &download_dir).expect("Failed to download/extract OCCT source tarball");
+			download_and_extract_tar_gz(&occt_url, effective_root).expect("Failed to download/extract OCCT source tarball");
 
 			std::fs::write(&extraction_sentinel, "done").unwrap();
 			eprintln!("OCCT source extracted successfully.");
 		}
 
-		let source_dir = std::fs::read_dir(&download_dir)
-			.expect("Failed to read occt-source directory")
+		let source_dir = std::fs::read_dir(effective_root)
+			.expect("Failed to read effective_root directory")
 			.flatten()
 			.find(|e| e.file_name().to_string_lossy().starts_with("OCCT") && e.path().is_dir())
 			.map(|e| e.path())
@@ -315,19 +314,21 @@ mod source {
 
 	/// Walk the OCCT source tree.
 	/// - `src/` and `adm/`: recurse and yield every **file**
-	/// - other top-level directories (`data/`, `dox/`, `tests/`, …): yield the **directory** itself
-	/// - top-level files (`CMakeLists.txt`, `LICENSE_LGPL_21.txt`, …): skipped
+	/// - other top-level directories: yield the **directory** itself
+	/// - top-level files: skipped
 	fn walk_occt_sources(source_dir: &Path, mut f: impl FnMut(&Path)) {
 		for entry in walkdir::WalkDir::new(source_dir).min_depth(1).max_depth(1).into_iter().flatten() {
-			let name = entry.file_name().to_string_lossy();
-			if name == "src" || name == "adm" {
-				for child in walkdir::WalkDir::new(entry.path()).into_iter().flatten() {
-					if child.file_type().is_file() {
-						f(child.path());
+			let e = entry.path();
+			match entry {
+				_ if !entry.file_type().is_dir() => {}
+				_ if "src|adm".contains(&*entry.file_name().to_string_lossy()) => {
+					for child in walkdir::WalkDir::new(e).into_iter().flatten() {
+						if child.file_type().is_file() {
+							f(child.path());
+						}
 					}
 				}
-			} else if entry.file_type().is_dir() {
-				f(entry.path());
+				_ => f(e),
 			}
 		}
 	}

--- a/build.rs
+++ b/build.rs
@@ -318,17 +318,16 @@ mod source {
 	/// - top-level files: skipped
 	fn walk_occt_sources(source_dir: &Path, mut f: impl FnMut(&Path)) {
 		for entry in walkdir::WalkDir::new(source_dir).min_depth(1).max_depth(1).into_iter().flatten() {
-			let e = entry.path();
 			match entry {
-				_ if !entry.file_type().is_dir() => {}
-				_ if "src|adm".contains(&*entry.file_name().to_string_lossy()) => {
-					for child in walkdir::WalkDir::new(e).into_iter().flatten() {
+				entry if "src|adm".contains(&*entry.file_name().to_string_lossy()) => {
+					for child in walkdir::WalkDir::new(entry.path()).into_iter().flatten() {
 						if child.file_type().is_file() {
 							f(child.path());
 						}
 					}
 				}
-				_ => f(e),
+				entry if entry.file_type().is_dir() => f(entry.path()),
+				_ => {},
 			}
 		}
 	}

--- a/build.rs
+++ b/build.rs
@@ -32,7 +32,16 @@ fn main() {
 
 	let target = env::var("TARGET").unwrap();
 
-	let [occt_include, occt_lib_dir] = resolve_occt(&out_dir, &target);
+	let target_dir = target_dir_from_out_dir(&out_dir, &target);
+	let default_root = target_dir.join(format!("cadrum-occt-{}-{}", slug(OCCT_VERSION), &target));
+	let effective_root = env::var("OCCT_ROOT")
+		.map(|r| {
+			let p = PathBuf::from(r);
+			if p.is_relative() { env::current_dir().unwrap().join(p) } else { p }
+		})
+		.unwrap_or(default_root);
+
+	let [occt_include, occt_lib_dir] = resolve_occt(&effective_root, &target);
 
 	link_occt_libraries(&occt_include, &occt_lib_dir);
 }
@@ -42,9 +51,6 @@ fn main() {
 /// `OUT_DIR` layout:
 ///   `<target_dir>/<profile>/build/<pkg>-<hash>/out`            (no `--target`)
 ///   `<target_dir>/<triple>/<profile>/build/<pkg>-<hash>/out`   (with `--target`)
-///
-/// Walking up 4 levels from `out` lands on either `<triple>` or `<target_dir>`.
-/// If it matches `TARGET`, one more parent gives the real target dir.
 fn target_dir_from_out_dir(out_dir: &Path, target: &str) -> PathBuf {
 	let above_profile = out_dir.ancestors().nth(4).expect("unexpected OUT_DIR layout");
 	if above_profile.file_name().map_or(false, |n| n == target) {
@@ -59,30 +65,22 @@ fn target_dir_from_out_dir(out_dir: &Path, target: &str) -> PathBuf {
 ///   1. Cache hit → use it
 ///   2. Cache miss + `source-build` → build from upstream sources
 ///   3. Cache miss otherwise → download prebuilt tarball
-fn resolve_occt(out_dir: &Path, target: &str) -> [PathBuf; 2] {
-	let target_dir = target_dir_from_out_dir(out_dir, target);
-	let default_root = target_dir.join(format!("cadrum-occt-{}-{}", slug(OCCT_VERSION), target));
-	let effective_root = env::var("OCCT_ROOT")
-		.map(|r| {
-			let p = PathBuf::from(r);
-			if p.is_relative() { env::current_dir().unwrap().join(p) } else { p }
-		})
-		.unwrap_or(default_root);
-
+fn resolve_occt(effective_root: &Path, target: &str) -> [PathBuf; 2] {
+	let _ = target; // used only in #[cfg(not(feature = "source-build"))]
 	println!("cargo:rerun-if-changed={}", effective_root.display());
 
-	match find_occt_dirs(&effective_root) {
+	match find_occt_dirs(effective_root) {
 		Some(dirs) => return dirs,
 		None => {
 			#[cfg(feature = "source-build")]
 			{
 				eprintln!("cargo:warning=OCCT cache miss at {} — building from source (this may take 10-30 minutes)", effective_root.display());
-				return source::build_from_source(out_dir, &effective_root)
+				return source::build_from_source(effective_root)
 					.expect("Failed to build OCCT from source");
 			}
 			#[cfg(not(feature = "source-build"))]
 			{
-				return download_prebuilt(out_dir, &effective_root, target)
+				return download_prebuilt(effective_root, target)
 					.unwrap_or_else(|| panic!(
 						"\nFailed to download prebuilt OCCT for target `{}`.\n\
 						 See README for the list of supported prebuilt targets, or enable\n\
@@ -97,8 +95,6 @@ fn resolve_occt(out_dir: &Path, target: &str) -> [PathBuf; 2] {
 
 /// Probe `occt_root` for include and lib directories.
 /// Returns `Some([include_dir, lib_dir])` if both exist, `None` otherwise.
-/// Handles Linux (`include`,`lib`), MinGW-gcc (`inc`,`win64/gcc/lib`),
-/// llvm-mingw (`win64/clang/lib`), and MSVC (`win64/vc14/lib`) layouts.
 fn find_occt_dirs(occt_root: &Path) -> Option<[PathBuf; 2]> {
 	let pick = |cands: &[PathBuf]| cands.iter().find(|p| p.exists()).cloned();
 	let inc = pick(&[occt_root.join("include").join("opencascade"), occt_root.join("inc"), occt_root.join("include")])?;
@@ -106,18 +102,7 @@ fn find_occt_dirs(occt_root: &Path) -> Option<[PathBuf; 2]> {
 	Some([inc, lib])
 }
 
-/// OCCT toolkits to link against (OCCT 7.8+ / 8.x naming). In 7.8+,
-/// TKSTEP*/TKBinTools/TKShapeUpgrade were reorganized into TKDESTEP/TKBin/
-/// TKShHealing. TKService is intentionally excluded — it pulls
-/// Image_AlienPixMap → ole32/windowscodecs on Windows and image I/O is unused.
-///
-/// The `color`-gated XDE (STEP-with-color) ApplicationFramework toolkits
-/// reference Graphic3d_* symbols that normally live in TKService; those
-/// references are stubbed out by `patch_occt_sources`. Layout verified by nm:
-///   TKLCAF — TDocStd_Document/Application
-///   TKXCAF — XCAFApp_Application, XCAFDoc_ColorTool/ShapeTool/DocumentTool
-///   TKCAF  — TNaming_NamedShape/Builder (needed by TKXCAF's XCAFDoc)
-///   TKCDF  — CDM_Document/Application (needed by TKLCAF's TDocStd_Document)
+/// OCCT toolkits to link against (OCCT 7.8+ / 8.x naming).
 const OCC_LIBS: &[&str] = &[
 	"TKernel", "TKMath", "TKBRep", "TKTopAlgo", "TKPrim", "TKBO", "TKBool",
 	"TKShHealing", "TKMesh", "TKGeomBase", "TKGeomAlgo", "TKG3d", "TKG2d",
@@ -140,23 +125,13 @@ fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path) {
 		println!("cargo:rustc-link-arg=-Wl,--allow-multiple-definition");
 	}
 
-	// windows-gnu: absorb libgcc / libstdc++ / libwinpthread statically so
-	// the final exe's only runtime dep is msvcrt.dll (OS-bundled on every
-	// Windows since NT4.0). Safe because wrapper.cpp exposes only a C ABI
-	// via cxx — no libstdc++ types cross the boundary, so downstream's
-	// libstdc++ version cannot conflict with the one frozen inside our
-	// objects.
 	if env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") && is_mingw_like {
 		println!("cargo:rustc-link-arg=-static");
 	}
 
-	// Build cxx bridge + C++ wrapper
 	let mut build = cxx_build::bridge("src/occt/ffi.rs");
 	build.file("cpp/wrapper.cpp").include(occt_include).std("c++17").define("_USE_MATH_DEFINES", None);
 
-	// wrapper.cpp は UTF-8 (日本語コメント含む)。MSVC は既定でシステム既定コードページ
-	// (日本語環境なら CP932) で読むため、マルチバイトの末尾バイトが `\` などと解釈されて
-	// 行が結合され、パースがずれる。`/utf-8` でソース/実行文字集合を UTF-8 に固定。
 	if std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc") {
 		build.flag("/utf-8");
 	}
@@ -173,7 +148,7 @@ fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path) {
 
 /// Download a prebuilt OCCT tarball for `target` into `dest`.
 #[cfg(not(feature = "source-build"))]
-fn download_prebuilt(out_dir: &Path, dest: &Path, target: &str) -> Option<[PathBuf; 2]> {
+fn download_prebuilt(dest: &Path, target: &str) -> Option<[PathBuf; 2]> {
 	let slug_ver = slug(OCCT_VERSION);
 	let top_name = format!("cadrum-occt-{}-{}", slug_ver, target);
 	let tarball_name = format!("{}.tar.gz", top_name);
@@ -181,28 +156,26 @@ fn download_prebuilt(out_dir: &Path, dest: &Path, target: &str) -> Option<[PathB
 
 	eprintln!("cargo:warning=Downloading prebuilt OCCT from {}", url);
 
-	let staging = out_dir.join("occt-prebuilt-staging");
-	let _ = std::fs::remove_dir_all(&staging);
-	std::fs::create_dir_all(&staging).ok()?;
+	let parent = dest.parent()?;
+	std::fs::create_dir_all(parent).ok()?;
 
-	if let Err(e) = download_and_extract_tar_gz(&url, &staging) {
+	if let Err(e) = download_and_extract_tar_gz(&url, parent) {
 		eprintln!("cargo:warning=prebuilt fetch failed: {}", e);
 		return None;
 	}
 
-	let extracted = staging.join(&top_name);
+	let extracted = parent.join(&top_name);
 	if !extracted.is_dir() {
 		eprintln!("cargo:warning=prebuilt tarball missing expected top-level dir `{}`", top_name);
 		return None;
 	}
 
-	if let Some(parent) = dest.parent() {
-		std::fs::create_dir_all(parent).ok()?;
-	}
-	let _ = std::fs::remove_dir_all(dest);
-	if let Err(e) = std::fs::rename(&extracted, dest) {
-		eprintln!("cargo:warning=failed to move extracted OCCT into {}: {}", dest.display(), e);
-		return None;
+	if extracted != *dest {
+		let _ = std::fs::remove_dir_all(dest);
+		if let Err(e) = std::fs::rename(&extracted, dest) {
+			eprintln!("cargo:warning=failed to move extracted OCCT into {}: {}", dest.display(), e);
+			return None;
+		}
 	}
 
 	find_occt_dirs(dest)
@@ -239,17 +212,17 @@ mod source {
 	use std::env;
 	use std::path::{Path, PathBuf};
 
-	/// Download OCCT source, patch, and build with CMake into `install_prefix`.
-	pub fn build_from_source(out_dir: &Path, install_prefix: &Path) -> Option<[PathBuf; 2]> {
-		// Already built?
-		if find_occt_dirs(install_prefix).is_some() {
-			return find_occt_dirs(install_prefix);
+	/// Download OCCT source, patch, build with CMake, then remove non-patched
+	/// source files (LGPL 2.1 §2: keep only the modified files).
+	pub fn build_from_source(effective_root: &Path) -> Option<[PathBuf; 2]> {
+		if let Some(dirs) = find_occt_dirs(effective_root) {
+			return Some(dirs);
 		}
 
 		let occt_version = OCCT_VERSION;
 		let occt_url = format!("https://github.com/Open-Cascade-SAS/OCCT/archive/refs/tags/{}.tar.gz", occt_version);
 
-		let download_dir = out_dir.join("occt-source");
+		let download_dir = effective_root.join("occt-source");
 		let extraction_sentinel = download_dir.join(".extraction_done");
 
 		if !extraction_sentinel.exists() {
@@ -279,14 +252,20 @@ mod source {
 			.map(|e| e.path())
 			.expect("OCCT source directory not found after extraction");
 
-		patch_occt_sources(&source_dir);
+		// Apply patches
+		walk_occt_sources(&source_dir, |path| {
+			if let Some(patched) = patch_or_none(path) {
+				std::fs::write(path, patched).expect("patch write failed");
+				eprintln!("Patched {}", path.file_name().unwrap().to_string_lossy());
+			}
+		});
 
 		eprintln!("Building OCCT with CMake (this may take a while)...");
 
 		let built = cmake::Config::new(&source_dir)
 			.profile("Release")
 			.define("BUILD_LIBRARY_TYPE", "Static")
-			.define("CMAKE_INSTALL_PREFIX", install_prefix.to_str().unwrap())
+			.define("CMAKE_INSTALL_PREFIX", effective_root.to_str().unwrap())
 			.define("USE_FREETYPE", "OFF")
 			.define("USE_FREEIMAGE", "OFF")
 			.define("USE_OPENVR", "OFF")
@@ -322,97 +301,99 @@ mod source {
 
 		eprintln!("OCCT built at: {}", built.display());
 
-		find_occt_dirs(install_prefix)
+		// LGPL 2.1 §2: keep only patched files; remove everything else
+		walk_occt_sources(&source_dir, |path| {
+			if path.is_dir() {
+				let _ = std::fs::remove_dir_all(path);
+			} else if patch_or_none(path).is_none() {
+				let _ = std::fs::remove_file(path);
+			}
+		});
+
+		find_occt_dirs(effective_root)
 	}
 
-	/// Patch OCCT source files to remove unwanted link dependencies.
-	///
-	/// 1. TKService (Visualization) — stub XCAFDoc_VisMaterial.cxx, empty XCAFPrs_Texture.cxx
-	/// 2. advapi32 / user32 (Windows) — stub OSD_WNT/File/Protection/signal/FileNode/Process
-	/// 3. glibc-only headers (musl) — stub Standard_StackTrace.cxx, comment out <execinfo.h>
-	/// 4. OCC_CONVERT_SIGNALS — comment out to avoid mingw _setjmp ABI issues
-	fn patch_occt_sources(source_dir: &Path) {
-		let is_windows = env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows");
-
-		for entry in [source_dir.join("src"), source_dir.join("adm")]
-			.into_iter()
-			.flat_map(walkdir::WalkDir::new)
-			.flatten()
-		{
-			if !entry.file_type().is_file() {
-				continue;
-			}
-			let path = entry.path();
-			let Some(name) = path.file_name().and_then(|s| s.to_str()) else { continue };
-			match name {
-				"XCAFDoc_VisMaterial.cxx" => stub_out_methods(path, true),
-				"XCAFPrs_Texture.cxx" => stub_out_methods(path, false),
-
-				"Standard_StackTrace.cxx" => {
-					stub_out_methods(path, true);
-					comment_out_include(path, "execinfo.h");
-				}
-
-				"OSD_WNT.cxx" if is_windows => stub_out_methods(path, false),
-				"OSD_File.cxx" | "OSD_Protection.cxx" | "OSD_signal.cxx" | "OSD_FileNode.cxx" | "OSD_Process.cxx"
-					if is_windows =>
-				{
-					stub_out_methods(path, true);
-				}
-
-				"occt_defs_flags.cmake" if is_windows => {
-					let needle = "add_definitions(-DOCC_CONVERT_SIGNALS)";
-					let replacement = "# add_definitions(-DOCC_CONVERT_SIGNALS)  # patched out by cadrum build.rs";
-					if let Ok(content) = std::fs::read_to_string(path) {
-						if content.contains(needle) && !content.contains(replacement) {
-							let patched = content.replace(needle, replacement);
-							if let Err(e) = std::fs::write(path, patched) {
-								eprintln!("warning: failed to patch {}: {}", path.display(), e);
-							} else {
-								eprintln!("patched out OCC_CONVERT_SIGNALS in {}", path.display());
-							}
-						}
+	/// Walk the OCCT source tree.
+	/// - `src/` and `adm/`: recurse and yield every **file**
+	/// - other top-level directories (`data/`, `dox/`, `tests/`, …): yield the **directory** itself
+	/// - top-level files (`CMakeLists.txt`, `LICENSE_LGPL_21.txt`, …): skipped
+	fn walk_occt_sources(source_dir: &Path, mut f: impl FnMut(&Path)) {
+		for entry in walkdir::WalkDir::new(source_dir).min_depth(1).max_depth(1).into_iter().flatten() {
+			let name = entry.file_name().to_string_lossy();
+			if name == "src" || name == "adm" {
+				for child in walkdir::WalkDir::new(entry.path()).into_iter().flatten() {
+					if child.file_type().is_file() {
+						f(child.path());
 					}
 				}
-
-				_ => {}
+			} else if entry.file_type().is_dir() {
+				f(entry.path());
 			}
 		}
 	}
 
-	fn comment_out_include(path: &Path, header: &str) {
-		if !path.exists() {
-			return;
+	/// Return the patched content for a file if it needs patching, `None` otherwise.
+	/// Pure function — does not write to disk.
+	fn patch_or_none(path: &Path) -> Option<String> {
+		let name = path.file_name()?.to_str()?;
+		let is_windows = env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows");
+
+		match name {
+			"XCAFDoc_VisMaterial.cxx" => Some(stub_content(path, true)),
+			"XCAFPrs_Texture.cxx" => Some(stub_content(path, false)),
+
+			"Standard_StackTrace.cxx" => {
+				let stubbed = stub_content(path, true);
+				Some(comment_out_include_in(&stubbed, "execinfo.h"))
+			}
+
+			"OSD_WNT.cxx" if is_windows => Some(stub_content(path, false)),
+			"OSD_File.cxx" | "OSD_Protection.cxx" | "OSD_signal.cxx"
+			| "OSD_FileNode.cxx" | "OSD_Process.cxx"
+				if is_windows =>
+			{
+				Some(stub_content(path, true))
+			}
+
+			"occt_defs_flags.cmake" if is_windows => {
+				let content = std::fs::read_to_string(path).ok()?;
+				let needle = "add_definitions(-DOCC_CONVERT_SIGNALS)";
+				let replacement = "# add_definitions(-DOCC_CONVERT_SIGNALS)  # patched out by cadrum build.rs";
+				if content.contains(needle) {
+					Some(content.replace(needle, replacement))
+				} else if content.contains(replacement) {
+					Some(content) // already patched — keep as-is
+				} else {
+					None
+				}
+			}
+
+			_ => None,
 		}
-		let content = std::fs::read_to_string(path).expect("Failed to read file for include patching");
-		let needle = format!("#include <{}>", header);
-		if !content.contains(&needle) {
-			return;
-		}
-		let replacement = format!("// {} (patched out by cadrum build.rs)", needle);
-		let patched = content.replace(&needle, &replacement);
-		std::fs::write(path, patched).expect("Failed to write patched include file");
-		eprintln!("Patched out <{}> in {}", header, path.file_name().unwrap().to_string_lossy());
 	}
 
-	fn stub_out_methods(path: &Path, keep_signatures: bool) {
-		if !path.exists() {
-			return;
-		}
-
-		let unix = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).map(|d| d.as_secs().to_string()).unwrap_or_else(|_| "unknown".to_string());
+	/// Generate stubbed content for a C++ source file without writing to disk.
+	fn stub_content(path: &Path, keep_signatures: bool) -> String {
+		let unix = std::time::SystemTime::now()
+			.duration_since(std::time::UNIX_EPOCH)
+			.map(|d| d.as_secs().to_string())
+			.unwrap_or_else(|_| "unknown".to_string());
 		let description = if keep_signatures { "method bodies stubbed" } else { "file emptied" };
 		let header = format!("// Stubbed by cadrum build.rs at unix={unix}: {description}.\n");
 
-		let patched = if keep_signatures {
+		if keep_signatures {
 			let content = std::fs::read_to_string(path).expect("Failed to read file for stubbing");
 			header + &stub_all_top_level_bodies(&content)
 		} else {
 			header
-		};
+		}
+	}
 
-		std::fs::write(path, patched).expect("Failed to write stubbed file");
-		eprintln!("Stubbed {}", path.file_name().unwrap().to_string_lossy());
+	/// Comment out `#include <header>` in a string and return the result.
+	fn comment_out_include_in(content: &str, header: &str) -> String {
+		let needle = format!("#include <{}>", header);
+		let replacement = format!("// {} (patched out by cadrum build.rs)", needle);
+		content.replace(&needle, &replacement)
 	}
 
 	fn lex_normalize(content: &str) -> String {

--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,7 @@ const OCCT_VERSION: &str = "V8_0_0_rc5";
 
 /// GitHub Release tag under `lzpel/cadrum` that hosts the prebuilt tarballs.
 /// Bump this when rebuilding prebuilts for the same OCCT version.
+#[cfg(not(feature = "source-build"))]
 const OCCT_PREBUILT_TAG: &str = "occt-v800rc5";
 
 /// `V8_0_0_rc5` → `v800rc5`. Shared rule: lowercase and drop underscores.
@@ -61,7 +62,12 @@ fn target_dir_from_out_dir(out_dir: &Path, target: &str) -> PathBuf {
 fn resolve_occt(out_dir: &Path, target: &str) -> [PathBuf; 2] {
 	let target_dir = target_dir_from_out_dir(out_dir, target);
 	let default_root = target_dir.join(format!("cadrum-occt-{}-{}", slug(OCCT_VERSION), target));
-	let effective_root = env::var("OCCT_ROOT").map(PathBuf::from).unwrap_or(default_root);
+	let effective_root = env::var("OCCT_ROOT")
+		.map(|r| {
+			let p = PathBuf::from(r);
+			if p.is_relative() { env::current_dir().unwrap().join(p) } else { p }
+		})
+		.unwrap_or(default_root);
 
 	println!("cargo:rerun-if-changed={}", effective_root.display());
 
@@ -166,6 +172,7 @@ fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path) {
 }
 
 /// Download a prebuilt OCCT tarball for `target` into `dest`.
+#[cfg(not(feature = "source-build"))]
 fn download_prebuilt(out_dir: &Path, dest: &Path, target: &str) -> Option<[PathBuf; 2]> {
 	let slug_ver = slug(OCCT_VERSION);
 	let top_name = format!("cadrum-occt-{}-{}", slug_ver, target);

--- a/figure/linux.svg
+++ b/figure/linux.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+<circle cx="16" cy="16" r="16"/>
+<g fill="#fff"><circle cx="10.5" cy="12" r="5"/><circle cx="21.5" cy="12" r="5"/></g>
+<circle cx="13" cy="12" r="1.6"/><circle cx="19" cy="12" r="1.6"/>
+<path fill="#f90" d="M10 18h12l-6 10z"/>
+</svg>

--- a/figure/windows.svg
+++ b/figure/windows.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16"><path d="M3 5.5l7.5-1v7H3zm8.5-1.2L21 3v8.5h-9.5zM3 12.5h7.5v7L3 18.5zm8.5 0H21V21l-9.5-1.5z" fill="#0078d4"/></svg>


### PR DESCRIPTION
## Summary
- `cmake`/`walkdir` を `optional` build-dependency に変更し `source-build` feature でのみ有効化。デフォルト `cargo build` ではコンパイルされず prebuilt ターゲットのビルドが高速化
- `build.rs` を `#[cfg(feature = "source-build")] mod source { ... }` で構造化し `resolve_occt` を match 連鎖に整理
- `CARGO_TARGET_DIR` ヒューリスティックを `OUT_DIR` ベースの `target_dir_from_out_dir()` に置換（`--target` フラグ対応）
- 相対パスの `OCCT_ROOT` を `env::current_dir()` 基準で絶対パスに変換
- `find_occt_dirs` → `Option<[PathBuf; 2]>`（exists チェック内部化）
- `resolve_occt` から `out_dir` パラメータを除去、effective_root 計算を `main` に引き上げ
- `patch_occt_sources` を `walk_occt_sources` + `patch_or_none` に分解（副作用分離）
- LGPL 2.1 §2 対応: ソースビルド後にパッチ済みファイル以外を削除（`data/` 55MB, `dox/` 18MB, `tests/` 9.6MB 等）、パッチ済み ~9 ファイルのみ `.a` と同居して配布可能に
- OCCT ソース展開先を `effective_root/OCCT-8_0_0_rc5/` に直接配置（`occt-source/` ネスト廃止）
- README の Build セクションを Usage 直後に移動し prebuilt 対応表 + OS アイコンで簡潔化

## Commits
1. `refactor(build)` — Cargo.toml + build.rs: 依存分離、mod source、match 連鎖、OUT_DIR 逆算
2. `docs` — figure/linux.svg (CC0, Wikimedia Commons) + figure/windows.svg
3. `docs` — README Build セクション整理
4. `fix(build)` — 相対 OCCT_ROOT を cwd 基準で解決、dead_code warnings 修正
5. `docs` — make deploy による README 自動更新
6. `refactor(build)` — resolve_occt から OUT_DIR 除去、LGPL ソース cleanup、walk + patch_or_none 分解
7. `refactor(build)` — OCCT ソースを effective_root 直下に展開
8. `style(build)` — walk_occt_sources の match を is_dir 正論理に整理

## Test plan
- [x] `cargo clean && OCCT_ROOT=target/cadrum-occt cargo build --features source-build` — ソースビルド成功
- [x] `OCCT_ROOT=target/cadrum-occt make deploy` — 全 example 実行 + mdbook ビルド成功
- [x] `cargo build` (source-build OFF, cache hit) — cmake/walkdir なしでビルド成功
- [x] `cargo test` — 全 53 テスト通過 (warning ゼロ)
- [x] ソースビルド後 `effective_root/OCCT-8_0_0_rc5/` にパッチ済み 9 ファイルのみ残存確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)