### PR TITLE
feat(shell): support empty open_faces as sealed internal void

### DIFF
--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -59,6 +59,7 @@
 #include <BRepTools_History.hxx>
 
 // --- Sweep / pipe / loft ---
+#include <BRepOffsetAPI_MakeOffsetShape.hxx>
 #include <BRepOffsetAPI_MakePipeShell.hxx>
 #include <BRepOffsetAPI_MakeThickSolid.hxx>
 #include <BRepOffsetAPI_ThruSections.hxx>
@@ -1122,6 +1123,46 @@ std::unique_ptr<TopoDS_Shape> make_thick_solid(
     double thickness)
 {
     try {
+        // Empty open_faces: MakeThickSolidByJoin degenerates to a plain offset
+        // shape (no cavity) because it needs at least one removed face to
+        // build the first wall W1. Instead, build the solid explicitly as
+        // outer_shell + reversed inner_shell so the result is a sealed solid
+        // with an internal void (OCCT permits multi-shell solids).
+        if (open_faces.empty()) {
+            BRepOffsetAPI_MakeOffsetShape offset;
+            offset.PerformByJoin(
+                solid, thickness,
+                /*tolerance=*/ 1.0e-6,
+                /*mode=*/ BRepOffset_Skin,
+                /*intersection=*/ false,
+                /*selfInter=*/ false,
+                /*join=*/ GeomAbs_Arc);
+            if (!offset.IsDone()) return nullptr;
+            TopoDS_Shape offset_shape = offset.Shape();
+
+            auto extract_shell = [](const TopoDS_Shape& s) -> TopoDS_Shell {
+                if (s.ShapeType() == TopAbs_SHELL) return TopoDS::Shell(s);
+                TopExp_Explorer ex(s, TopAbs_SHELL);
+                if (!ex.More()) return TopoDS_Shell();
+                return TopoDS::Shell(ex.Current());
+            };
+
+            TopoDS_Shell original_shell = extract_shell(solid);
+            TopoDS_Shell offset_shell = extract_shell(offset_shape);
+            if (original_shell.IsNull() || offset_shell.IsNull()) return nullptr;
+
+            // thickness sign determines which shell is outer:
+            //   negative → offset shrinks inward: original = outer, offset = inner cavity
+            //   positive → offset expands outward: offset = outer, original = inner cavity
+            TopoDS_Shell outer = thickness < 0.0 ? original_shell : offset_shell;
+            TopoDS_Shell inner = thickness < 0.0 ? offset_shell : original_shell;
+
+            BRepBuilderAPI_MakeSolid solid_maker(outer);
+            solid_maker.Add(TopoDS::Shell(inner.Reversed()));
+            if (!solid_maker.IsDone()) return nullptr;
+            return std::make_unique<TopoDS_Shape>(solid_maker.Solid());
+        }
+
         NCollection_List<TopoDS_Shape> faces_to_remove;
         for (const auto& f : open_faces) faces_to_remove.Append(f);
 

--- a/examples/08_shell.rs
+++ b/examples/08_shell.rs
@@ -1,5 +1,7 @@
 //! Demo of `Solid::shell`:
 //! - Cube: remove top face, offset inward → open-top container
+//! - Sealed cube: empty open_faces → solid with an internal void (outer skin
+//!   + reversed inner shell)
 //! - Torus: bisect with a half-space to introduce planar cut faces, then
 //!   shell using those cut faces as the openings → thin-walled half-ring
 //!   with both cross-sections exposed
@@ -11,6 +13,11 @@ fn hollow_cube() -> Result<Solid, Error> {
 	// TopExp_Explorer order on a box is stable; +Z face ends up last.
 	let top = cube.iter_face().last().expect("cube has faces");
 	cube.shell(-1.0, [top])
+}
+
+fn sealed_cube() -> Result<Solid, Error> {
+	let cube = Solid::cube(8.0, 8.0, 8.0);
+	cube.shell(-1.0, std::iter::empty::<&cadrum::Face>())
 }
 
 fn halved_shelled_torus(thickness: f64) -> Result<Solid, Error> {
@@ -30,6 +37,7 @@ fn main() -> Result<(), Error> {
 
 	let result = [
 		hollow_cube()?.color("#d0a878"),
+		sealed_cube()?.color("#6fbf73").translate(DVec3::Y * 10.0),
 		halved_shelled_torus(1.0)?.color("#ff5e00").translate(DVec3::X * 18.0),
 		halved_shelled_torus(-1.0)?.color("#0052ff").translate(DVec3::X * 18.0 + DVec3::Y * 10.0),
 	];

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -450,6 +450,12 @@ pub trait SolidStruct: Sized + Clone + Compound {
 	/// enclosing the original as its inner boundary).
 	///
 	/// `open_faces` must be faces of `self` (e.g. selected via `self.iter_face()`).
+	/// When `open_faces` is empty, `BRepOffsetAPI_MakeThickSolid` degenerates to
+	/// a plain offset shape (no cavity) because it needs at least one removed
+	/// face to build the inner wall. The wrapper detects this and falls back to
+	/// `BRepOffsetAPI_MakeOffsetShape` + `BRepBuilderAPI_MakeSolid`, assembling
+	/// an outer shell and a reversed inner shell into a sealed multi-shell
+	/// solid with an internal void (the void is inaccessible from outside).
 	/// Fails on OCCT rejection (self-intersecting offset at sharp corners, etc).
 	fn shell<'a>(&self, thickness: f64, open_faces: impl IntoIterator<Item = &'a Self::Face>) -> Result<Self, Error> where Self::Face: 'a;
 

--- a/tests/shell.rs
+++ b/tests/shell.rs
@@ -31,3 +31,32 @@ fn test_shell_outward_produces_wall() {
 	assert_eq!(shell.shell_count(), 1);
 }
 
+#[test]
+fn test_shell_empty_open_faces_inward_seals_cavity() {
+	let cube = Solid::cube(10.0, 10.0, 10.0);
+	// Negative thickness + empty open_faces: sealed solid with an internal void.
+	// Expected wall-material volume = 10³ − 9³ = 271.
+	let sealed = cube.shell(-0.5, std::iter::empty::<&cadrum::Face>()).expect("inward empty-open shell should succeed");
+	assert_eq!(sealed.shell_count(), 2, "outer + reversed inner shell");
+	assert!((sealed.volume() - 271.0).abs() < 1e-3, "inward empty shell volume = 10³ − 9³, got {}", sealed.volume());
+}
+
+#[test]
+fn test_shell_empty_open_faces_outward_seals_cavity() {
+	let cube = Solid::cube(10.0, 10.0, 10.0);
+	// Positive thickness + empty open_faces: outer shell expands outward with
+	// GeomAbs_Arc join (spheres at corners, quarter-cylinders along edges),
+	// original surface becomes the internal cavity wall.
+	// Outer offset volume = 10³ + 6·(10²·0.5) [face slabs]
+	//                     + 12·(π·0.5²·10/4) [quarter-cylinder edges]
+	//                     + 8·((4/3)π·0.5³/8) [sphere-octant corners]
+	//                   = 1000 + 300 + 7.5π/4·... = 1000 + 300 + 7.5π + π/6.
+	// Wait: quarter-cyl vol per edge = π·r²·L/4 = π·0.25·10/4 = 0.625π; 12 edges = 7.5π.
+	// Sphere-octant per corner = (4/3)π·0.5³/8 = π/48; 8 corners = π/6.
+	// Shell material = 300 + 7.5π + π/6 ≈ 324.086.
+	let sealed = cube.shell(0.5, std::iter::empty::<&cadrum::Face>()).expect("outward empty-open shell should succeed");
+	assert_eq!(sealed.shell_count(), 2, "outer + reversed inner shell");
+	let expected = 300.0 + 7.5 * std::f64::consts::PI + std::f64::consts::PI / 6.0;
+	assert!((sealed.volume() - expected).abs() < 1e-3, "outward empty shell volume ≈ {expected:.3}, got {}", sealed.volume());
+}
+


### PR DESCRIPTION
## Summary
- `Solid::shell` に空 `open_faces` を渡したとき、OCCT `BRepOffsetAPI_MakeThickSolid` が「削除面が無いと W1 が作れない」仕様で縮退し、穴のないただのオフセットソリッドになっていた問題を修正。
- 空リスト時は `BRepOffsetAPI_MakeOffsetShape` + `BRepBuilderAPI_MakeSolid` で外殻 + 反転内殻を組み立て、OCCT が許容する「外殻と内部空洞を持つ多シェルソリッド」を生成する。
- `thickness` の符号で外殻/内殻の役割を入れ替え（負 → 元形状が外殻、正 → オフセット側が外殻）。

## Changes
- `cpp/wrapper.cpp`: `make_thick_solid` に空リスト分岐を追加、`BRepOffsetAPI_MakeOffsetShape.hxx` を include。
- `src/traits.rs`: `shell` の docstring に空リスト時のフォールバック挙動を追記。
- `tests/shell.rs`: 空リストの inward / outward を検証するテストを追加（outward は `GeomAbs_Arc` によるコーナー丸めを考慮した期待体積 `300 + 7.5π + π/6`）。
- `examples/08_shell.rs`: 緑の `sealed_cube`（空リストで密閉空洞を作成）を `Y*10` に配置。

## Test plan
- [x] `cargo test --test shell` — 5/5 passing
- [x] `cargo run --example 08_shell` — STEP / SVG 生成を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)