### PR TITLE
feat(queries): shell_count を廃止し area/center/inertia を追加

### DIFF
--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -604,18 +604,51 @@ bool shape_is_solid(const TopoDS_Shape& shape) {
     return !shape.IsNull() && shape.ShapeType() == TopAbs_SOLID;
 }
 
-uint32_t shape_shell_count(const TopoDS_Shape& shape) {
-    uint32_t count = 0;
-    for (TopExp_Explorer ex(shape, TopAbs_SHELL); ex.More(); ex.Next()) {
-        ++count;
-    }
-    return count;
-}
-
 double shape_volume(const TopoDS_Shape& shape) {
     GProp_GProps props;
     BRepGProp::VolumeProperties(shape, props);
     return props.Mass();
+}
+
+double shape_surface_area(const TopoDS_Shape& shape) {
+    GProp_GProps props;
+    BRepGProp::SurfaceProperties(shape, props);
+    return props.Mass();
+}
+
+void shape_center_of_mass(const TopoDS_Shape& shape,
+    double& x, double& y, double& z)
+{
+    GProp_GProps props;
+    BRepGProp::VolumeProperties(shape, props);
+    gp_Pnt com = props.CentreOfMass();
+    x = com.X(); y = com.Y(); z = com.Z();
+}
+
+void shape_inertia_tensor(const TopoDS_Shape& shape,
+    double& m00, double& m01, double& m02,
+    double& m10, double& m11, double& m12,
+    double& m20, double& m21, double& m22)
+{
+    // OCCT's MatrixOfInertia() is expressed about the center of mass, but the
+    // Rust-side API returns the tensor about the world origin so collections
+    // can aggregate by plain matrix sum (parallel-axis theorem is already
+    // folded in). Shift here with I_world = I_com + m·(|d|² I - d⊗d),
+    // where d = COM vector from world origin, m = volume (uniform density).
+    GProp_GProps props;
+    BRepGProp::VolumeProperties(shape, props);
+    gp_Mat ic = props.MatrixOfInertia();
+    gp_Pnt com = props.CentreOfMass();
+    double mass = props.Mass();
+    double dx = com.X(), dy = com.Y(), dz = com.Z();
+    double d2 = dx*dx + dy*dy + dz*dz;
+    m00 = ic.Value(1,1) + mass * (d2 - dx*dx);
+    m11 = ic.Value(2,2) + mass * (d2 - dy*dy);
+    m22 = ic.Value(3,3) + mass * (d2 - dz*dz);
+    m01 = ic.Value(1,2) - mass * dx * dy;
+    m02 = ic.Value(1,3) - mass * dx * dz;
+    m12 = ic.Value(2,3) - mass * dy * dz;
+    m10 = m01; m20 = m02; m21 = m12;
 }
 
 bool shape_contains_point(const TopoDS_Shape& shape, double x, double y, double z) {

--- a/cpp/wrapper.h
+++ b/cpp/wrapper.h
@@ -166,8 +166,14 @@ std::unique_ptr<TopoDS_Shape> mirror_shape(
     double nx, double ny, double nz);
 bool shape_is_null(const TopoDS_Shape& shape);
 bool shape_is_solid(const TopoDS_Shape& shape);
-uint32_t shape_shell_count(const TopoDS_Shape& shape);
 double shape_volume(const TopoDS_Shape& shape);
+double shape_surface_area(const TopoDS_Shape& shape);
+void shape_center_of_mass(const TopoDS_Shape& shape,
+    double& x, double& y, double& z);
+void shape_inertia_tensor(const TopoDS_Shape& shape,
+    double& m00, double& m01, double& m02,
+    double& m10, double& m11, double& m12,
+    double& m20, double& m21, double& m22);
 bool shape_contains_point(const TopoDS_Shape& shape, double x, double y, double z);
 void shape_bounding_box(const TopoDS_Shape& shape,
     double& xmin, double& ymin, double& zmin,

--- a/src/occt/ffi.rs
+++ b/src/occt/ffi.rs
@@ -120,8 +120,10 @@ mod ffi_bridge {
 
 		fn shape_is_null(shape: &TopoDS_Shape) -> bool;
 		fn shape_is_solid(shape: &TopoDS_Shape) -> bool;
-		fn shape_shell_count(shape: &TopoDS_Shape) -> u32;
 		fn shape_volume(shape: &TopoDS_Shape) -> f64;
+		fn shape_surface_area(shape: &TopoDS_Shape) -> f64;
+		fn shape_center_of_mass(shape: &TopoDS_Shape, x: &mut f64, y: &mut f64, z: &mut f64);
+		fn shape_inertia_tensor(shape: &TopoDS_Shape, m00: &mut f64, m01: &mut f64, m02: &mut f64, m10: &mut f64, m11: &mut f64, m12: &mut f64, m20: &mut f64, m21: &mut f64, m22: &mut f64);
 		fn shape_contains_point(shape: &TopoDS_Shape, x: f64, y: f64, z: f64) -> bool;
 		fn shape_bounding_box(shape: &TopoDS_Shape, xmin: &mut f64, ymin: &mut f64, zmin: &mut f64, xmax: &mut f64, ymax: &mut f64, zmax: &mut f64);
 

--- a/src/occt/solid.rs
+++ b/src/occt/solid.rs
@@ -456,8 +456,31 @@ impl Compound for Solid {
 		ffi::shape_volume(&self.inner)
 	}
 
-	fn shell_count(&self) -> u32 {
-		ffi::shape_shell_count(&self.inner)
+	fn area(&self) -> f64 {
+		ffi::shape_surface_area(&self.inner)
+	}
+
+	fn center(&self) -> DVec3 {
+		let (mut x, mut y, mut z) = (0.0_f64, 0.0_f64, 0.0_f64);
+		ffi::shape_center_of_mass(&self.inner, &mut x, &mut y, &mut z);
+		DVec3::new(x, y, z)
+	}
+
+	fn inertia(&self) -> glam::DMat3 {
+		let (mut m00, mut m01, mut m02) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut m10, mut m11, mut m12) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut m20, mut m21, mut m22) = (0.0_f64, 0.0_f64, 0.0_f64);
+		ffi::shape_inertia_tensor(&self.inner,
+			&mut m00, &mut m01, &mut m02,
+			&mut m10, &mut m11, &mut m12,
+			&mut m20, &mut m21, &mut m22);
+		// OCCT fills row-major; DMat3::from_cols_array is column-major so
+		// transpose when handing the components over.
+		glam::DMat3::from_cols_array(&[
+			m00, m10, m20,
+			m01, m11, m21,
+			m02, m12, m22,
+		])
 	}
 
 	fn contains(&self, point: DVec3) -> bool {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -544,7 +544,16 @@ pub trait Compound: Transform {
 	fn volume(&self) -> f64;
 	fn bounding_box(&self) -> [DVec3; 2];
 	fn contains(&self, point: DVec3) -> bool;
-	fn shell_count(&self) -> u32;
+	/// Total surface area. Aggregates as a simple sum across elements.
+	fn area(&self) -> f64;
+	/// Center of mass (uniform density). Aggregates as a volume-weighted
+	/// average of per-element centers: `Σ(vol_i · center_i) / Σ vol_i`.
+	fn center(&self) -> DVec3;
+	/// Inertia tensor about the **world origin** (uniform density).
+	/// World-origin referencing makes aggregation a straight matrix sum
+	/// (parallel-axis theorem is already folded in). Translate to the
+	/// center-of-mass frame manually if needed.
+	fn inertia(&self) -> DMat3;
 
 	// --- Color ---
 	#[cfg(feature = "color")]
@@ -583,7 +592,13 @@ impl<T: SolidStruct> Compound for Vec<T> {
 			.unwrap_or([DVec3::ZERO, DVec3::ZERO])
 	}
 	fn contains(&self, p: DVec3) -> bool { self.iter().any(|s| s.contains(p)) }
-	fn shell_count(&self) -> u32 { self.iter().map(|s| s.shell_count()).sum() }
+	fn area(&self) -> f64 { self.iter().map(|s| s.area()).sum() }
+	fn center(&self) -> DVec3 {
+		let total_vol: f64 = self.iter().map(|s| s.volume()).sum();
+		if total_vol == 0.0 { return DVec3::ZERO; }
+		self.iter().map(|s| s.center() * s.volume()).sum::<DVec3>() / total_vol
+	}
+	fn inertia(&self) -> DMat3 { self.iter().map(|s| s.inertia()).fold(DMat3::ZERO, |a, b| a + b) }
 	#[cfg(feature = "color")]
 	fn color(self, color: impl Into<Color>) -> Self {
 		let c: Color = color.into();
@@ -626,7 +641,13 @@ impl<T: SolidStruct, const N: usize> Compound for [T; N] {
 			.unwrap_or([DVec3::ZERO, DVec3::ZERO])
 	}
 	fn contains(&self, p: DVec3) -> bool { self.iter().any(|s| s.contains(p)) }
-	fn shell_count(&self) -> u32 { self.iter().map(|s| s.shell_count()).sum() }
+	fn area(&self) -> f64 { self.iter().map(|s| s.area()).sum() }
+	fn center(&self) -> DVec3 {
+		let total_vol: f64 = self.iter().map(|s| s.volume()).sum();
+		if total_vol == 0.0 { return DVec3::ZERO; }
+		self.iter().map(|s| s.center() * s.volume()).sum::<DVec3>() / total_vol
+	}
+	fn inertia(&self) -> DMat3 { self.iter().map(|s| s.inertia()).fold(DMat3::ZERO, |a, b| a + b) }
 	#[cfg(feature = "color")]
 	fn color(self, color: impl Into<Color>) -> Self {
 		let c: Color = color.into();

--- a/tests/bspline.rs
+++ b/tests/bspline.rs
@@ -98,7 +98,6 @@ fn test_bspline_01_two_period_torus_point_symmetry() {
 	});
 
 	let plasma = Solid::bspline(grid, true).expect("2-period bspline torus should succeed");
-	assert_eq!(plasma.shell_count(), 1);
 	assert!(plasma.volume() > 0.0);
 
 	assert_quadrant_point_symmetry(&plasma, 0.01);

--- a/tests/loft.rs
+++ b/tests/loft.rs
@@ -42,7 +42,6 @@ fn test_loft_01_frustum_volume_matches_analytical() {
 		"frustum volume {:.4} vs analytical {:.4} (relative error {:.4})",
 		actual, expected, rel_err
 	);
-	assert_eq!(frustum.shell_count(), 1);
 
 	write_outputs(std::slice::from_ref(&frustum), "test_loft_01_frustum_volume_matches_analytical");
 	println!("frustum loft: volume = {:.4} (expected {:.4})", actual, expected);
@@ -105,7 +104,6 @@ fn test_loft_04_closure_iterator_form() {
 
 	let plasma = Solid::loft(ribs.iter().map(|e| [e])).expect("closure-form loft should succeed");
 
-	assert_eq!(plasma.shell_count(), 1);
 	assert!(plasma.volume() > 0.0);
 
 	write_outputs(std::slice::from_ref(&plasma), "test_loft_05_closure_iterator_form");

--- a/tests/mass_properties.rs
+++ b/tests/mass_properties.rs
@@ -1,0 +1,122 @@
+//! Validate `area` / `center` / `inertia` queries against analytical solutions.
+//!
+//! OCCT computes properties with uniform density ρ = 1. The inertia tensor is
+//! returned about the world origin (not the center of mass), which makes
+//! aggregation over collections a straight matrix sum (parallel-axis theorem
+//! is already folded in).
+
+use cadrum::{Compound, Solid};
+use glam::DVec3;
+
+const EPS: f64 = 1e-6;
+
+/// Cube of side `a` with corner at the world origin, ρ = 1.
+/// Analytical values referenced throughout:
+///   volume = a³
+///   center = (a/2, a/2, a/2)
+///   area   = 6 a²
+///   I_xx = I_yy = I_zz = ∫(y² + z²) dV over [0,a]³ = 2 a⁵ / 3
+///   |I_xy| = |I_yz| = |I_zx| = a⁵ / 4  (sign depends on tensor sign convention)
+#[test]
+fn test_cube_mass_properties_match_analytical() {
+	let a = 10.0_f64;
+	let cube = Solid::cube(a, a, a);
+
+	assert!((cube.volume() - a.powi(3)).abs() < EPS);
+	assert!((cube.area() - 6.0 * a.powi(2)).abs() < EPS);
+	assert!((cube.center() - DVec3::splat(a / 2.0)).length() < EPS);
+
+	let i = cube.inertia();
+	let expected_diag = 2.0 * a.powi(5) / 3.0;
+	let expected_off = a.powi(5) / 4.0;
+	// Diagonals are positive and equal for a symmetric cube.
+	assert!((i.col(0).x - expected_diag).abs() < 1e-3, "I_xx = {}, expected {expected_diag}", i.col(0).x);
+	assert!((i.col(1).y - expected_diag).abs() < 1e-3, "I_yy = {}, expected {expected_diag}", i.col(1).y);
+	assert!((i.col(2).z - expected_diag).abs() < 1e-3, "I_zz = {}, expected {expected_diag}", i.col(2).z);
+	// Off-diagonals: magnitude only (sign depends on OCCT convention).
+	assert!((i.col(1).x.abs() - expected_off).abs() < 1e-3, "|I_xy| = {}, expected {expected_off}", i.col(1).x.abs());
+	assert!((i.col(2).y.abs() - expected_off).abs() < 1e-3, "|I_yz| = {}, expected {expected_off}", i.col(2).y.abs());
+	assert!((i.col(2).x.abs() - expected_off).abs() < 1e-3, "|I_zx| = {}, expected {expected_off}", i.col(2).x.abs());
+}
+
+/// Sphere of radius `r` centered at origin.
+///   volume = (4/3) π r³
+///   area   = 4 π r²
+///   center = 0
+///   I_diag = (2/5) m r² = (8/15) π r⁵  (sphere centered at origin → COM = origin)
+#[test]
+fn test_sphere_mass_properties_match_analytical() {
+	let r = 5.0_f64;
+	let sphere = Solid::sphere(r);
+
+	let pi = std::f64::consts::PI;
+	assert!((sphere.volume() - 4.0 / 3.0 * pi * r.powi(3)).abs() < 1e-2);
+	assert!((sphere.area() - 4.0 * pi * r.powi(2)).abs() < 1e-2);
+	assert!(sphere.center().length() < 1e-3, "sphere COM should be at origin, got {:?}", sphere.center());
+
+	let i = sphere.inertia();
+	let expected_diag = 8.0 / 15.0 * pi * r.powi(5);
+	assert!((i.col(0).x - expected_diag).abs() < 1e-1, "I_xx = {}, expected {expected_diag}", i.col(0).x);
+	assert!((i.col(1).y - expected_diag).abs() < 1e-1);
+	assert!((i.col(2).z - expected_diag).abs() < 1e-1);
+	// Off-diagonals should be ~0 for a sphere at origin.
+	assert!(i.col(1).x.abs() < 1e-3);
+	assert!(i.col(2).x.abs() < 1e-3);
+	assert!(i.col(2).y.abs() < 1e-3);
+}
+
+/// Aggregate of two identical cubes offset along +X. The collection's center
+/// of mass is the volume-weighted average of the per-cube centers; here both
+/// weights are equal so the result is the midpoint.
+#[test]
+fn test_vec_center_is_volume_weighted_average() {
+	let a = 2.0_f64;
+	let offset = 10.0_f64;
+	let cubes = vec![
+		Solid::cube(a, a, a),
+		Solid::cube(a, a, a).translate(DVec3::new(offset, 0.0, 0.0)),
+	];
+
+	let expected_center = DVec3::new((a / 2.0 + (a / 2.0 + offset)) / 2.0, a / 2.0, a / 2.0);
+	assert!(
+		(cubes.center() - expected_center).length() < EPS,
+		"aggregate center = {:?}, expected {expected_center:?}", cubes.center()
+	);
+	assert!((cubes.volume() - 2.0 * a.powi(3)).abs() < EPS);
+	assert!((cubes.area() - 2.0 * 6.0 * a.powi(2)).abs() < EPS);
+}
+
+/// World-origin inertia is additive: `inertia(Vec)` equals the sum of
+/// per-element `inertia()`. This is tautological for the current implementation
+/// but guards against someone "fixing" the aggregator to re-center to the
+/// collection's COM (which would break parallel-axis additivity).
+#[test]
+fn test_vec_inertia_equals_sum_of_elements() {
+	let cubes = vec![
+		Solid::cube(3.0, 3.0, 3.0),
+		Solid::cube(2.0, 2.0, 2.0).translate(DVec3::new(5.0, 0.0, 0.0)),
+		Solid::cube(4.0, 4.0, 4.0).translate(DVec3::new(0.0, 7.0, 0.0)),
+	];
+
+	let expected = cubes.iter().map(|c| c.inertia()).fold(glam::DMat3::ZERO, |a, b| a + b);
+	let actual = cubes.inertia();
+	for col in 0..3 {
+		for row in 0..3 {
+			assert!(
+				(actual.col(col)[row] - expected.col(col)[row]).abs() < 1e-9,
+				"inertia[{row}][{col}] = {}, expected {}", actual.col(col)[row], expected.col(col)[row]
+			);
+		}
+	}
+}
+
+/// Empty Vec returns zero/identity values without panicking. Exercises the
+/// zero-volume guard in `center()`.
+#[test]
+fn test_empty_vec_queries_do_not_panic() {
+	let empty: Vec<Solid> = vec![];
+	assert_eq!(empty.volume(), 0.0);
+	assert_eq!(empty.area(), 0.0);
+	assert_eq!(empty.center(), DVec3::ZERO);
+	assert_eq!(empty.inertia(), glam::DMat3::ZERO);
+}

--- a/tests/shape.rs
+++ b/tests/shape.rs
@@ -20,13 +20,6 @@ fn test_translated_preserves_volume() {
 }
 
 #[test]
-fn test_translated_preserves_shell_count() {
-	let shape = test_box();
-	let moved = shape.translate(dvec3(5.0, 0.0, 0.0));
-	assert_eq!(moved.shell_count(), 1);
-}
-
-#[test]
 fn test_union_of_translated_overlapping_solids_has_single_volume() {
 	// 異なる場所に同じ大きさの立方体を2つ作り、translatedで同じ場所に重ねてからunionする。
 	// 結果のvolumeは1つ分（1000）になるはず。
@@ -70,10 +63,10 @@ fn test_rotated_full_turn_preserves_volume() {
 }
 
 #[test]
-fn test_rotated_preserves_shell_count() {
+fn test_rotated_y_preserves_volume() {
 	let shape = test_box();
 	let rotated = shape.rotate_y(std::f64::consts::FRAC_PI_2);
-	assert_eq!(rotated.shell_count(), 1);
+	assert!((rotated.volume() - 1000.0).abs() < 1e-3);
 }
 
 // ==================== scale ====================
@@ -95,10 +88,11 @@ fn test_scale_half_volume() {
 }
 
 #[test]
-fn test_scale_preserves_shell_count() {
+fn test_scale_triple_volume() {
 	let shape = test_box();
+	// 3× uniform scale → volume × 27
 	let scaled = shape.scale(DVec3::ZERO, 3.0);
-	assert_eq!(scaled.shell_count(), 1);
+	assert!((scaled.volume() - 27_000.0).abs() < 1e-3);
 }
 
 // ==================== face id preservation ====================

--- a/tests/shell.rs
+++ b/tests/shell.rs
@@ -17,7 +17,7 @@ fn test_shell_cube_preserves_solid_structure() {
 	let cube = Solid::cube(10.0, 10.0, 10.0);
 	let open = cube.iter_face().next().unwrap();
 	let shelled = cube.shell(-0.5, [open]).expect("shell should succeed");
-	assert_eq!(shelled.shell_count(), 1, "shelled cube should remain a single shell");
+	assert!(shelled.volume() > 0.0, "shelled cube should produce a valid solid");
 }
 
 #[test]
@@ -28,7 +28,6 @@ fn test_shell_outward_produces_wall() {
 	// inner cavity of a 0.5-thick shell.
 	let shell = cube.shell(0.5, [open]).expect("shell outward should succeed");
 	assert!(shell.volume() > 0.0 && shell.volume() < 1000.0, "outer shell is wall material only, not the original cube");
-	assert_eq!(shell.shell_count(), 1);
 }
 
 #[test]
@@ -37,8 +36,7 @@ fn test_shell_empty_open_faces_inward_seals_cavity() {
 	// Negative thickness + empty open_faces: sealed solid with an internal void.
 	// Expected wall-material volume = 10³ − 9³ = 271.
 	let sealed = cube.shell(-0.5, std::iter::empty::<&cadrum::Face>()).expect("inward empty-open shell should succeed");
-	assert_eq!(sealed.shell_count(), 2, "outer + reversed inner shell");
-	assert!((sealed.volume() - 271.0).abs() < 1e-3, "inward empty shell volume = 10³ − 9³, got {}", sealed.volume());
+assert!((sealed.volume() - 271.0).abs() < 1e-3, "inward empty shell volume = 10³ − 9³, got {}", sealed.volume());
 }
 
 #[test]
@@ -55,8 +53,7 @@ fn test_shell_empty_open_faces_outward_seals_cavity() {
 	// Sphere-octant per corner = (4/3)π·0.5³/8 = π/48; 8 corners = π/6.
 	// Shell material = 300 + 7.5π + π/6 ≈ 324.086.
 	let sealed = cube.shell(0.5, std::iter::empty::<&cadrum::Face>()).expect("outward empty-open shell should succeed");
-	assert_eq!(sealed.shell_count(), 2, "outer + reversed inner shell");
-	let expected = 300.0 + 7.5 * std::f64::consts::PI + std::f64::consts::PI / 6.0;
+let expected = 300.0 + 7.5 * std::f64::consts::PI + std::f64::consts::PI / 6.0;
 	assert!((sealed.volume() - expected).abs() < 1e-3, "outward empty shell volume ≈ {expected:.3}, got {}", sealed.volume());
 }
 


### PR DESCRIPTION
## 概要
- `Compound` trait から `shell_count` を削除（コレクション全体のシェル数を合計しても実用的な意味が無かったため）。
- `Compound` に質量特性クエリを 3 本追加: `area()` / `center()` / `inertia()`。#113 を close する。
- `inertia()` は **世界原点基準** のテンソルを返す。そのため `Vec<T>` / `[T; N]` 上の集約は単純な行列和で正しい値になる（parallel-axis theorem は C++ wrapper 側で適用済み）。
- `center()` のコレクション集約は各要素 COM の体積重み付き平均、`area()` は単純和。
- OCCT の `MatrixOfInertia()` は COM 基準のテンソルを返すため、wrapper で `I_world = I_com + m·(|d|² I − d⊗d)` により原点基準へ変換している。

## テスト計画
- [x] `cargo test --test mass_properties` — 立方体/球の解析値照合、Vec の COM 体積重み平均、慣性テンソル加法性、空 Vec エッジケースの 5 テスト
- [x] `cargo test --test shape --test shell --test bspline --test loft` — 既存テストの `shell_count` 検証を volume 検証へ差し替えた後も全て green
- [x] `cargo build --no-default-features`
- [x] `cargo run --example 08_shell`

🤖 Generated with [Claude Code](https://claude.com/claude-code)