### PR TITLE
fix(#97): silence OCCT default messenger

### DIFF
--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -88,6 +88,7 @@
 #include <STEPControl_Reader.hxx>
 #include <STEPControl_Writer.hxx>
 #include <Message_ProgressRange.hxx>
+#include <Message.hxx>
 
 // --- C++ standard library ---
 #include <istream>
@@ -98,10 +99,17 @@
 #include <cstdint>
 #include <algorithm>
 #include <unordered_map>
-#include <unordered_set>
 #include <array>
 
 namespace cadrum {
+
+// OCCT defaults to a stdout printer that emits "Statistics on Transfer" banners on STEP read/write.
+// Clear all printers at load time per the documented recommendation.
+// ******        Statistics on Transfer (Write)                 ******
+static const int _silence_occt_default_printer = []() {
+    Message::DefaultMessenger()->ChangePrinters().Clear();
+    return 0;
+}();
 
 // ==================== RustReadStreambuf ====================
 


### PR DESCRIPTION
Closes #97.

## Summary
- Clear `Message::DefaultMessenger()` printer sequence at load time so STEP read/write no longer spams "Statistics on Transfer (Write)" banners to stdout.
- Uses `ChangePrinters().Clear()` per the documented recommendation in OCCT's `Message_Messenger` ("If printing to cout is not needed, clear messenger by GetPrinters().Clear()").
- Drops the now-unused `<unordered_set>` include while touching the I/O block.

## Why this is safe
cadrum statically links OCCT and exposes no Rust API onto the messenger — downstream users have no path to install a custom printer that this `Clear()` would wipe. Errors still surface through `IFSelect_ReturnStatus` (no diagnostic loss).

## Test plan
- [x] `cargo run --example 02_write_read` — banners gone, only user `println!` lines remain.
- [x] `cargo run --example 01_primitives` — clean (no OCCT chatter).
- [x] `cargo test` — all 7 tests pass, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)