### PR TITLE
docs(#102): OCCT topology 不変性と cadrum 設計への含意メモ

### DIFF
--- a/notes/20260420-OCCTトポロジ不変性と設計含意.md
+++ b/notes/20260420-OCCTトポロジ不変性と設計含意.md
@@ -1,0 +1,458 @@
+# OCCT における topology の immutability と Rust `Solid` 設計への含意
+
+## Context
+
+`Solid` に `OnceLock<Vec<Edge>>` などの edge cache を持たせる設計を検討するにあたり、OCCT 側の topology 変更 API の挙動を整理する必要があった。結論として **OCCT は topology の in-place 変更を API レベルで提供していない**ため、Rust 側で「構築後 immutable」の invariant を型レベルに固めても実装上の踏み抜きは発生しない。本ノートはその根拠と代表操作の内訳を記録する。
+
+関連 issue: [#102 Edge を view 型に再設計](https://github.com/lzpel/cadrum/issues/102)
+
+---
+
+## OCCT の data model
+
+`TopoDS_Shape` は 3 要素のハンドル：
+
+```
+TopoDS_Shape {
+    tshape:      Handle<TopoDS_TShape>,  // 実体 (topology tree)、ref-counted で共有可
+    location:    TopLoc_Location,        // world への変換
+    orientation: TopAbs_Orientation,     // FORWARD / REVERSED
+}
+```
+
+**`TShape` は構築後 read-only** が OCCT の前提。API レベルで「edge を追加する」「fillet で形を変える」ための in-place 変更メソッドは存在せず、全ての形状変更は `BRepBuilderAPI_*` / `BRepAlgoAPI_*` / `BRepFilletAPI_*` を通じて **新しい `TopoDS_Shape` を build して返す**。
+
+### ソース (OCCT 公式ドキュメントからの直接引用)
+
+#### 1. TShape の共有モデル (handle-body idiom)
+
+OCCT User Guide, "Modeling Data — Topology":
+<https://dev.opencascade.org/doc/overview/html/occt_user_guides__modeling_data.html>
+
+> The sharing of TopoDS_Shapes is meaningless. What is important is the sharing of the underlying TopoDS_TShapes. Assignment or passage in argument does not copy the data structure: this only creates new TopoDS_Shapes which refer to the same TopoDS_TShape.
+
+> 訳: TopoDS_Shape を共有することには意味が無い。重要なのは基底にある TopoDS_TShape の共有である。代入や引数渡しはデータ構造をコピーせず、同じ TopoDS_TShape を参照する新しい TopoDS_Shape を生成するだけである。
+
+> TopoDS_TShape class is manipulated by reference; TopoDS_Shape class by value. A TopoDS_Shape is nothing more than a reference enhanced with an orientation and a local coordinate.
+
+> 訳: TopoDS_TShape クラスは参照で扱われ、TopoDS_Shape クラスは値で扱われる。TopoDS_Shape は、orientation と local coordinate を付加した参照に過ぎない。
+
+> A shareable data structure is handled by reference. When a simple reference is insufficient, two pieces of information are added: an orientation and a local coordinate reference.
+
+> 訳: 共有可能なデータ構造は参照で扱う。単なる参照では不十分な場合、orientation と local coordinate の 2 つの情報を付加する。
+
+> The data structure is as compact as possible. Sub-objects can be shared among different objects.
+
+> 訳: データ構造は可能な限りコンパクト。サブオブジェクトは複数のオブジェクト間で共有できる。
+
+→ `TopoDS_Shape` は `TopoDS_TShape` への参照+location+orientation の軽量 wrapper。assign/コピーは TShape 共有の shallow copy。
+
+TopoDS_TShape refman: <https://dev.opencascade.org/doc/refman/html/class_topo_d_s___t_shape.html>
+
+> Users have no direct access to the classes derived from TShape. They handle them with the classes derived from Shape.
+
+> 訳: ユーザは TShape から派生したクラスに直接アクセスできない。Shape から派生したクラス経由で扱う。
+
+→ ユーザは TShape を直接操作できず、Shape 経由でのみ扱う設計。
+
+#### 2. 形状変更は新 shape を build する
+
+**BRepBuilderAPI_Transform**:
+<https://dev.opencascade.org/doc/refman/html/class_b_rep_builder_a_p_i___transform.html>
+
+> if the determinant of the vectorial part of T is equal to 1., and if theCopyGeom equals false (the default value), the resulting shape is the same as the original but with a new location assigned to it. Otherwise, the transformation is applied on a duplication of theShape.
+
+> 訳: T のベクトル部の行列式が 1.0 で、かつ theCopyGeom が false (デフォルト値) の場合、結果 shape は元の shape と同じで新しい location が設定されたものになる。そうでない場合、変換は theShape の複製に対して適用される。
+
+→ 通常 transform は入力 shape を **duplicate して変形**。scale や mirror のような rigid でない transform で `Moved()` が使えないのはこれが理由。
+
+**BRepAlgoAPI_BooleanOperation**:
+<https://dev.opencascade.org/doc/refman/html/class_b_rep_algo_a_p_i___boolean_operation.html>
+
+> In non-destructive mode the argument shapes are not modified. Instead a copy of a sub-shape is created in the result if it is needed to be updated.
+
+> 訳: non-destructive モードでは引数の shape は変更されない。更新が必要な場合は、代わりに sub-shape のコピーが結果内に生成される。
+
+> The class builds the splits of the given arguments using the intersection results and combines the result.
+
+> 訳: このクラスは交差結果を用いて与えられた引数の分割を構築し、結果を結合する。
+
+→ boolean は **non-destructive がデフォルト**。入力 shape は変更されず、結果は新 shape として build される。
+
+**BRepFilletAPI_MakeFillet**:
+<https://dev.opencascade.org/doc/refman/html/class_b_rep_fillet_a_p_i___make_fillet.html>
+
+> Builds the fillets on all the contours in the internal data structure of this algorithm and constructs the resulting shape.
+
+> 訳: このアルゴリズムの内部データ構造内のすべての contour 上に fillet を構築し、結果 shape を構成する。
+
+> Use the function Shape to retrieve the filleted shape.
+
+> 訳: fillet 適用後の shape を取り出すには Shape 関数を使用する。
+
+→ fillet は結果 shape を **内部で構築** し、`Shape()` accessor で取り出す。入力 shape の in-place 変更ではない。
+
+#### 3. cadrum で将来実装する可能性のある API の挙動
+
+fillet/boolean/transform 以外にも、cadrum が将来的に取り込みそうな主要 API について挙動を確認する。**ほぼすべて「new shape を build」方針で、`BRepMesh_IncrementalMesh` のみが triangulation を in-place で attach する例外**。
+
+##### Chamfer (面取り)
+
+**BRepFilletAPI_MakeChamfer**:
+<https://dev.opencascade.org/doc/refman/html/class_b_rep_fillet_a_p_i___make_chamfer.html>
+
+> A MakeChamfer object provides a framework for: initializing the construction algorithm with a given shape, acquiring the data characterizing the chamfers, building the chamfers and constructing the resulting shape, and consulting the result.
+
+> 訳: MakeChamfer オブジェクトは、与えられた shape で構築アルゴリズムを初期化し、chamfer を特徴付けるデータを取得し、chamfer を構築して結果 shape を組み立て、結果を参照するためのフレームワークを提供する。
+
+→ fillet と同じ framework パターン。入力 shape は変更されず、結果は新 shape として build される。
+
+##### 中空化 / 肉付け (Shell / Thick Solid)
+
+**BRepOffsetAPI_MakeThickSolid**:
+<https://dev.opencascade.org/doc/refman/html/class_b_rep_offset_a_p_i___make_thick_solid.html>
+
+> A hollowed solid is built from an initial solid and a set of faces on this solid, which are to be removed.
+
+> 訳: 中空化された solid は、初期 solid と、その solid 上の削除対象 face の集合から構築される。
+
+> Constructs a hollowed solid from the solid S by removing the set of faces ClosingFaces from S.
+
+> 訳: solid S から face 集合 ClosingFaces を除去して、中空化された solid を構築する。
+
+→ "built from" / "constructs" — 新 solid を build する。入力 S は変更されない。
+
+##### オフセット shape
+
+**BRepOffsetAPI_MakeOffsetShape**:
+<https://dev.opencascade.org/doc/refman/html/class_b_rep_offset_a_p_i___make_offset_shape.html>
+
+> Describes functions to build a shell out of a shape. The result is an unlooped shape parallel to the source shape.
+
+> 訳: shape から shell を build する関数群。結果は source shape に平行な unlooped shape となる。
+
+> A MakeOffsetShape object provides a framework for: defining the construction of a shell, implementing the construction algorithm, consulting the result.
+
+> 訳: MakeOffsetShape オブジェクトは、shell の構築定義・アルゴリズム実装・結果参照のためのフレームワークを提供する。
+
+→ source shape は変更されず、結果は別 shape。
+
+##### Draft (抜き勾配)
+
+**BRepOffsetAPI_DraftAngle**:
+<https://dev.opencascade.org/doc/refman/html/class_b_rep_offset_a_p_i___draft_angle.html>
+
+> Taper-adding transformations on a shape. The resulting shape is constructed by defining one face to be tapered after another one.
+
+> 訳: shape に対するテーパ付加変換。結果 shape は、テーパをかける face を 1 つずつ定義することで構築される。
+
+> Initializes an algorithm to perform taper-adding transformations on faces of the shape S. S will be referred to as the initial shape of the algorithm.
+
+> 訳: shape S の face に対してテーパ付加変換を行うアルゴリズムを初期化する。S はアルゴリズムの "initial shape" と呼ばれる。
+
+→ "initial shape" という呼称が示す通り S は入力として保持され、結果は新 shape として構築される。
+
+##### Feature 系プリズム (局所的な押し出し/穴あけ)
+
+**BRepFeat_MakePrism**:
+<https://dev.opencascade.org/doc/refman/html/class_b_rep_feat___make_prism.html>
+
+> Describes functions to build prism features. These can be depressions or protrusions.
+
+> 訳: prism feature を構築する関数群。凹み (depression) または突起 (protrusion) のいずれも扱える。
+
+> Fuse offers a choice between: removing matter with a Boolean cut using the setting 0, adding matter with Boolean fusion using the setting 1. If it is inside the basis shape, a local operation such as glueing can be performed.
+
+> 訳: Fuse では、設定 0 で Boolean cut による素材除去、設定 1 で Boolean fusion による素材追加を選択できる。基底 shape 内部ならば glue のような局所操作も可能。
+
+→ 内部で Boolean cut/fuse を走らせる feature modeling。結局は BRepAlgoAPI と同じく新 shape を build する。
+
+##### Sewing (フェイス結合してシェル化)
+
+**BRepBuilderAPI_Sewing**:
+<https://dev.opencascade.org/doc/refman/html/class_b_rep_builder_a_p_i___sewing.html>
+
+> Provides methods to identify possible contiguous boundaries, assemble contiguous shapes into one shape.
+
+> 訳: 連続する可能性のある境界を識別し、連続 shape を 1 つの shape に組み立てる手法を提供する。
+
+→ 入力 shape 群は参照されるのみ、出力は `SewedShape()` accessor で取り出す別 shape。
+
+##### 明示的な deep copy
+
+**BRepBuilderAPI_Copy**:
+<https://dev.opencascade.org/doc/refman/html/class_b_rep_builder_a_p_i___copy.html>
+
+> Duplication of a shape. A Copy object provides a framework for: defining the construction of a duplicate shape...
+
+> 訳: shape の複製。Copy オブジェクトは複製 shape の構築を定義するフレームワークを提供する。
+
+> Constructs a copy framework and copies the shape S. Use the function Shape to access the result. If copyGeom is False, only topological objects will be copied, while geometry and triangulation will be shared with original shape.
+
+> 訳: copy framework を構築し、shape S を複製する。結果には Shape 関数でアクセスする。copyGeom が False の場合、topological オブジェクトのみコピーされ、geometry と triangulation は元 shape と共有される。
+
+→ 明示的に deep copy する必要がある場合のための API。`copyGeom=false` なら topology のみ複製し、geometry/triangulation は共有可能 (省コスト複製)。
+
+##### Healing / Fixing (形状修復)
+
+**ShapeFix_Shape**:
+<https://dev.opencascade.org/doc/refman/html/class_shape_fix___shape.html>
+
+> Fixing shape in general.
+
+> 訳: shape 一般の修復。
+
+ドキュメント本文には "in-place か new shape か" を明言する記述はないが、`ShapeFix_Root` 由来の `Shape()` accessor で結果を取り出すパターン。つまり **出力は別 shape として取り出す**形。sub-shape は共有される可能性があるが、ユーザから見える入力 `TopoDS_Shape` ハンドルは変更されない。
+
+**ShapeUpgrade_UnifySameDomain** (同一 geometry の隣接 face を統合):
+<https://dev.opencascade.org/doc/refman/html/class_shape_upgrade___unify_same_domain.html>
+
+**cadrum の `Solid::clean()` が wrap している API。** 結論から言えば他の builder 系と**完全に同じ「参照から新実体を build する」モデル**。以下、refman からの根拠引用。
+
+##### クラス概要
+
+> The output result of the tool is the unified shape.
+
+> 訳: このツールの出力結果は unified shape。
+
+> This tool tries to unify faces and edges of the shape which lie on the same geometry. ... In this case these faces/edges can be unified into one face/edge.
+
+> 訳: このツールは、同じ geometry 上にある shape の face / edge を統合しようとする。該当する face / edge は 1 つに統合されうる。
+
+##### 入力は参照 (consume しない)
+
+コンストラクタおよび `Initialize()` の signature (refman より):
+
+```cpp
+ShapeUpgrade_UnifySameDomain(const TopoDS_Shape& aShape,
+                             const Standard_Boolean UnifyEdges      = Standard_True,
+                             const Standard_Boolean UnifyFaces      = Standard_True,
+                             const Standard_Boolean ConcatBSplines  = Standard_False);
+
+void Initialize(const TopoDS_Shape& aShape, /* ... */);
+```
+
+→ 入力は `const TopoDS_Shape&` で受ける。所有権は呼び出し側が保持、consume しない。他の `BRepBuilderAPI_*` / `BRepAlgoAPI_*` / `BRepFilletAPI_*` と同じ参照受け取りの builder pattern。
+
+##### Build → Shape の 2 段階アクセサパターン
+
+> Constructor defining input shape and necessary flags. It does not perform unification.
+
+> 訳: コンストラクタは入力 shape と必要なフラグを定義する。unification は実行しない。
+
+> Initializes with a shape and necessary flags. It does not perform unification. If you intend to nullify the History place holder do it after initialization.
+
+> 訳: shape と必要なフラグで初期化する。unification は実行しない。History place holder を null にしたい場合は初期化後に行う。
+
+> Performs unification and builds the resulting shape. (`Build()`)
+
+> 訳: unification を実行し、結果 shape を build する。
+
+> Gives the resulting shape. (`Shape()`)
+
+> 訳: 結果 shape を返す。
+
+→ 他の builder 系と全く同じ「コンストラクタ/Initialize で参照を受け取り、Build() で計算し、Shape() で結果を取り出す」 3 段階パターン。
+
+##### 入力不変の保証 (明示)
+
+`SetSafeInputMode` の doc 記述がこの点で決定的：
+
+> Sets the flag defining the behavior of the algorithm regarding modification of input shape. If this flag is equal to True then the input (original) shape can't be modified during modification process. Default value is true.
+
+> 訳: 入力 shape の変更挙動を定義するフラグを設定する。このフラグが True なら、modification process 中に入力 (original) shape は変更されえない。デフォルト値は true。
+
+→ **デフォルトで入力は不変が保証される**。OCCT 自身が「フラグで変更可能性を選択できる」と書いていること自体、そもそも "input vs output" の 2 者として設計されている証拠。cadrum の wrapper は SafeInputMode を明示設定していないので、デフォルト true で input 不変のまま使っている。
+
+##### 履歴トラッキング
+
+> All the modifications of initial shape are recorded during unifying. Methods History are intended to: set a place holder for the history of modifications of sub-shapes of the initial shape; get the collected history.
+
+> 訳: unify 中に initial shape に対して発生した変更はすべて記録される。History メソッドは、initial shape の sub-shape の変更履歴のための place holder を設定し、収集された履歴を取得するためにある。
+
+cadrum の `clean_shape_full` (cpp/wrapper.cpp:1628) はこの `unifier.History()` を使って、merge 前後の face の `TShape*` 対応表を構築し、`colormap` の remapping に使っている (face が merge されても色が追従する仕組み)。
+
+##### 結論
+
+`ShapeUpgrade_UnifySameDomain` は **完全に builder 系と同じモデル**：
+
+| 項目 | 挙動 |
+|---|---|
+| 入力受け取り | `const TopoDS_Shape&` の参照 (consume しない) |
+| 計算フェーズ | `Build()` で別途実行 |
+| 結果取り出し | `Shape()` accessor で別 `TopoDS_Shape` を返す |
+| 入力不変 | `SetSafeInputMode` デフォルト true で保証 |
+| 履歴 | `History()` で入力 sub-shape → 出力 sub-shape の mapping 取得可 |
+
+したがって cadrum の `Solid::clean()` が `fn(&self) -> Result<Self>` で新 Solid を返すシグネチャは、OCCT 側の意図と完全に一致している。`BRepTools::Clean` のような in-place API とは別物。
+
+##### Meshing — **例外的に in-place 変更**
+
+**BRepMesh_IncrementalMesh**:
+<https://dev.opencascade.org/doc/refman/html/class_b_rep_mesh___incremental_mesh.html>
+
+> Builds the mesh of a shape with respect of their correctly triangulated parts.
+
+> 訳: shape のメッシュを、既に正しく triangulate されている部分を考慮して構築する。
+
+> Constructor. Automatically calls method Perform. Parameters theShape shape to be meshed.
+
+> 訳: コンストラクタ。Perform メソッドを自動的に呼び出す。パラメータ theShape: メッシュ化対象の shape。
+
+このクラスは **`Shape()` アクセサを持たない** — 生成された triangulation は入力 `TopoDS_Shape` の基底 TShape に直接 attach される。OCCT の中で **in-place 変更を行う代表的 API**。cadrum の `Mesh` 生成 (src/common/mesh.rs 経由) もこれに該当し、topology 自体は不変のまま triangulation (face に紐づく mesh) だけが lazy field として付加される。
+
+これが `BRepTools::Clean` の in-place 挙動 (triangulation cache 削除) と対になっている: `IncrementalMesh` で付けて、`Clean` で外す、どちらも topology は触らない。
+
+**注意: cadrum の `Solid::clean()` は `BRepTools::Clean` ではなく `ShapeUpgrade_UnifySameDomain` を使っている** (cpp/wrapper.cpp:531, 1630)。名前は似ているが:
+
+- `BRepTools::Clean`: **triangulation cache 削除の in-place 操作**。topology 不変。cadrum では現在**未使用**
+- `ShapeUpgrade_UnifySameDomain`: **geometry 簡約化** (隣接する同一 geometry の face を merge)。新 shape を build。cadrum の `Solid::clean()` はこれを wrap している
+
+`Solid::clean()` のシグネチャが `fn clean(&self) -> Result<Self>` で新 `Solid` を返すのは `UnifySameDomain` の挙動と整合する。将来 `BRepTools::Clean` 相当の triangulation クリア API を cadrum に追加する場合は `&mut self` で呼びたくなるが、OnceLock 設計との整合のためには**避けて、新 `Solid` 返却のシグネチャに統一する**のが安全 (triangulation を更新する理由で inner ハンドルを差し替えると、edge cache は unaffected だが sealed module の invariant が曖昧になる)。
+
+---
+
+#### まとめ: API 挙動の分類
+
+| 分類 | 代表 API | topology | triangulation / cache |
+|---|---|---|---|
+| **Builder 系 (新 shape 生成)** | `BRepBuilderAPI_*`, `BRepAlgoAPI_*`, `BRepFilletAPI_*`, `BRepOffsetAPI_*`, `BRepFeat_*`, `ShapeFix_*`, `ShapeUpgrade_*` | 入力不変、新 TShape を build | なし or 結果に新規構築 |
+| **Cheap move** | `TopoDS_Shape::Moved` | 入力の TShape 共有、Location 差分のみ | 入力と共有 |
+| **In-place (topology 不変)** | `BRepTools::Clean`, `BRepMesh_IncrementalMesh` | **同一 TShape** | **in-place で付加/削除** |
+| **Compound への要素追加** | `BRep_Builder::Add` | compound は入れ物のため in-place で子追加可能、SOLID には不可 | — |
+
+**cadrum の Edge cache (`OnceLock<Vec<Edge>>`) にとって重要な含意**:
+
+- Builder 系 (新 shape) は **必ず新 `Solid` を構築する** ので、`Solid::new(...)` 経由で `OnceLock::new()` になる。cache 整合性は自動維持。
+- Cheap move は現行 `translate` / `rotate` で既に使われており、同じく新 `Solid` を構築 (新 `TopoDS_Shape` handle を持つ) ので問題なし。
+- **In-place 系 (mesh 生成、clean) は既存 `Solid` の TShape を変えるが topology は不変** — Edge は topology の一部なので cache は有効なまま。問題なし。
+- 唯一の注意点は将来 `Solid` に **`&mut self` で `TopoDS_Shape` ハンドルを差し替える API** を追加する場合で、これは sealed core module pattern で型レベルに禁止すれば済む。
+
+---
+
+## 代表操作で何が起こるか
+
+| 操作 | 実装クラス | 既存 TShape | 新規作成 | 出典 |
+|---|---|---|---|---|
+| `fillet` | `BRepFilletAPI_MakeFillet` | 参照 (入力として) | 新 TShape を build | OCCT refman: [BRepFilletAPI_MakeFillet](https://dev.opencascade.org/doc/refman/html/class_b_rep_fillet_a_p_i___make_fillet.html) |
+| boolean (`union`/`subtract`/...) | `BRepAlgoAPI_Fuse/Cut/Common` | 入力として参照、可能なら sub-shape を reuse | 新 top-level TShape | OCCT refman: [BRepAlgoAPI_BooleanOperation](https://dev.opencascade.org/doc/refman/html/class_b_rep_algo_a_p_i___boolean_operation.html) |
+| transform (通常) | `BRepBuilderAPI_Transform(copy=true)` | 参照 | 新 TShape | OCCT refman: [BRepBuilderAPI_Transform](https://dev.opencascade.org/doc/refman/html/class_b_rep_builder_a_p_i___transform.html) / `BRepBuilderAPI_Transform.cxx:48-49` (myUseModif branch) |
+| transform (cheap) | `TopoDS_Shape::Moved(TopLoc_Location)` | **共有** | Location だけ更新、新 TShape 作らず | OCCT refman: [TopoDS_Shape::Moved](https://dev.opencascade.org/doc/refman/html/class_topo_d_s___shape.html#ad1c84b3d57bde1fb5c31627540ba2d80) |
+| `Solid::clean` (cadrum) | `ShapeUpgrade_UnifySameDomain` | 入力参照、face merge で新 TShape | 新 shape を `Shape()` で取得 | OCCT refman: [ShapeUpgrade_UnifySameDomain](https://dev.opencascade.org/doc/refman/html/class_shape_upgrade___unify_same_domain.html) |
+| `BRepTools::Clean` (cadrum では未使用) | `BRepTools::Clean` | **同一 TShape を in-place** | triangulation cache 削除のみ、topology 不変 | OCCT refman: [BRepTools::Clean](https://dev.opencascade.org/doc/refman/html/class_b_rep_tools.html#af3f8f2e35b4fe41f8676f5cf0586b9eb) |
+| edge 追加 (compound) | `BRep_Builder::Add` | **同一 TShape を in-place 拡張** | なし | OCCT refman: [BRep_Builder::Add](https://dev.opencascade.org/doc/refman/html/class_b_rep___builder.html) |
+
+### ポイント
+
+- **`fillet`, boolean, 通常 transform**: 新 shape が必ず build される。元の shape はそのまま残る (ref count で共有継続、GC されない)。`TopoDS_Shape*` の同一性は保たれない。
+- **compound への edge 追加** (`BRep_Builder::Add(compound, edge)`): 同一 TShape を拡張する。ただしこれは compound (複数 solid/edge の入れ物) 専用の操作で、**SOLID の topology 拡張ではない**。SOLID に edge を足すような API は OCCT に存在しない (形状変更は全て re-build)。
+- **cheap transform (`Moved`)**: TShape 共有のまま Location を変える。O(1)。ただし Location は scale != 1 または negative determinant を拒否するため scale/mirror では使えない (OCCT 7.6 以降、Fix 0027457)。
+
+---
+
+## cadrum での実装確認
+
+### `translate` / `rotate` は cheap transform
+
+```cpp
+// cpp/wrapper.cpp:547 (translate_shape)
+return std::make_unique<TopoDS_Shape>(shape.Moved(TopLoc_Location(trsf)));
+
+// cpp/wrapper.cpp:559 (rotate_shape)
+return std::make_unique<TopoDS_Shape>(shape.Moved(TopLoc_Location(trsf)));
+```
+
+O(1) の cheap transform。TShape は共有される。
+
+### `scale` / `mirror` は BRepBuilderAPI_Transform
+
+```cpp
+// cpp/wrapper.cpp:573 (scale_shape)
+BRepBuilderAPI_Transform transform(shape, trsf, true);
+return std::make_unique<TopoDS_Shape>(transform.Shape());
+
+// cpp/wrapper.cpp:588 (mirror_shape)
+BRepBuilderAPI_Transform transform(shape, trsf, true);
+return std::make_unique<TopoDS_Shape>(transform.Shape());
+```
+
+Rust 側コメント (src/occt/solid.rs:335-343) で理由が文書化されている:
+
+> scale/mirror cannot use Moved(): since OCCT Fix 0027457 (v7.6), TopLoc_Location
+> rejects gp_Trsf with scale != 1 or negative determinant, because downstream
+> algorithms (meshing, booleans) break on non-rigid transforms in locations.
+> Therefore BRepBuilderAPI_Transform is required, which rebuilds topology.
+>
+> See: https://dev.opencascade.org/content/how-scale-or-mirror-shape
+>      BRepBuilderAPI_Transform.cxx:48-49 (myUseModif branch)
+
+### 現行 Rust API の shape
+
+全 topology 変更系メソッドが `fn(self) -> Self` または `fn(&self) -> Result<Self>` で **self 消費または新 Solid 生成**。`&mut self` で `inner: UniquePtr<TopoDS_Shape>` を差し替える API は存在しない (src/occt/solid.rs の全シグネチャで確認済み、2026-04-20 時点)。
+
+---
+
+## 設計含意
+
+### deep copy (BRepBuilderAPI_Copy) は必須ではない
+
+OCCT の `BRepAlgoAPI_Fuse` 等は「入力の TShape を壊さず、新 TShape を build する」設計なので、入力 shape を別所で保持していても安全。明示的に `BRepBuilderAPI_Copy` を呼ぶ必要があるのは:
+
+- マルチスレッドで同じ shape を並列編集する場合 (OCCT は TShape の書き込みを内部でしない前提だが、triangulation cache のような lazy field があるので安全側に寄せる)
+- 入力 shape の Location / Orientation を別の派生 shape と独立に扱いたい場合
+
+cadrum が期待するふつうの CAD パイプラインでは不要。
+
+### Rust `Solid` の immutability と OCCT モデルは整合
+
+| 側 | 不変量 |
+|---|---|
+| OCCT | topology 変更 = 新 `TopoDS_Shape` 返却。既存 TShape は in-place 変更できない |
+| cadrum `Solid` | topology 変更 = 新 `Solid` 返却。既存インスタンスは immutable |
+
+同じ形をしているため、Rust 側で `inner` フィールドを sealed module に閉じ込めて `&mut self` 経由の差し替え路を塞いでも、実装上困らない。
+
+### edge cache (`OnceLock<Vec<Edge>>`) の妥当性
+
+`translate` / `rotate` が cheap `Moved()` を使うため、**eager な Vec<Edge> cache を持たせると OCCT の O(1) transform が Rust 側の O(N) edge 再探索で劣化する**。`OnceLock::new()` の lazy cache なら:
+
+1. OCCT: `Moved()` O(1)
+2. Rust: 新 Solid 構築時 `OnceLock::new()` のみ → O(1)
+3. 最終的に `iter_edge()` が呼ばれた時点で初めて O(N) を一回だけ払う
+
+`a.translate(...).rotate_z(...).translate(...)` のような chain で中間 solid を使わない場合、eager は中間で 2N edge の無駄生成、lazy はゼロ。
+
+### Location 変更で cache は古くなる (重要)
+
+`TopExp_Explorer` が子 edge を作る時、親 shape の Location を合成して `TopoDS_Edge` を構築する。shape A (Location L1) から explore して得た Edge は L1 を内部に焼き込んでいる。shape を `Moved(L_Δ)` で更新した場合、cache の Edge は古い L1 を持ち続けるため、新 shape の edge として使うと Location がズレる (fillet 対象指定、`approximation_segments` の world 座標、全て不整合)。
+
+cadrum の現行 API は `translate` が `self` を消費して新 Solid を返す設計なので、自動的に cache も新規化される (新 Solid は `OnceLock::new()` を持つ)。**この設計を壊す** (例: `&mut self` で inner を差し替える API を追加) **と cache 不整合が発生する**点は sealed module 化の動機として重要。
+
+---
+
+## 将来のリスクと対処
+
+### リスク 1: `&mut self` で inner を差し替える API を追加してしまう
+
+sealed module pattern (inner を完全 private、`Solid::new` と read-only getter のみ公開) で型レベルに防ぐ。詳細は issue #102 の safety model セクション、および cache 設計議論のメモを参照。
+
+### リスク 2: cheap transform in-place 最適化
+
+将来 `apply_location_inplace(&mut self, trsf)` のような `Moved()` を in-place 適用する最適化を入れたくなるかもしれないが、cache があると **Edge の Location が古いまま取り残される**ので必ず `OnceLock::new()` で reset が必要。sealed core module 内にその helper を限定すれば invariant は維持可能。
+
+### リスク 3: マルチスレッドでの TShape 共有
+
+OCCT の `TopoDS_Shape` は shallow copy (ref count++) で、複数 Rust `Solid` インスタンスが同一 TShape を共有する可能性がある (boolean 結果の sub-solid など)。read-only なので race は起きないが、`triangulation` などの lazy field を触る操作は同期必要。cadrum では `LOFT_LOCK: Mutex<()>` (src/occt/solid.rs:17) で loft の global state を守っているのと同じ思想。edge 探索 (`TopExp_Explorer`) は read-only なのでロック不要。
+
+---
+
+## 参考リンク
+
+- OCCT 公式 Reference Manual: https://dev.opencascade.org/doc/refman/html/
+- OCCT User Guide (Modeling Data): https://dev.opencascade.org/doc/overview/html/occt_user_guides__modeling_data.html
+- scale/mirror で Location が使えない背景: https://dev.opencascade.org/content/how-scale-or-mirror-shape
+- OCCT Fix 0027457 (TopLoc_Location の scale rejection): https://tracker.dev.opencascade.org/view.php?id=27457
+- cadrum 関連箇所:
+  - `cpp/wrapper.cpp:541-593` — transform_shape / rotate_shape / scale_shape / mirror_shape
+  - `src/occt/solid.rs:316-366` — Transform trait 実装
+  - `src/occt/solid.rs:335-343` — scale/mirror で Moved を使えない理由の inline コメント


### PR DESCRIPTION
## Summary

- OCCT の主要 API (`BRepBuilderAPI_*` / `BRepAlgoAPI_*` / `BRepFilletAPI_*` / `BRepOffsetAPI_*` / `ShapeFix_*` / `ShapeUpgrade_*` / `BRepFeat_*`) が「入力参照 + 新 shape 構築」モデルであることを refman 原文引用 + 日本語訳で整理
- cadrum の `Solid::clean()` が wrap する `ShapeUpgrade_UnifySameDomain` の `SetSafeInputMode` デフォルト挙動 (入力不変) を詳細引用で裏取り
- `translate` / `rotate` の cheap `Moved()` (TShape 共有) と `scale` / `mirror` の `BRepBuilderAPI_Transform` (新 TShape 構築) の違いを、cadrum 側実装 (`cpp/wrapper.cpp:541-593`) と OCCT Fix 0027457 まで遡って記録
- `BRepMesh_IncrementalMesh` (triangulation in-place 付加) と `BRepTools::Clean` (in-place 削除、cadrum 未使用) が topology 不変の in-place 例外であることを明記

## Context

issue #102 (`Edge` を view 型に再設計して `Solid::iter_edge(&self) -> impl Iterator<Item = &Edge>` を実現する) の議論で、`Solid` に `OnceLock<Vec<Edge>>` などの edge cache を持たせる設計の妥当性を判断するために、OCCT 側の topology 変更 API の挙動を整理する必要が生じた。

結論として **OCCT は topology の in-place 変更を API レベルで提供していない** ため、Rust 側で「構築後 immutable」の invariant を型レベル (sealed core module pattern) に固めても実装上の踏み抜きは発生しない — この判断の根拠資料として notes に残す。

## Test plan

- [x] コード変更なし (notes/ に markdown 追加のみ)
- [x] 既存 notes の命名規約 `YYYYMMDD-日本語タイトル.md` (AGENTS.md) に準拠
- [x] 全引用に日本語訳を併記
- [x] OCCT refman へのリンクと cadrum 該当箇所 (`cpp/wrapper.cpp` / `src/occt/solid.rs` 行番号) を相互参照

🤖 Generated with [Claude Code](https://claude.com/claude-code)