### PR TITLE
fix: drop x86_64-pc-windows-msvc from docs.rs targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,6 @@ walkdir = "2"
 # source-build only: build OCCT from upstream sources
 cmake = { version = "0.1", optional = true }
 
-[package.metadata.docs.rs]
-targets = ["x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu"]
-rustdoc-args = ["--cfg", "docsrs"]
-
 # Examples that depend on the `color` feature. Cargo will skip building these
 # under `--no-default-features`. Examples without a `[[example]]` entry
 # (02_write_read, markdown) build under all feature configurations.


### PR DESCRIPTION
## Summary

`Cargo.toml` の `[package.metadata.docs.rs]` セクションを丸ごと削除:

- `targets = ["x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu"]` — docs.rs は Linux コンテナ上で動作するため MSVC クロスビルド不可 (lib.exe が無い)
- `rustdoc-args = ["--cfg", "docsrs"]` — ソース内に `docsrs` cfg を参照する箇所がゼロで dead config

## Root cause (targets 側)

失敗ログ: https://docs.rs/crate/cadrum/latest/builds/3152925

```
error occurred in cc-rs: failed to find tool "lib.exe": No such file or directory (os error 2)
```

MSVC は Linux からクロスコンパイル不可能な toolchain で、docs.rs 環境の本質的制約。デフォルト (linux-gnu) のみに戻す。

## Test plan

- [ ] マージ後 docs.rs の再ビルドが成功することを確認 (Linux ターゲットのみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)