### PR TITLE
fix(build): docs.rs build failure — generate delegation before DOCS_RS guard

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -23,12 +23,12 @@ fn main() {
 	println!("cargo:rerun-if-changed=src/traits.rs");
 	println!("cargo:rerun-if-changed=build_delegation.rs");
 
+	let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+	build_delegation::build_delegation(include_str!("src/traits.rs"), &out_dir);
+
 	if env::var("DOCS_RS").is_ok() {
 		return;
 	}
-
-	let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-	build_delegation::build_delegation(include_str!("src/traits.rs"), &out_dir);
 
 	let target = env::var("TARGET").unwrap();
 

--- a/examples/08_shell.rs
+++ b/examples/08_shell.rs
@@ -48,7 +48,7 @@ fn main() -> Result<(), Error> {
 	// Isometric view from (1, 1, 2) with shading so the cavity depth reads
 	// naturally.
 	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-	cadrum::mesh(&result, 0.2).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), false, true, &mut f)).expect("failed to write SVG");
+	cadrum::mesh(&result, 0.2).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), true, true, &mut f)).expect("failed to write SVG");
 
 	println!("wrote {example_name}.step / {example_name}.svg");
 	Ok(())


### PR DESCRIPTION
## Summary
- `src/lib.rs` unconditionally `include!`s `$OUT_DIR/generated_delegation.rs`, but build.rs returned on `DOCS_RS` before calling `build_delegation`. On docs.rs the include target never existed, so rustdoc failed with *No such file or directory*（#110 の docs.rs ビルドログ参照）.
- 修正は codegen 呼び出しを `DOCS_RS` 早期 return より前に移すだけ。純 Rust の文字列生成で OCCT 非依存なので docs.rs サンドボックスで動く。DOCS_RS guard 自体は OCCT tarball DL と静的リンクをスキップするため引き続き必要（docs.rs はビルドスクリプト内のネットワークを遮断している）。
- 併せて `examples/08_shell.rs` の SVG 出力で hidden lines を有効化。

Closes #110

## Test plan
- [x] `cargo check` passes locally
- [ ] docs.rs rebuild succeeds on next release
- [ ] `cargo run --example 08_shell` で生成された SVG の隠れ線表示を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)