### PR TITLE
fix(#89): bundle container libstdc++/libgcc into mingw prebuilt tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target/
 out/
+logs/
 linkedin.md
 .venv/
 *.brep

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ pure = []
 # Build OCCT from upstream sources when the cache is empty, instead of
 # downloading a prebuilt tarball. Off by default — most users will use the
 # prebuilt binary path.
-source-build = ["dep:cmake", "dep:walkdir"]
+source-build = ["dep:cmake"]
 
 [dependencies]
 cxx = "1"
@@ -32,9 +32,9 @@ cxx-build = "1"
 minreq = { version = "2", features = ["https-rustls"] }
 libflate = "2"
 tar = "0.4"
+walkdir = "2"
 # source-build only: build OCCT from upstream sources
 cmake = { version = "0.1", optional = true }
-walkdir = { version = "2", optional = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu"]

--- a/build.rs
+++ b/build.rs
@@ -119,6 +119,18 @@ fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path) {
 		println!("cargo:rustc-link-lib=static={}", lib);
 	}
 
+	// Tarball 側が "cadrum" を含む名前の static library を同梱していれば拾う。
+	// 典型: mingw 向けに libcadrum_stdc++.a / libcadrum_gcc.a 等を同梱して、
+	// ホスト側 GCC のバージョン差による libstdc++ ABI ミスマッチを回避する (#89)。
+	// OCC_LIBS ループの後に置くので OCCT libs の未解決 symbol を後段で満たす順序になる。
+	for entry in walkdir::WalkDir::new(occt_lib_dir).min_depth(1).max_depth(1).into_iter().flatten() {
+		let Some(name) = entry.file_name().to_str() else { continue };
+		if name.contains("cadrum") {
+			let name=name.strip_prefix("lib").unwrap_or(name).strip_suffix(".a").or(name.strip_suffix(".lib")).unwrap_or(name);
+			println!("cargo:rustc-link-lib=static={}", name);
+		}
+	}
+
 	let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
 	let is_mingw_like = target_env == "gnu" || target_env == "gnullvm";
 	if is_mingw_like {

--- a/makefile
+++ b/makefile
@@ -10,9 +10,32 @@ deploy: generate # generate out/markdown from examples, then build out/html
 	./out/bin/mdbook build
 publish: deploy # publish to crates.io
 	cargo publish
+ifeq ($(CARGO_BUILD_TARGET),x86_64-pc-windows-gnu)
+# mingw gcc のインストール先から lib<name>.a の絶対 path を引く関数。
+# 使用例: $(call mingw_lib,libstdc++.a) → /usr/.../libstdc++.a
+# -print-file-name= はドライバの library search path から名前解決するだけで、C/C++ 区別はしないので
+# gcc 一本で stdc++/gcc/gcc_eh いずれも取れる (g++ でも同じ結果)。コンパイラは parse 時点で
+# 存在するので make 関数で OK (対 `$(shell find ...)` は parse 時評価なので cargo build 前に
+# 走り空を返す — OCCT lib dir の探索は shell substitution 側で行う、下の recipe を参照)。
+mingw_lib = $(shell x86_64-w64-mingw32-gcc -print-file-name=$(1))
+endif
+
 cadrum-occt: generate # build occt from source natively
 	cargo clean
 	cargo build --example 01_primitives --release --features source-build 2>&1 | tee out/log.txt # colorはdefaultの一部なのでfeature指定不要
+ifeq ($(CARGO_BUILD_TARGET),x86_64-pc-windows-gnu)
+	@# mingw コンテナで作った OCCT の lib dir にコンテナ側 gcc の runtime (libstdc++/libgcc/libgcc_eh) を
+	@# libcadrum_* リネームでコピーする。build.rs の scanner が libcadrum_* を自動で -l として拾い、
+	@# ホスト側 mingw との GCC バージョン差による ABI 不整合を回避する (#89 対策)。
+	@# libTKernel.a の位置から dirname で lib dir を得る。shell substitution `$$(...)` を使うのは
+	@# recipe 実行時に評価する必要があるため — make の `$(shell ...)` は recipe 開始時点で
+	@# 一括展開されるので cargo build 前に走って空を返してしまう。
+	@LIBDIR=$$(find target -maxdepth 6 -type f -name libTKernel.a -path '*cadrum-occt*' | head -n 1 | xargs -r dirname); \
+	[ -n "$$LIBDIR" ] || { echo "bundle: OCCT lib dir not found under target/" >&2; exit 1; }; \
+	cp -v "$(call mingw_lib,libstdc++.a)" "$$LIBDIR/libcadrum_stdc++.a"; \
+	cp -v "$(call mingw_lib,libgcc.a)"    "$$LIBDIR/libcadrum_gcc.a"; \
+	cp -v "$(call mingw_lib,libgcc_eh.a)" "$$LIBDIR/libcadrum_gcc_eh.a"
+endif
 	find target -maxdepth 1 -type d -name 'cadrum*' | xargs -IX sh -c 'tar -czf out/$$(basename X).tar.gz -C $$(dirname X) $$(basename X)'
 cadrum-occt-%: # build occt from source in cross ( = native build in container ) cadrum-occt-aarch64-unknown-linux-gnu cadrum-occt-x86_64-pc-windows-gnu cadrum-occt-x86_64-unknown-linux-gnu
 	docker build -f docker/Dockerfile_$(*) -t cadrum-occt-$(*) .


### PR DESCRIPTION
Closes #89.

## Summary

- 配布 tarball (`x86_64-pc-windows-gnu`) に**コンテナ側 GCC の `libstdc++.a` / `libgcc.a` / `libgcc_eh.a`** を `libcadrum_` prefix 付きで同梱するようにした
- build.rs は OCCT の lib dir を scan し、`cadrum` を名前に含む static library を検出して自動的に `cargo:rustc-link-lib=static=cadrum_<name>` を emit
- ホスト側 mingw の GCC バージョン (15.2 等) がコンテナ側 (GCC 12) と異なっても、OCCT が参照する libstdc++ シンボルが bundled 版で満たされるため ABI ミスマッチが起きない

## Why

#89 の原因は **OCCT を焼いたコンテナ (GCC 12-posix) と末端ユーザのホスト (GCC 15.2) で libstdc++ ABI が乖離**していること。OCCT の `BinTools_ShapeSet::ReadShape` や `OSD_LocalFileSystem` が参照する `std::istream::seekg(std::fpos<int>)` / `std::basic_filebuf::seekpos` 等は GCC 12 の libstdc++ シンボル形で出力されており、GCC 15 の libstdc++ には既に存在しないため `undefined reference` で fail する。

配布する側の立場では「GCC バージョンを揃えろ」は解になり得ない (末端ユーザは様々な mingw バージョンを使う)。解は **OCCT 配布物の側で libstdc++ 依存を閉じ込める** ことで、そのための最小変更パス = tarball に libstdc++/libgcc/libgcc_eh を同梱する。

## How

### build.rs (consumer-side, 7 行追加)

```rust
for entry in walkdir::WalkDir::new(occt_lib_dir).min_depth(1).max_depth(1).into_iter().flatten() {
    let Some(name) = entry.file_name().to_str() else { continue };
    if name.contains(\"cadrum\") {
        let name = name.strip_prefix(\"lib\").unwrap_or(name).strip_suffix(\".a\").or(name.strip_suffix(\".lib\")).unwrap_or(name);
        println!(\"cargo:rustc-link-lib=static={}\", name);
    }
}
```

- `libcadrum_stdc++.a` → `-lcadrum_stdc++`
- `cadrum_stdc++.lib` (MSVC 形式) → `-lcadrum_stdc++`
- 他 prebuilt (MSVC / Linux) は同梱ファイルが無いので no-op — target / feature での分岐は不要、ファイル有無 1 軸で制御される
- ordering: OCC_LIBS ループの後に置いたので、OCCT libs が先に symbol を要求し bundled runtime が満たす順序になる
- `--allow-multiple-definition` (既に付いている) と組み合わさるので、万一ホスト libstdc++ と衝突しても安全

### makefile (producer-side, mingw のみ)

`cadrum-occt` ターゲットに `ifeq ($(CARGO_BUILD_TARGET),x86_64-pc-windows-gnu)` gate で bundle step を追加:

```makefile
@LIBDIR=\$\$(find target -maxdepth 6 -type f -name libTKernel.a -path '*cadrum-occt*' | head -n 1 | xargs -r dirname); \
[ -n \"\$\$LIBDIR\" ] || { echo \"bundle: OCCT lib dir not found under target/\" >&2; exit 1; }; \
cp -v \"\$(call mingw_lib,libstdc++.a)\" \"\$\$LIBDIR/libcadrum_stdc++.a\"; \
cp -v \"\$(call mingw_lib,libgcc.a)\"    \"\$\$LIBDIR/libcadrum_gcc.a\"; \
cp -v \"\$(call mingw_lib,libgcc_eh.a)\" \"\$\$LIBDIR/libcadrum_gcc_eh.a\"
```

- `mingw_lib` は make 関数で `gcc -print-file-name=...` を呼ぶラッパ
- libTKernel.a の位置から dirname で OCCT lib dir を動的に得る — source-build の CMake install layout (`lib/`) と prebuilt の OCCT 公式 layout (`win64/gcc/lib/`) 両方に対応
- **shell substitution `\$\$(...)` を使っているのは意図的**: GNU make の `\$(shell ...)` は recursive `=` 変数でも recipe 開始時に一括展開されるため、cargo build が target/ を populate する前に走って空を返してしまう

### Cargo.toml

walkdir を source-build feature の optional から unconditional build-dep に移動 (scanner が feature と無関係に必要)。

## Test plan

- [x] `make check-cadrum-occt-x86_64-pc-windows-gnu` が end-to-end で通ることを確認 (コンテナビルド → bundle → tar → host 展開 → cargo run --example 01_primitives)
- [x] 01_primitives が**リンクを通過**して **exe として実行**される
- [x] OCCT STEP writer の動作確認 (\"Statistics on Transfer\" が出力され、`01_primitives.step` が生成される = BinTools/OSD 経路が実走)
- [x] `01_primitives.svg` も生成される (mesh 経路も OK)
- [x] ホストの GCC は 15.2 で、コンテナは GCC 12 — 異バージョン跨ぎで動作することを確認済み

## Out of scope

- MSVC / Linux prebuilt への同様の bundling は必要ないため未実施 (ABI 乖離が mingw 固有)
- アーカイブを archive-merge 方式 (libstdc++ の .o を OCCT.a に取り込む) で単一ファイル化する案は保留 (より invasive でサイズも増える)

🤖 Generated with [Claude Code](https://claude.com/claude-code)