### PR TITLE
feat(fillet): Solid::fillet_edges を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Rust CAD library powered by statically linked, headless [OpenCASCADE](https://de
 | [<img src="https://lzpel.github.io/cadrum/01_primitives.svg" width="180" alt="primitives"/>](#primitives) | [<img src="https://lzpel.github.io/cadrum/02_write_read.svg" width="180" alt="write read"/>](#write-read) | [<img src="https://lzpel.github.io/cadrum/03_transform.svg" width="180" alt="transform"/>](#transform) | [<img src="https://lzpel.github.io/cadrum/04_boolean.svg" width="180" alt="boolean"/>](#boolean) |
 | [extrude](#extrude) | [loft](#loft) | [sweep](#sweep) | [shell](#shell) |
 | [<img src="https://lzpel.github.io/cadrum/05_extrude.svg" width="180" alt="extrude"/>](#extrude) | [<img src="https://lzpel.github.io/cadrum/06_loft.svg" width="180" alt="loft"/>](#loft) | [<img src="https://lzpel.github.io/cadrum/07_sweep.svg" width="180" alt="sweep"/>](#sweep) | [<img src="https://lzpel.github.io/cadrum/08_shell.svg" width="180" alt="shell"/>](#shell) |
-| [bspline](#bspline) |  |  |  |
-| [<img src="https://lzpel.github.io/cadrum/09_bspline.svg" width="180" alt="bspline"/>](#bspline) |  |  |  |
+| [bspline](#bspline) | [fillet](#fillet) |  |  |
+| [<img src="https://lzpel.github.io/cadrum/09_bspline.svg" width="180" alt="bspline"/>](#bspline) | [<img src="https://lzpel.github.io/cadrum/10_fillet.svg" width="180" alt="fillet"/>](#fillet) |  |  |
 
 More examples with source code are available at [lzpel.github.io/cadrum](https://lzpel.github.io/cadrum).
 
@@ -612,6 +612,8 @@ cargo run --example 08_shell
 ```rust
 //! Demo of `Solid::shell`:
 //! - Cube: remove top face, offset inward → open-top container
+//! - Sealed cube: empty open_faces → solid with an internal void (outer skin
+//!   + reversed inner shell)
 //! - Torus: bisect with a half-space to introduce planar cut faces, then
 //!   shell using those cut faces as the openings → thin-walled half-ring
 //!   with both cross-sections exposed
@@ -623,6 +625,11 @@ fn hollow_cube() -> Result<Solid, Error> {
 	// TopExp_Explorer order on a box is stable; +Z face ends up last.
 	let top = cube.iter_face().last().expect("cube has faces");
 	cube.shell(-1.0, [top])
+}
+
+fn sealed_cube() -> Result<Solid, Error> {
+	let cube = Solid::cube(8.0, 8.0, 8.0);
+	cube.shell(-1.0, std::iter::empty::<&cadrum::Face>())
 }
 
 fn halved_shelled_torus(thickness: f64) -> Result<Solid, Error> {
@@ -642,6 +649,7 @@ fn main() -> Result<(), Error> {
 
 	let result = [
 		hollow_cube()?.color("#d0a878"),
+		sealed_cube()?.color("#6fbf73").translate(DVec3::Y * 10.0),
 		halved_shelled_torus(1.0)?.color("#ff5e00").translate(DVec3::X * 18.0),
 		halved_shelled_torus(-1.0)?.color("#0052ff").translate(DVec3::X * 18.0 + DVec3::Y * 10.0),
 	];
@@ -652,7 +660,7 @@ fn main() -> Result<(), Error> {
 	// Isometric view from (1, 1, 2) with shading so the cavity depth reads
 	// naturally.
 	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-	cadrum::mesh(&result, 0.2).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), false, true, &mut f)).expect("failed to write SVG");
+	cadrum::mesh(&result, 0.2).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), true, true, &mut f)).expect("failed to write SVG");
 
 	println!("wrote {example_name}.step / {example_name}.svg");
 	Ok(())
@@ -725,6 +733,75 @@ fn main() {
 
 <p align="center">
   <img src="https://lzpel.github.io/cadrum/09_bspline.svg" alt="09_bspline" width="360"/>
+</p>
+
+#### Fillet
+
+Demo of `Solid::fillet_edges`:
+
+```sh
+cargo run --example 10_fillet
+```
+
+```rust
+//! Demo of `Solid::fillet_edges`:
+//! - All 12 cube edges filleted uniformly (rounded cube)
+//! - Only top 4 edges filleted (soft top, sharp base)
+//! - Cylinder top circular edge filleted (coin shape)
+
+use cadrum::{DVec3, Error, Solid};
+
+fn rounded_cube(size: f64) -> Result<Solid, Error> {
+	let cube = Solid::cube(size, size, size);
+	let radius = size * 0.2;
+	cube.fillet_edges(radius, cube.iter_edge())
+}
+
+fn soft_top_cube(size: f64) -> Result<Solid, Error> {
+	let cube = Solid::cube(size, size, size);
+	let radius = size * 0.2;
+	// Top edges: straight segments whose both endpoints lie at z ≈ size.
+	let top_edges: Vec<_> = cube
+		.iter_edge()
+		.filter(|e| (e.start_point().z - size).abs() < 1e-6 && (e.end_point().z - size).abs() < 1e-6)
+		.collect();
+	cube.fillet_edges(radius, top_edges)
+}
+
+fn coin(radius: f64, height: f64) -> Result<Solid, Error> {
+	let cyl = Solid::cylinder(radius, DVec3::Z, height);
+	// Top cap boundary: a closed circular edge whose start == end lives at z = h.
+	let top_circle: Vec<_> = cyl
+		.iter_edge()
+		.filter(|e| (e.start_point().z - height).abs() < 1e-6)
+		.collect();
+	cyl.fillet_edges(height * 0.3, top_circle)
+}
+
+fn main() -> Result<(), Error> {
+	let example_name = std::path::Path::new(file!()).file_stem().unwrap().to_str().unwrap();
+
+	let result = [
+		rounded_cube(8.0)?.color("#d0a878"),
+		soft_top_cube(8.0)?.color("#6fbf73").translate(DVec3::X * 12.0),
+		coin(6.0, 2.0)?.color("#0052ff").translate(DVec3::X * 24.0),
+	];
+
+	let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create STEP file");
+	cadrum::write_step(&result, &mut f).expect("failed to write STEP");
+
+	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
+	cadrum::mesh(&result, 0.2).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), true, true, &mut f)).expect("failed to write SVG");
+
+	println!("wrote {example_name}.step / {example_name}.svg");
+	Ok(())
+}
+
+```
+- [10_fillet.step](https://lzpel.github.io/cadrum/10_fillet.step)
+
+<p align="center">
+  <img src="https://lzpel.github.io/cadrum/10_fillet.svg" alt="10_fillet" width="360"/>
 </p>
 
 

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -59,6 +59,7 @@
 #include <BRepTools_History.hxx>
 
 // --- Sweep / pipe / loft ---
+#include <BRepFilletAPI_MakeFillet.hxx>
 #include <BRepOffsetAPI_MakeOffsetShape.hxx>
 #include <BRepOffsetAPI_MakePipeShell.hxx>
 #include <BRepOffsetAPI_MakeThickSolid.hxx>
@@ -1210,6 +1211,39 @@ std::unique_ptr<TopoDS_Shape> make_thick_solid(
         builder.Build();
         if (!builder.IsDone()) return nullptr;
         return std::make_unique<TopoDS_Shape>(builder.Shape());
+    } catch (const Standard_Failure&) {
+        return nullptr;
+    }
+}
+
+std::unique_ptr<TopoDS_Shape> make_fillet(
+    const TopoDS_Shape& solid,
+    const std::vector<TopoDS_Edge>& edges,
+    double radius)
+{
+    try {
+        if (edges.empty()) {
+            // No-op: hand back an independent shallow copy so the Rust side
+            // always gets a fresh owned handle (matches the non-empty path).
+            return std::make_unique<TopoDS_Shape>(solid);
+        }
+        BRepFilletAPI_MakeFillet mk(solid);
+        for (const TopoDS_Edge& e : edges) {
+            if (e.IsNull()) continue;
+            mk.Add(radius, e);
+        }
+        mk.Build();
+        if (!mk.IsDone()) return nullptr;
+        TopoDS_Shape result = mk.Shape();
+        if (result.IsNull()) return nullptr;
+        // MakeFillet can wrap the solid in a compound; Solid::new requires a
+        // TopAbs_SOLID, so extract the first one if we got a container.
+        if (result.ShapeType() != TopAbs_SOLID) {
+            TopExp_Explorer ex(result, TopAbs_SOLID);
+            if (!ex.More()) return nullptr;
+            result = ex.Current();
+        }
+        return std::make_unique<TopoDS_Shape>(result);
     } catch (const Standard_Failure&) {
         return nullptr;
     }

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -1028,12 +1028,18 @@ std::unique_ptr<TopoDS_Edge> make_bspline_edge(
     }
 }
 
-void edge_start_point(const TopoDS_Edge& edge, double& x, double& y, double& z) {
-    x = 0.0; y = 0.0; z = 0.0;
+void edge_endpoints(const TopoDS_Edge& edge,
+    double& sx, double& sy, double& sz,
+    double& ex, double& ey, double& ez)
+{
+    sx = 0.0; sy = 0.0; sz = 0.0;
+    ex = 0.0; ey = 0.0; ez = 0.0;
     try {
         BRepAdaptor_Curve curve(edge);
-        gp_Pnt p = curve.Value(curve.FirstParameter());
-        x = p.X(); y = p.Y(); z = p.Z();
+        gp_Pnt start = curve.Value(curve.FirstParameter());
+        gp_Pnt end = curve.Value(curve.LastParameter());
+        sx = start.X(); sy = start.Y(); sz = start.Z();
+        ex = end.X();   ey = end.Y();   ez = end.Z();
     } catch (const Standard_Failure&) {}
 }
 

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -1043,16 +1043,25 @@ void edge_endpoints(const TopoDS_Edge& edge,
     } catch (const Standard_Failure&) {}
 }
 
-void edge_start_tangent(const TopoDS_Edge& edge, double& x, double& y, double& z) {
-    x = 0.0; y = 0.0; z = 0.0;
+void edge_tangents(const TopoDS_Edge& edge,
+    double& sx, double& sy, double& sz,
+    double& ex, double& ey, double& ez)
+{
+    sx = 0.0; sy = 0.0; sz = 0.0;
+    ex = 0.0; ey = 0.0; ez = 0.0;
     try {
         BRepAdaptor_Curve curve(edge);
         gp_Pnt p;
-        gp_Vec v;
-        curve.D1(curve.FirstParameter(), p, v);
-        if (v.Magnitude() > Precision::Confusion()) {
-            v.Normalize();
-            x = v.X(); y = v.Y(); z = v.Z();
+        gp_Vec vs, ve;
+        curve.D1(curve.FirstParameter(), p, vs);
+        curve.D1(curve.LastParameter(), p, ve);
+        if (vs.Magnitude() > Precision::Confusion()) {
+            vs.Normalize();
+            sx = vs.X(); sy = vs.Y(); sz = vs.Z();
+        }
+        if (ve.Magnitude() > Precision::Confusion()) {
+            ve.Normalize();
+            ex = ve.X(); ey = ve.Y(); ez = ve.Z();
         }
     } catch (const Standard_Failure&) {}
 }

--- a/cpp/wrapper.h
+++ b/cpp/wrapper.h
@@ -333,6 +333,15 @@ std::unique_ptr<TopoDS_Shape> make_thick_solid(
     const std::vector<TopoDS_Face>& open_faces,
     double thickness);
 
+// Fillet the given edges of `solid` with a uniform radius using
+// BRepFilletAPI_MakeFillet. Empty `edges` is a no-op (returns a shallow
+// copy of `solid`). Returns nullptr on OCCT failure (radius too large,
+// tangent discontinuity, edges not belonging to `solid`, etc.).
+std::unique_ptr<TopoDS_Shape> make_fillet(
+    const TopoDS_Shape& solid,
+    const std::vector<TopoDS_Edge>& edges,
+    double radius);
+
 // Loft (skin) a smooth solid through N cross-section wires.
 // Sections in `all_edges` are separated by null-edge sentinels.
 std::unique_ptr<TopoDS_Shape> make_loft(

--- a/cpp/wrapper.h
+++ b/cpp/wrapper.h
@@ -264,7 +264,9 @@ std::unique_ptr<TopoDS_Edge> make_bspline_edge(
     double ex, double ey, double ez);
 
 // Edge query helpers.
-void edge_start_point(const TopoDS_Edge& edge, double& x, double& y, double& z);
+void edge_endpoints(const TopoDS_Edge& edge,
+    double& sx, double& sy, double& sz,
+    double& ex, double& ey, double& ez);
 void edge_start_tangent(const TopoDS_Edge& edge, double& x, double& y, double& z);
 bool edge_is_closed(const TopoDS_Edge& edge);
 

--- a/cpp/wrapper.h
+++ b/cpp/wrapper.h
@@ -267,7 +267,9 @@ std::unique_ptr<TopoDS_Edge> make_bspline_edge(
 void edge_endpoints(const TopoDS_Edge& edge,
     double& sx, double& sy, double& sz,
     double& ex, double& ey, double& ez);
-void edge_start_tangent(const TopoDS_Edge& edge, double& x, double& y, double& z);
+void edge_tangents(const TopoDS_Edge& edge,
+    double& sx, double& sy, double& sz,
+    double& ex, double& ey, double& ez);
 bool edge_is_closed(const TopoDS_Edge& edge);
 
 // Edge clone (deep copy of underlying TShape).

--- a/examples/10_fillet.rs
+++ b/examples/10_fillet.rs
@@ -5,43 +5,40 @@
 
 use cadrum::{DVec3, Error, Solid};
 
-fn rounded_cube() -> Result<Solid, Error> {
-	let a = 8.0;
-	let cube = Solid::cube(a, a, a);
-	let edges: Vec<_> = cube.iter_edge().collect();
-	cube.fillet_edges(1.2, edges)
+fn rounded_cube(size: f64) -> Result<Solid, Error> {
+	let cube = Solid::cube(size, size, size);
+	let radius = size * 0.2;
+	cube.fillet_edges(radius, cube.iter_edge())
 }
 
-fn soft_top_cube() -> Result<Solid, Error> {
-	let a = 8.0;
-	let cube = Solid::cube(a, a, a);
-	// Top edges of a cube are straight segments — polyline approximation has
-	// exactly 2 samples, both at z ≈ a. Filter on that.
+fn soft_top_cube(size: f64) -> Result<Solid, Error> {
+	let cube = Solid::cube(size, size, size);
+	let radius = size * 0.2;
+	// Top edges: straight segments whose both endpoints lie at z ≈ size.
 	let top_edges: Vec<_> = cube
 		.iter_edge()
-		.filter(|e| e.approximation_segments(0.01).iter().all(|p| (p.z - a).abs() < 1e-3))
+		.filter(|e| (e.start_point().z - size).abs() < 1e-6 && (e.end_point().z - size).abs() < 1e-6)
 		.collect();
-	cube.fillet_edges(1.5, top_edges)
+	cube.fillet_edges(radius, top_edges)
 }
 
-fn coin() -> Result<Solid, Error> {
-	let h = 2.0;
-	let cyl = Solid::cylinder(6.0, DVec3::Z, h);
-	// Circular edges on a cylinder live at z = 0 and z = h. Pick the top cap.
+fn coin(radius: f64, height: f64) -> Result<Solid, Error> {
+	let cyl = Solid::cylinder(radius, DVec3::Z, height);
+	// Top cap boundary: a closed circular edge whose start == end lives at z = h.
 	let top_circle: Vec<_> = cyl
 		.iter_edge()
-		.filter(|e| e.approximation_segments(0.05).iter().all(|p| (p.z - h).abs() < 1e-3))
+		.filter(|e| (e.start_point().z - height).abs() < 1e-6)
 		.collect();
-	cyl.fillet_edges(0.6, top_circle)
+	cyl.fillet_edges(height * 0.3, top_circle)
 }
 
 fn main() -> Result<(), Error> {
 	let example_name = std::path::Path::new(file!()).file_stem().unwrap().to_str().unwrap();
 
 	let result = [
-		rounded_cube()?.color("#d0a878"),
-		soft_top_cube()?.color("#6fbf73").translate(DVec3::X * 12.0),
-		coin()?.color("#0052ff").translate(DVec3::X * 24.0),
+		rounded_cube(8.0)?.color("#d0a878"),
+		soft_top_cube(8.0)?.color("#6fbf73").translate(DVec3::X * 12.0),
+		coin(6.0, 2.0)?.color("#0052ff").translate(DVec3::X * 24.0),
 	];
 
 	let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create STEP file");

--- a/examples/10_fillet.rs
+++ b/examples/10_fillet.rs
@@ -1,0 +1,55 @@
+//! Demo of `Solid::fillet_edges`:
+//! - All 12 cube edges filleted uniformly (rounded cube)
+//! - Only top 4 edges filleted (soft top, sharp base)
+//! - Cylinder top circular edge filleted (coin shape)
+
+use cadrum::{DVec3, Error, Solid};
+
+fn rounded_cube() -> Result<Solid, Error> {
+	let a = 8.0;
+	let cube = Solid::cube(a, a, a);
+	let edges: Vec<_> = cube.iter_edge().collect();
+	cube.fillet_edges(1.2, edges)
+}
+
+fn soft_top_cube() -> Result<Solid, Error> {
+	let a = 8.0;
+	let cube = Solid::cube(a, a, a);
+	// Top edges of a cube are straight segments — polyline approximation has
+	// exactly 2 samples, both at z ≈ a. Filter on that.
+	let top_edges: Vec<_> = cube
+		.iter_edge()
+		.filter(|e| e.approximation_segments(0.01).iter().all(|p| (p.z - a).abs() < 1e-3))
+		.collect();
+	cube.fillet_edges(1.5, top_edges)
+}
+
+fn coin() -> Result<Solid, Error> {
+	let h = 2.0;
+	let cyl = Solid::cylinder(6.0, DVec3::Z, h);
+	// Circular edges on a cylinder live at z = 0 and z = h. Pick the top cap.
+	let top_circle: Vec<_> = cyl
+		.iter_edge()
+		.filter(|e| e.approximation_segments(0.05).iter().all(|p| (p.z - h).abs() < 1e-3))
+		.collect();
+	cyl.fillet_edges(0.6, top_circle)
+}
+
+fn main() -> Result<(), Error> {
+	let example_name = std::path::Path::new(file!()).file_stem().unwrap().to_str().unwrap();
+
+	let result = [
+		rounded_cube()?.color("#d0a878"),
+		soft_top_cube()?.color("#6fbf73").translate(DVec3::X * 12.0),
+		coin()?.color("#0052ff").translate(DVec3::X * 24.0),
+	];
+
+	let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create STEP file");
+	cadrum::write_step(&result, &mut f).expect("failed to write STEP");
+
+	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
+	cadrum::mesh(&result, 0.2).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), true, true, &mut f)).expect("failed to write SVG");
+
+	println!("wrote {example_name}.step / {example_name}.svg");
+	Ok(())
+}

--- a/examples/10_fillet.rs
+++ b/examples/10_fillet.rs
@@ -6,30 +6,29 @@
 use cadrum::{DVec3, Error, Solid};
 
 fn rounded_cube(size: f64) -> Result<Solid, Error> {
-	let cube = Solid::cube(size, size, size);
+	let cube = Solid::cube(size, size, size).translate(-DVec3::ONE * (size / 2.0));
 	let radius = size * 0.2;
 	cube.fillet_edges(radius, cube.iter_edge())
 }
 
 fn soft_top_cube(size: f64) -> Result<Solid, Error> {
-	let cube = Solid::cube(size, size, size);
+	let cube = Solid::cube(size, size, size).translate(-DVec3::ONE * (size / 2.0));
 	let radius = size * 0.2;
-	// Top edges: straight segments whose both endpoints lie at z ≈ size.
-	let top_edges: Vec<_> = cube
+	// Top cap boundary: a closed circular edge whose start == end lives at z = h.
+	let top_edges = cube
 		.iter_edge()
-		.filter(|e| (e.start_point().z - size).abs() < 1e-6 && (e.end_point().z - size).abs() < 1e-6)
-		.collect();
+		.filter(|e| [e.start_point(), e.end_point()].iter().all(|p| (p.z - size / 2.0).abs() < 1e-6));
 	cube.fillet_edges(radius, top_edges)
 }
 
 fn coin(radius: f64, height: f64) -> Result<Solid, Error> {
 	let cyl = Solid::cylinder(radius, DVec3::Z, height);
+	let radius = height * 0.3;
 	// Top cap boundary: a closed circular edge whose start == end lives at z = h.
-	let top_circle: Vec<_> = cyl
+	let top_circle = cyl
 		.iter_edge()
-		.filter(|e| (e.start_point().z - height).abs() < 1e-6)
-		.collect();
-	cyl.fillet_edges(height * 0.3, top_circle)
+		.filter(|e| [e.start_point(), e.end_point()].iter().all(|p| (p.z - height).abs() < 1e-6));
+	cyl.fillet_edges(radius, top_circle)
 }
 
 fn main() -> Result<(), Error> {
@@ -38,7 +37,7 @@ fn main() -> Result<(), Error> {
 	let result = [
 		rounded_cube(8.0)?.color("#d0a878"),
 		soft_top_cube(8.0)?.color("#6fbf73").translate(DVec3::X * 12.0),
-		coin(6.0, 2.0)?.color("#0052ff").translate(DVec3::X * 24.0),
+		coin(4.0, 2.0)?.color("#0052ff").translate(DVec3::X * 24.0),
 	];
 
 	let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create STEP file");

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -38,6 +38,11 @@ pub enum Error {
 	/// yielding a self-intersecting offset surface, or OCCT internal failure.
 	ShellFailed,
 
+	/// Fillet (`Solid::fillet_edges` via `BRepFilletAPI_MakeFillet`) failed:
+	/// radius too large for the local geometry, tangent discontinuity along
+	/// the selected edge chain, or an edge not belonging to `self` was passed.
+	FilletFailed,
+
 	/// Lofting (`Solid::loft` / `BRepOffsetAPI_ThruSections`) failed: section
 	/// count too low, section wire ill-formed, or OCCT internal failure.
 	/// The string identifies which precondition or stage failed.
@@ -80,6 +85,7 @@ impl std::fmt::Display for Error {
 			Error::ExtrudeFailed => write!(f, "Extrude failed"),
 			Error::SweepFailed => write!(f, "Sweep failed"),
 			Error::ShellFailed => write!(f, "Shell failed"),
+			Error::FilletFailed => write!(f, "Fillet failed"),
 			Error::LoftFailed(msg) => write!(f, "Loft failed: {}", msg),
 			Error::BsplineFailed(msg) => write!(f, "Bspline failed: {}", msg),
 			Error::InvalidEdge(msg) => write!(f, "Invalid edge: {}", msg),

--- a/src/occt/edge.rs
+++ b/src/occt/edge.rs
@@ -150,11 +150,17 @@ impl Wire for Edge {
 	}
 
 	fn start_tangent(&self) -> DVec3 {
-		let mut x = 0.0;
-		let mut y = 0.0;
-		let mut z = 0.0;
-		ffi::edge_start_tangent(&self.inner, &mut x, &mut y, &mut z);
-		DVec3::new(x, y, z)
+		let (mut sx, mut sy, mut sz) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut ex, mut ey, mut ez) = (0.0_f64, 0.0_f64, 0.0_f64);
+		ffi::edge_tangents(&self.inner, &mut sx, &mut sy, &mut sz, &mut ex, &mut ey, &mut ez);
+		DVec3::new(sx, sy, sz)
+	}
+
+	fn end_tangent(&self) -> DVec3 {
+		let (mut sx, mut sy, mut sz) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut ex, mut ey, mut ez) = (0.0_f64, 0.0_f64, 0.0_f64);
+		ffi::edge_tangents(&self.inner, &mut sx, &mut sy, &mut sz, &mut ex, &mut ey, &mut ez);
+		DVec3::new(ex, ey, ez)
 	}
 
 	fn is_closed(&self) -> bool {

--- a/src/occt/edge.rs
+++ b/src/occt/edge.rs
@@ -136,11 +136,17 @@ impl Wire for Edge {
 	type Elem = Edge;
 
 	fn start_point(&self) -> DVec3 {
-		let mut x = 0.0;
-		let mut y = 0.0;
-		let mut z = 0.0;
-		ffi::edge_start_point(&self.inner, &mut x, &mut y, &mut z);
-		DVec3::new(x, y, z)
+		let (mut sx, mut sy, mut sz) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut ex, mut ey, mut ez) = (0.0_f64, 0.0_f64, 0.0_f64);
+		ffi::edge_endpoints(&self.inner, &mut sx, &mut sy, &mut sz, &mut ex, &mut ey, &mut ez);
+		DVec3::new(sx, sy, sz)
+	}
+
+	fn end_point(&self) -> DVec3 {
+		let (mut sx, mut sy, mut sz) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut ex, mut ey, mut ez) = (0.0_f64, 0.0_f64, 0.0_f64);
+		ffi::edge_endpoints(&self.inner, &mut sx, &mut sy, &mut sz, &mut ex, &mut ey, &mut ez);
+		DVec3::new(ex, ey, ez)
 	}
 
 	fn start_tangent(&self) -> DVec3 {

--- a/src/occt/ffi.rs
+++ b/src/occt/ffi.rs
@@ -184,6 +184,7 @@ mod ffi_bridge {
 		fn face_vec_push(v: Pin<&mut CxxVector<TopoDS_Face>>, f: &TopoDS_Face);
 
 		fn make_thick_solid(solid: &TopoDS_Shape, open_faces: &CxxVector<TopoDS_Face>, thickness: f64) -> UniquePtr<TopoDS_Shape>;
+		fn make_fillet(solid: &TopoDS_Shape, edges: &CxxVector<TopoDS_Edge>, radius: f64) -> UniquePtr<TopoDS_Shape>;
 	}
 }
 

--- a/src/occt/ffi.rs
+++ b/src/occt/ffi.rs
@@ -161,7 +161,7 @@ mod ffi_bridge {
 		fn make_bspline_edge(coords: &[f64], end_kind: u32, sx: f64, sy: f64, sz: f64, ex: f64, ey: f64, ez: f64) -> UniquePtr<TopoDS_Edge>;
 
 		fn edge_endpoints(edge: &TopoDS_Edge, sx: &mut f64, sy: &mut f64, sz: &mut f64, ex: &mut f64, ey: &mut f64, ez: &mut f64);
-		fn edge_start_tangent(edge: &TopoDS_Edge, x: &mut f64, y: &mut f64, z: &mut f64);
+		fn edge_tangents(edge: &TopoDS_Edge, sx: &mut f64, sy: &mut f64, sz: &mut f64, ex: &mut f64, ey: &mut f64, ez: &mut f64);
 		fn edge_is_closed(edge: &TopoDS_Edge) -> bool;
 
 		fn deep_copy_edge(edge: &TopoDS_Edge) -> UniquePtr<TopoDS_Edge>;

--- a/src/occt/ffi.rs
+++ b/src/occt/ffi.rs
@@ -160,7 +160,7 @@ mod ffi_bridge {
 		fn make_arc_edge(sx: f64, sy: f64, sz: f64, mx: f64, my: f64, mz: f64, ex: f64, ey: f64, ez: f64) -> UniquePtr<TopoDS_Edge>;
 		fn make_bspline_edge(coords: &[f64], end_kind: u32, sx: f64, sy: f64, sz: f64, ex: f64, ey: f64, ez: f64) -> UniquePtr<TopoDS_Edge>;
 
-		fn edge_start_point(edge: &TopoDS_Edge, x: &mut f64, y: &mut f64, z: &mut f64);
+		fn edge_endpoints(edge: &TopoDS_Edge, sx: &mut f64, sy: &mut f64, sz: &mut f64, ex: &mut f64, ey: &mut f64, ez: &mut f64);
 		fn edge_start_tangent(edge: &TopoDS_Edge, x: &mut f64, y: &mut f64, z: &mut f64);
 		fn edge_is_closed(edge: &TopoDS_Edge) -> bool;
 

--- a/src/occt/solid.rs
+++ b/src/occt/solid.rs
@@ -241,6 +241,24 @@ impl SolidStruct for Solid {
 		))
 	}
 
+	// ==================== Fillet ====================
+
+	fn fillet_edges<'a>(&self, radius: f64, edges: impl IntoIterator<Item = &'a Edge>) -> Result<Self, Error> {
+		let mut edge_vec = ffi::edge_vec_new();
+		for e in edges {
+			ffi::edge_vec_push(edge_vec.pin_mut(), &e.inner);
+		}
+		let shape = ffi::make_fillet(&self.inner, &edge_vec, radius);
+		if shape.is_null() {
+			return Err(Error::FilletFailed);
+		}
+		Ok(Solid::new(
+			shape,
+			#[cfg(feature = "color")]
+			std::collections::HashMap::new(),
+		))
+	}
+
 	// ==================== Sweep ====================
 
 	fn sweep<'a, 'b, 'c>(profile: impl IntoIterator<Item = &'a Edge>, spine: impl IntoIterator<Item = &'b Edge>, orient: ProfileOrient<'c>) -> Result<Self, Error> {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -459,6 +459,18 @@ pub trait SolidStruct: Sized + Clone + Compound {
 	/// Fails on OCCT rejection (self-intersecting offset at sharp corners, etc).
 	fn shell<'a>(&self, thickness: f64, open_faces: impl IntoIterator<Item = &'a Self::Face>) -> Result<Self, Error> where Self::Face: 'a;
 
+	/// Round the given edges of `self` with a uniform radius. Edges are
+	/// typically selected via `self.iter_edge().filter(...)`.
+	///
+	/// Wraps `BRepFilletAPI_MakeFillet`. Fails (`Error::FilletFailed`) if
+	/// the radius is too large for the local geometry, if tangent
+	/// discontinuity prevents OCCT from building the fillet surface, or
+	/// if an edge not belonging to `self` is passed.
+	///
+	/// Empty `edges` is a no-op and returns a clone of `self` — handy when
+	/// a selector chain legitimately yields zero edges.
+	fn fillet_edges<'a>(&self, radius: f64, edges: impl IntoIterator<Item = &'a Self::Edge>) -> Result<Self, Error> where Self::Edge: 'a;
+
 	// --- Sweep ---
 	/// Sweep a closed profile wire (= ordered edge list) along a spine wire
 	/// to create a solid. Both inputs are accepted as `IntoIterator` of edge

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -299,6 +299,7 @@ pub trait Wire: Transform {
 	type Elem: EdgeStruct;
 
 	fn start_point(&self) -> DVec3;
+	fn end_point(&self) -> DVec3;
 	fn start_tangent(&self) -> DVec3;
 	fn is_closed(&self) -> bool;
 	fn approximation_segments(&self, tolerance: f64) -> Vec<DVec3>;
@@ -692,25 +693,23 @@ impl<T: EdgeStruct> Wire for Vec<T> {
 		self.first().map(|e| e.start_point()).unwrap_or(DVec3::ZERO)
 	}
 
+	fn end_point(&self) -> DVec3 {
+		self.last().map(|e| e.end_point()).unwrap_or(DVec3::ZERO)
+	}
+
 	fn start_tangent(&self) -> DVec3 {
 		self.first().map(|e| e.start_tangent()).unwrap_or(DVec3::ZERO)
 	}
 
 	fn is_closed(&self) -> bool {
 		// Empty wire: not closed. Single-edge wire: defer to that edge.
-		// Multi-edge wire: walk the polyline approximation of the last edge to
-		// find its end point, and compare with the first edge's start.
+		// Multi-edge wire: the first edge's start equals the last edge's end.
 		// 1e-6 はモデル単位 (mm) を想定したハードコード — 引数化は API が
 		// 増えるため後回し。極小/極大スケールのモデルで誤判定したら直す。
 		match self.len() {
 			0 => false,
 			1 => self[0].is_closed(),
-			_ => {
-				let start = self[0].start_point();
-				let last_pts = self[self.len() - 1].approximation_segments(1e-3);
-				let end = last_pts.last().copied().unwrap_or(DVec3::ZERO);
-				(start - end).length() < 1e-6
-			}
+			_ => (self[0].start_point() - self[self.len() - 1].end_point()).length() < 1e-6,
 		}
 	}
 
@@ -738,6 +737,10 @@ impl<T: EdgeStruct, const N: usize> Wire for [T; N] {
 		self.first().map(|e| e.start_point()).unwrap_or(DVec3::ZERO)
 	}
 
+	fn end_point(&self) -> DVec3 {
+		self.last().map(|e| e.end_point()).unwrap_or(DVec3::ZERO)
+	}
+
 	fn start_tangent(&self) -> DVec3 {
 		self.first().map(|e| e.start_tangent()).unwrap_or(DVec3::ZERO)
 	}
@@ -746,12 +749,7 @@ impl<T: EdgeStruct, const N: usize> Wire for [T; N] {
 		match N {
 			0 => false,
 			1 => self[0].is_closed(),
-			_ => {
-				let start = self[0].start_point();
-				let last_pts = self[N - 1].approximation_segments(1e-3);
-				let end = last_pts.last().copied().unwrap_or(DVec3::ZERO);
-				(start - end).length() < 1e-6
-			}
+			_ => (self[0].start_point() - self[N - 1].end_point()).length() < 1e-6,
 		}
 	}
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -277,9 +277,10 @@ pub enum BSplineEnd {
 /// Methods on `Wire` therefore have meaningful semantics for both a single
 /// edge and an ordered edge list:
 ///
-/// - `start_point` / `start_tangent` — the wire's starting position/direction.
-///   For a single edge, the edge's first point and tangent.
-///   For a `Vec<Edge>`, the first edge's start.
+/// - `start_point` / `end_point` / `start_tangent` / `end_tangent` — the
+///   wire's endpoint positions and tangent directions.
+///   For a single edge, the edge's first/last point and tangent.
+///   For a `Vec<Edge>`, the first edge's start and the last edge's end.
 /// - `is_closed` — does the geometry form a closed loop?
 ///   For a single edge, whether start == end (e.g. a circle).
 ///   For a `Vec<Edge>`, whether the first edge's start equals the last edge's end.
@@ -301,6 +302,7 @@ pub trait Wire: Transform {
 	fn start_point(&self) -> DVec3;
 	fn end_point(&self) -> DVec3;
 	fn start_tangent(&self) -> DVec3;
+	fn end_tangent(&self) -> DVec3;
 	fn is_closed(&self) -> bool;
 	fn approximation_segments(&self, tolerance: f64) -> Vec<DVec3>;
 
@@ -701,6 +703,10 @@ impl<T: EdgeStruct> Wire for Vec<T> {
 		self.first().map(|e| e.start_tangent()).unwrap_or(DVec3::ZERO)
 	}
 
+	fn end_tangent(&self) -> DVec3 {
+		self.last().map(|e| e.end_tangent()).unwrap_or(DVec3::ZERO)
+	}
+
 	fn is_closed(&self) -> bool {
 		// Empty wire: not closed. Single-edge wire: defer to that edge.
 		// Multi-edge wire: the first edge's start equals the last edge's end.
@@ -743,6 +749,10 @@ impl<T: EdgeStruct, const N: usize> Wire for [T; N] {
 
 	fn start_tangent(&self) -> DVec3 {
 		self.first().map(|e| e.start_tangent()).unwrap_or(DVec3::ZERO)
+	}
+
+	fn end_tangent(&self) -> DVec3 {
+		self.last().map(|e| e.end_tangent()).unwrap_or(DVec3::ZERO)
 	}
 
 	fn is_closed(&self) -> bool {

--- a/tests/fillet.rs
+++ b/tests/fillet.rs
@@ -1,0 +1,67 @@
+//! Integration tests for `Solid::fillet_edges`.
+//!
+//! A unit cube with edge length `a` filleted by radius `r` removes:
+//!   - 12 quarter-cylinder edges: each replaces a quarter-square prism of
+//!     cross-section `r² − π r² / 4` over length `a − 2r`
+//!   - 8 sphere-octant corners:   each replaces a cube corner of volume
+//!     `r³ − (4/3) π r³ / 8 = r³ − π r³ / 6`
+//! The analytical result below is used to validate OCCT's output within 0.1%.
+
+use cadrum::{Error, Solid};
+use std::f64::consts::PI;
+
+const EPS: f64 = 1e-6;
+
+#[test]
+fn test_fillet_cube_reduces_volume_and_area() {
+	let a = 10.0_f64;
+	let r = 1.0_f64;
+	let cube = Solid::cube(a, a, a);
+	let original_volume = cube.volume();
+	let original_area = cube.area();
+	let edges: Vec<_> = cube.iter_edge().collect();
+	let rounded = cube.fillet_edges(r, edges).expect("fillet should succeed");
+
+	assert!(rounded.volume() < original_volume,
+		"fillet must reduce volume: {} vs {}", rounded.volume(), original_volume);
+	assert!(rounded.area() < original_area,
+		"fillet must reduce area: {} vs {}", rounded.area(), original_area);
+}
+
+#[test]
+fn test_fillet_cube_matches_analytical_volume() {
+	let a = 10.0_f64;
+	let r = 1.0_f64;
+	let cube = Solid::cube(a, a, a);
+	let edges: Vec<_> = cube.iter_edge().collect();
+	let rounded = cube.fillet_edges(r, edges).expect("fillet cube");
+
+	let removed_edges = 12.0 * (r * r - PI * r * r / 4.0) * (a - 2.0 * r);
+	let removed_corners = 8.0 * (r.powi(3) - PI * r.powi(3) / 6.0);
+	let expected = a.powi(3) - removed_edges - removed_corners;
+	let rel_err = (rounded.volume() - expected).abs() / expected;
+	assert!(rel_err < 1e-3,
+		"rounded cube volume {} vs analytical {} (rel err {})",
+		rounded.volume(), expected, rel_err);
+}
+
+#[test]
+fn test_fillet_empty_edges_is_noop() {
+	let cube = Solid::cube(5.0, 5.0, 5.0);
+	let original_volume = cube.volume();
+	let unchanged = cube
+		.fillet_edges(0.5, std::iter::empty::<&cadrum::Edge>())
+		.expect("empty fillet is a no-op, not an error");
+	assert!((unchanged.volume() - original_volume).abs() < EPS,
+		"no-op fillet should preserve volume exactly, got {}", unchanged.volume());
+}
+
+#[test]
+fn test_fillet_radius_too_large_returns_err() {
+	let cube = Solid::cube(2.0, 2.0, 2.0);
+	let edges: Vec<_> = cube.iter_edge().collect();
+	// r = 5 > a/2 = 1 → geometrically impossible; OCCT reports not-done.
+	let err = cube.fillet_edges(5.0, edges).err().expect("oversized radius must fail");
+	assert!(matches!(err, Error::FilletFailed),
+		"expected FilletFailed, got {:?}", err);
+}


### PR DESCRIPTION
## 概要
`BRepFilletAPI_MakeFillet` をラップして均一半径の fillet を追加。#112 の第一段階。

```rust
cube.fillet_edges(1.0, cube.iter_edge().filter(|e| /* selector */))?
```

### API 命名: `fillet_edges` vs `fillet`
`fillet_edges` を採用。シグネチャ第二引数が edges イテレータであることを名前で明示し、将来 `chamfer_edges` や可変半径版と並べたとき一貫する。AGENTS.md の「単一要素でも `&[edge]` と書かせて集合受け取りを型レベルで認識してもらう」方針とも噛み合う。

### 設計決定
- シグネチャは `shell(&self, thickness, open_faces: impl IntoIterator<Item=&Face>)` を踏襲し `fillet_edges(&self, radius, edges: impl IntoIterator<Item=&Edge>)` に。
- 失敗時は `Error::FilletFailed`。既存 `ShellFailed` / `ExtrudeFailed` と同じ粒度。
- **空 edge は no-op** — selector chain が空を返しても panic しないほうが iterator フローが書きやすい。
- OCCT は結果を compound で返すことがあるため wrapper で SOLID を取り出し `Solid::new` 不変量を維持。
- **可変半径 / chamfer は別 issue (#112 フォロー)** — UX が別物なので切り分け。

### 派生: `Wire::end_point` / `Wire::end_tangent`
`10_fillet.rs` の top-edge selector を綺麗に書くため、`Wire` trait に `end_point` と `end_tangent` を追加した。新しい FFI は増やさず、既存の `edge_start_point` / `edge_start_tangent` を `edge_endpoints` / `edge_tangents` へリネームして 6 out-params にすることで 1 回の呼び出しで両端を取る。`Vec<Edge>` / `[Edge; N]` の blanket impl も対応し、`is_closed` の `approximation_segments(1e-3)` hack も `end_point` に置換して簡素化。

## テスト計画
- [x] `cargo test --test fillet` — 4 テスト (体積/面積減少、解析値照合 1% 以内、空 no-op、半径過大 → FilletFailed)
- [x] `cargo test` — 既存全 suite green
- [x] `cargo build --no-default-features`
- [x] `cargo run --example 10_fillet` — rounded cube / soft-top / coin の 3 例を STEP + SVG へ出力

🤖 Generated with [Claude Code](https://claude.com/claude-code)