### PR TITLE
feat(chamfer): Solid::chamfer_edges を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -828,6 +828,7 @@ fn beveled_cube(size: f64) -> Result<Solid, Error> {
 fn beveled_top_cube(size: f64) -> Result<Solid, Error> {
 	let cube = Solid::cube(size, size, size).translate(-DVec3::ONE * (size / 2.0));
 	let distance = size * 0.2;
+	// Top cap boundary: a closed circular edge whose start == end lives at z = h.
 	let top_edges = cube
 		.iter_edge()
 		.filter(|e| [e.start_point(), e.end_point()].iter().all(|p| (p.z - size / 2.0).abs() < 1e-6));

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Rust CAD library powered by statically linked, headless [OpenCASCADE](https://de
 | [<img src="https://lzpel.github.io/cadrum/01_primitives.svg" width="180" alt="primitives"/>](#primitives) | [<img src="https://lzpel.github.io/cadrum/02_write_read.svg" width="180" alt="write read"/>](#write-read) | [<img src="https://lzpel.github.io/cadrum/03_transform.svg" width="180" alt="transform"/>](#transform) | [<img src="https://lzpel.github.io/cadrum/04_boolean.svg" width="180" alt="boolean"/>](#boolean) |
 | [extrude](#extrude) | [loft](#loft) | [sweep](#sweep) | [shell](#shell) |
 | [<img src="https://lzpel.github.io/cadrum/05_extrude.svg" width="180" alt="extrude"/>](#extrude) | [<img src="https://lzpel.github.io/cadrum/06_loft.svg" width="180" alt="loft"/>](#loft) | [<img src="https://lzpel.github.io/cadrum/07_sweep.svg" width="180" alt="sweep"/>](#sweep) | [<img src="https://lzpel.github.io/cadrum/08_shell.svg" width="180" alt="shell"/>](#shell) |
-| [bspline](#bspline) | [fillet](#fillet) |  |  |
-| [<img src="https://lzpel.github.io/cadrum/09_bspline.svg" width="180" alt="bspline"/>](#bspline) | [<img src="https://lzpel.github.io/cadrum/10_fillet.svg" width="180" alt="fillet"/>](#fillet) |  |  |
+| [bspline](#bspline) | [fillet](#fillet) | [chamfer](#chamfer) |  |
+| [<img src="https://lzpel.github.io/cadrum/09_bspline.svg" width="180" alt="bspline"/>](#bspline) | [<img src="https://lzpel.github.io/cadrum/10_fillet.svg" width="180" alt="fillet"/>](#fillet) | [<img src="https://lzpel.github.io/cadrum/11_chamfer.svg" width="180" alt="chamfer"/>](#chamfer) |  |
 
 More examples with source code are available at [lzpel.github.io/cadrum](https://lzpel.github.io/cadrum).
 
@@ -752,30 +752,29 @@ cargo run --example 10_fillet
 use cadrum::{DVec3, Error, Solid};
 
 fn rounded_cube(size: f64) -> Result<Solid, Error> {
-	let cube = Solid::cube(size, size, size);
+	let cube = Solid::cube(size, size, size).translate(-DVec3::ONE * (size / 2.0));
 	let radius = size * 0.2;
 	cube.fillet_edges(radius, cube.iter_edge())
 }
 
 fn soft_top_cube(size: f64) -> Result<Solid, Error> {
-	let cube = Solid::cube(size, size, size);
+	let cube = Solid::cube(size, size, size).translate(-DVec3::ONE * (size / 2.0));
 	let radius = size * 0.2;
-	// Top edges: straight segments whose both endpoints lie at z ≈ size.
-	let top_edges: Vec<_> = cube
+	// Top cap boundary: a closed circular edge whose start == end lives at z = h.
+	let top_edges = cube
 		.iter_edge()
-		.filter(|e| (e.start_point().z - size).abs() < 1e-6 && (e.end_point().z - size).abs() < 1e-6)
-		.collect();
+		.filter(|e| [e.start_point(), e.end_point()].iter().all(|p| (p.z - size / 2.0).abs() < 1e-6));
 	cube.fillet_edges(radius, top_edges)
 }
 
 fn coin(radius: f64, height: f64) -> Result<Solid, Error> {
 	let cyl = Solid::cylinder(radius, DVec3::Z, height);
+	let radius = height * 0.3;
 	// Top cap boundary: a closed circular edge whose start == end lives at z = h.
-	let top_circle: Vec<_> = cyl
+	let top_circle = cyl
 		.iter_edge()
-		.filter(|e| (e.start_point().z - height).abs() < 1e-6)
-		.collect();
-	cyl.fillet_edges(height * 0.3, top_circle)
+		.filter(|e| [e.start_point(), e.end_point()].iter().all(|p| (p.z - height).abs() < 1e-6));
+	cyl.fillet_edges(radius, top_circle)
 }
 
 fn main() -> Result<(), Error> {
@@ -784,7 +783,7 @@ fn main() -> Result<(), Error> {
 	let result = [
 		rounded_cube(8.0)?.color("#d0a878"),
 		soft_top_cube(8.0)?.color("#6fbf73").translate(DVec3::X * 12.0),
-		coin(6.0, 2.0)?.color("#0052ff").translate(DVec3::X * 24.0),
+		coin(4.0, 2.0)?.color("#0052ff").translate(DVec3::X * 24.0),
 	];
 
 	let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create STEP file");
@@ -802,6 +801,73 @@ fn main() -> Result<(), Error> {
 
 <p align="center">
   <img src="https://lzpel.github.io/cadrum/10_fillet.svg" alt="10_fillet" width="360"/>
+</p>
+
+#### Chamfer
+
+Demo of `Solid::chamfer_edges` — mirror of `10_fillet.rs` using bevels:
+
+```sh
+cargo run --example 11_chamfer
+```
+
+```rust
+//! Demo of `Solid::chamfer_edges` — mirror of `10_fillet.rs` using bevels:
+//! - All 12 cube edges chamfered uniformly (beveled cube)
+//! - Only top 4 edges chamfered (soft top, sharp base)
+//! - Cylinder top circular edge chamfered (coin with beveled rim)
+
+use cadrum::{DVec3, Error, Solid};
+
+fn beveled_cube(size: f64) -> Result<Solid, Error> {
+	let cube = Solid::cube(size, size, size).translate(-DVec3::ONE * (size / 2.0));
+	let distance = size * 0.2;
+	cube.chamfer_edges(distance, cube.iter_edge())
+}
+
+fn beveled_top_cube(size: f64) -> Result<Solid, Error> {
+	let cube = Solid::cube(size, size, size).translate(-DVec3::ONE * (size / 2.0));
+	let distance = size * 0.2;
+	let top_edges = cube
+		.iter_edge()
+		.filter(|e| [e.start_point(), e.end_point()].iter().all(|p| (p.z - size / 2.0).abs() < 1e-6));
+	cube.chamfer_edges(distance, top_edges)
+}
+
+fn beveled_coin(radius: f64, height: f64) -> Result<Solid, Error> {
+	let cyl = Solid::cylinder(radius, DVec3::Z, height);
+	let distance = height * 0.3;
+	// Top cap boundary: a closed circular edge whose start == end lives at z = h.
+	let top_circle = cyl
+		.iter_edge()
+		.filter(|e| [e.start_point(), e.end_point()].iter().all(|p| (p.z - height).abs() < 1e-6));
+	cyl.chamfer_edges(distance, top_circle)
+}
+
+fn main() -> Result<(), Error> {
+	let example_name = std::path::Path::new(file!()).file_stem().unwrap().to_str().unwrap();
+
+	let result = [
+		beveled_cube(8.0)?.color("#d0a878"),
+		beveled_top_cube(8.0)?.color("#6fbf73").translate(DVec3::X * 12.0),
+		beveled_coin(4.0, 2.0)?.color("#0052ff").translate(DVec3::X * 24.0),
+	];
+
+	let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create STEP file");
+	cadrum::write_step(&result, &mut f).expect("failed to write STEP");
+
+	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
+	cadrum::mesh(&result, 0.2).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), true, true, &mut f)).expect("failed to write SVG");
+
+	println!("wrote {example_name}.step / {example_name}.svg");
+	Ok(())
+}
+
+```
+- [11_chamfer.step](https://lzpel.github.io/cadrum/11_chamfer.step)
+
+<p align="center">
+  <img src="https://lzpel.github.io/cadrum/11_chamfer.svg" alt="11_chamfer" width="360"/>
 </p>
 
 

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -60,6 +60,7 @@
 
 // --- Sweep / pipe / loft ---
 #include <BRepFilletAPI_MakeFillet.hxx>
+#include <BRepFilletAPI_MakeChamfer.hxx>
 #include <BRepOffsetAPI_MakeOffsetShape.hxx>
 #include <BRepOffsetAPI_MakePipeShell.hxx>
 #include <BRepOffsetAPI_MakeThickSolid.hxx>
@@ -1253,6 +1254,37 @@ std::unique_ptr<TopoDS_Shape> make_fillet(
         if (result.IsNull()) return nullptr;
         // MakeFillet can wrap the solid in a compound; Solid::new requires a
         // TopAbs_SOLID, so extract the first one if we got a container.
+        if (result.ShapeType() != TopAbs_SOLID) {
+            TopExp_Explorer ex(result, TopAbs_SOLID);
+            if (!ex.More()) return nullptr;
+            result = ex.Current();
+        }
+        return std::make_unique<TopoDS_Shape>(result);
+    } catch (const Standard_Failure&) {
+        return nullptr;
+    }
+}
+
+std::unique_ptr<TopoDS_Shape> make_chamfer(
+    const TopoDS_Shape& solid,
+    const std::vector<TopoDS_Edge>& edges,
+    double distance)
+{
+    try {
+        if (edges.empty()) {
+            return std::make_unique<TopoDS_Shape>(solid);
+        }
+        BRepFilletAPI_MakeChamfer mk(solid);
+        for (const TopoDS_Edge& e : edges) {
+            if (e.IsNull()) continue;
+            mk.Add(distance, e);
+        }
+        mk.Build();
+        if (!mk.IsDone()) return nullptr;
+        TopoDS_Shape result = mk.Shape();
+        if (result.IsNull()) return nullptr;
+        // Like MakeFillet, MakeChamfer may wrap the result in a compound.
+        // Extract the first solid so Solid::new's TopAbs_SOLID invariant holds.
         if (result.ShapeType() != TopAbs_SOLID) {
             TopExp_Explorer ex(result, TopAbs_SOLID);
             if (!ex.More()) return nullptr;

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -1252,8 +1252,8 @@ std::unique_ptr<TopoDS_Shape> make_fillet(
         if (!mk.IsDone()) return nullptr;
         TopoDS_Shape result = mk.Shape();
         if (result.IsNull()) return nullptr;
-        // MakeFillet can wrap the solid in a compound; Solid::new requires a
-        // TopAbs_SOLID, so extract the first one if we got a container.
+        // MakeFillet can wrap the solid in a compound even if it contains only one solid.
+        // Solid::new requires a TopAbs_SOLID, so extract the first one if we got a container.
         if (result.ShapeType() != TopAbs_SOLID) {
             TopExp_Explorer ex(result, TopAbs_SOLID);
             if (!ex.More()) return nullptr;
@@ -1283,7 +1283,7 @@ std::unique_ptr<TopoDS_Shape> make_chamfer(
         if (!mk.IsDone()) return nullptr;
         TopoDS_Shape result = mk.Shape();
         if (result.IsNull()) return nullptr;
-        // Like MakeFillet, MakeChamfer may wrap the result in a compound.
+        // Like MakeFillet, MakeChamfer may wrap the result in a compound even if it contains only one solid.
         // Extract the first solid so Solid::new's TopAbs_SOLID invariant holds.
         if (result.ShapeType() != TopAbs_SOLID) {
             TopExp_Explorer ex(result, TopAbs_SOLID);

--- a/cpp/wrapper.h
+++ b/cpp/wrapper.h
@@ -346,6 +346,16 @@ std::unique_ptr<TopoDS_Shape> make_fillet(
     const std::vector<TopoDS_Edge>& edges,
     double radius);
 
+// Chamfer (symmetric bevel) the given edges of `solid` with a uniform
+// distance using BRepFilletAPI_MakeChamfer. Empty `edges` is a no-op
+// (returns a shallow copy of `solid`). Returns nullptr on OCCT failure
+// (distance too large, tangent discontinuity, edges not belonging to
+// `solid`, etc.).
+std::unique_ptr<TopoDS_Shape> make_chamfer(
+    const TopoDS_Shape& solid,
+    const std::vector<TopoDS_Edge>& edges,
+    double distance);
+
 // Loft (skin) a smooth solid through N cross-section wires.
 // Sections in `all_edges` are separated by null-edge sentinels.
 std::unique_ptr<TopoDS_Shape> make_loft(

--- a/examples/11_chamfer.rs
+++ b/examples/11_chamfer.rs
@@ -14,6 +14,7 @@ fn beveled_cube(size: f64) -> Result<Solid, Error> {
 fn beveled_top_cube(size: f64) -> Result<Solid, Error> {
 	let cube = Solid::cube(size, size, size).translate(-DVec3::ONE * (size / 2.0));
 	let distance = size * 0.2;
+	// Top cap boundary: a closed circular edge whose start == end lives at z = h.
 	let top_edges = cube
 		.iter_edge()
 		.filter(|e| [e.start_point(), e.end_point()].iter().all(|p| (p.z - size / 2.0).abs() < 1e-6));

--- a/examples/11_chamfer.rs
+++ b/examples/11_chamfer.rs
@@ -1,0 +1,50 @@
+//! Demo of `Solid::chamfer_edges` — mirror of `10_fillet.rs` using bevels:
+//! - All 12 cube edges chamfered uniformly (beveled cube)
+//! - Only top 4 edges chamfered (soft top, sharp base)
+//! - Cylinder top circular edge chamfered (coin with beveled rim)
+
+use cadrum::{DVec3, Error, Solid};
+
+fn beveled_cube(size: f64) -> Result<Solid, Error> {
+	let cube = Solid::cube(size, size, size).translate(-DVec3::ONE * (size / 2.0));
+	let distance = size * 0.2;
+	cube.chamfer_edges(distance, cube.iter_edge())
+}
+
+fn beveled_top_cube(size: f64) -> Result<Solid, Error> {
+	let cube = Solid::cube(size, size, size).translate(-DVec3::ONE * (size / 2.0));
+	let distance = size * 0.2;
+	let top_edges = cube
+		.iter_edge()
+		.filter(|e| [e.start_point(), e.end_point()].iter().all(|p| (p.z - size / 2.0).abs() < 1e-6));
+	cube.chamfer_edges(distance, top_edges)
+}
+
+fn beveled_coin(radius: f64, height: f64) -> Result<Solid, Error> {
+	let cyl = Solid::cylinder(radius, DVec3::Z, height);
+	let distance = height * 0.3;
+	// Top cap boundary: a closed circular edge whose start == end lives at z = h.
+	let top_circle = cyl
+		.iter_edge()
+		.filter(|e| [e.start_point(), e.end_point()].iter().all(|p| (p.z - height).abs() < 1e-6));
+	cyl.chamfer_edges(distance, top_circle)
+}
+
+fn main() -> Result<(), Error> {
+	let example_name = std::path::Path::new(file!()).file_stem().unwrap().to_str().unwrap();
+
+	let result = [
+		beveled_cube(8.0)?.color("#d0a878"),
+		beveled_top_cube(8.0)?.color("#6fbf73").translate(DVec3::X * 12.0),
+		beveled_coin(4.0, 2.0)?.color("#0052ff").translate(DVec3::X * 24.0),
+	];
+
+	let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create STEP file");
+	cadrum::write_step(&result, &mut f).expect("failed to write STEP");
+
+	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
+	cadrum::mesh(&result, 0.2).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), true, true, &mut f)).expect("failed to write SVG");
+
+	println!("wrote {example_name}.step / {example_name}.svg");
+	Ok(())
+}

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -43,6 +43,11 @@ pub enum Error {
 	/// the selected edge chain, or an edge not belonging to `self` was passed.
 	FilletFailed,
 
+	/// Chamfer (`Solid::chamfer_edges` via `BRepFilletAPI_MakeChamfer`) failed:
+	/// distance too large for the local geometry, tangent discontinuity along
+	/// the selected edge chain, or an edge not belonging to `self` was passed.
+	ChamferFailed,
+
 	/// Lofting (`Solid::loft` / `BRepOffsetAPI_ThruSections`) failed: section
 	/// count too low, section wire ill-formed, or OCCT internal failure.
 	/// The string identifies which precondition or stage failed.
@@ -86,6 +91,7 @@ impl std::fmt::Display for Error {
 			Error::SweepFailed => write!(f, "Sweep failed"),
 			Error::ShellFailed => write!(f, "Shell failed"),
 			Error::FilletFailed => write!(f, "Fillet failed"),
+			Error::ChamferFailed => write!(f, "Chamfer failed"),
 			Error::LoftFailed(msg) => write!(f, "Loft failed: {}", msg),
 			Error::BsplineFailed(msg) => write!(f, "Bspline failed: {}", msg),
 			Error::InvalidEdge(msg) => write!(f, "Invalid edge: {}", msg),

--- a/src/occt/ffi.rs
+++ b/src/occt/ffi.rs
@@ -185,6 +185,7 @@ mod ffi_bridge {
 
 		fn make_thick_solid(solid: &TopoDS_Shape, open_faces: &CxxVector<TopoDS_Face>, thickness: f64) -> UniquePtr<TopoDS_Shape>;
 		fn make_fillet(solid: &TopoDS_Shape, edges: &CxxVector<TopoDS_Edge>, radius: f64) -> UniquePtr<TopoDS_Shape>;
+		fn make_chamfer(solid: &TopoDS_Shape, edges: &CxxVector<TopoDS_Edge>, distance: f64) -> UniquePtr<TopoDS_Shape>;
 	}
 }
 

--- a/src/occt/solid.rs
+++ b/src/occt/solid.rs
@@ -241,7 +241,7 @@ impl SolidStruct for Solid {
 		))
 	}
 
-	// ==================== Fillet ====================
+	// ==================== Fillet / Chamfer ====================
 
 	fn fillet_edges<'a>(&self, radius: f64, edges: impl IntoIterator<Item = &'a Edge>) -> Result<Self, Error> {
 		let mut edge_vec = ffi::edge_vec_new();
@@ -251,6 +251,22 @@ impl SolidStruct for Solid {
 		let shape = ffi::make_fillet(&self.inner, &edge_vec, radius);
 		if shape.is_null() {
 			return Err(Error::FilletFailed);
+		}
+		Ok(Solid::new(
+			shape,
+			#[cfg(feature = "color")]
+			std::collections::HashMap::new(),
+		))
+	}
+
+	fn chamfer_edges<'a>(&self, distance: f64, edges: impl IntoIterator<Item = &'a Edge>) -> Result<Self, Error> {
+		let mut edge_vec = ffi::edge_vec_new();
+		for e in edges {
+			ffi::edge_vec_push(edge_vec.pin_mut(), &e.inner);
+		}
+		let shape = ffi::make_chamfer(&self.inner, &edge_vec, distance);
+		if shape.is_null() {
+			return Err(Error::ChamferFailed);
 		}
 		Ok(Solid::new(
 			shape,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -474,6 +474,17 @@ pub trait SolidStruct: Sized + Clone + Compound {
 	/// a selector chain legitimately yields zero edges.
 	fn fillet_edges<'a>(&self, radius: f64, edges: impl IntoIterator<Item = &'a Self::Edge>) -> Result<Self, Error> where Self::Edge: 'a;
 
+	/// Chamfer (bevel) the given edges of `self` with a uniform distance.
+	/// Edges are typically selected via `self.iter_edge().filter(...)`.
+	///
+	/// Wraps `BRepFilletAPI_MakeChamfer`. The chamfer plane is symmetric —
+	/// the same `distance` is taken off along each of the two faces
+	/// adjacent to the edge. Fails (`Error::ChamferFailed`) under the same
+	/// conditions as `fillet_edges`.
+	///
+	/// Empty `edges` is a no-op and returns a clone of `self`.
+	fn chamfer_edges<'a>(&self, distance: f64, edges: impl IntoIterator<Item = &'a Self::Edge>) -> Result<Self, Error> where Self::Edge: 'a;
+
 	// --- Sweep ---
 	/// Sweep a closed profile wire (= ordered edge list) along a spine wire
 	/// to create a solid. Both inputs are accepted as `IntoIterator` of edge

--- a/tests/chamfer.rs
+++ b/tests/chamfer.rs
@@ -1,0 +1,69 @@
+//! Integration tests for `Solid::chamfer_edges`.
+//!
+//! A cube with edge length `a` chamfered by distance `d` (d ≤ a/2) removes
+//! material from 12 edges (triangular wedges) and their corner overlaps.
+//! Inclusion-exclusion on 12 wedges / 24 pair-intersections at corners /
+//! 8 triple-intersections at corners gives the closed form
+//!   `V_removed = 6 d² (a − d)`.
+//! This is used below to validate OCCT's output within 0.1%.
+
+use cadrum::{Error, Solid};
+
+const EPS: f64 = 1e-6;
+
+#[test]
+fn test_chamfer_cube_reduces_volume_and_area() {
+	let a = 10.0_f64;
+	let d = 1.0_f64;
+	let cube = Solid::cube(a, a, a);
+	let original_volume = cube.volume();
+	let original_area = cube.area();
+	let edges: Vec<_> = cube.iter_edge().collect();
+	let beveled = cube.chamfer_edges(d, edges).expect("chamfer should succeed");
+
+	assert!(beveled.volume() < original_volume,
+		"chamfer must reduce volume: {} vs {}", beveled.volume(), original_volume);
+	assert!(beveled.area() < original_area,
+		"chamfer must reduce area: {} vs {}", beveled.area(), original_area);
+}
+
+#[test]
+fn test_chamfer_cube_matches_analytical_volume() {
+	let a = 10.0_f64;
+	let d = 1.0_f64;
+	let cube = Solid::cube(a, a, a);
+	let edges: Vec<_> = cube.iter_edge().collect();
+	let beveled = cube.chamfer_edges(d, edges).expect("chamfer cube");
+
+	// Inclusion-exclusion:
+	//   12 edge-wedges (d²/2 × a)       = 6 a d²
+	//   − 24 corner pair-intersections  = 8 d³
+	//   + 8 corner triple-intersections = 2 d³
+	//   = 6 d² (a − d)
+	let expected = a.powi(3) - 6.0 * d * d * (a - d);
+	let rel_err = (beveled.volume() - expected).abs() / expected;
+	assert!(rel_err < 1e-3,
+		"chamfered cube volume {} vs analytical {} (rel err {})",
+		beveled.volume(), expected, rel_err);
+}
+
+#[test]
+fn test_chamfer_empty_edges_is_noop() {
+	let cube = Solid::cube(5.0, 5.0, 5.0);
+	let original_volume = cube.volume();
+	let unchanged = cube
+		.chamfer_edges(0.5, std::iter::empty::<&cadrum::Edge>())
+		.expect("empty chamfer is a no-op, not an error");
+	assert!((unchanged.volume() - original_volume).abs() < EPS,
+		"no-op chamfer should preserve volume exactly, got {}", unchanged.volume());
+}
+
+#[test]
+fn test_chamfer_distance_too_large_returns_err() {
+	let cube = Solid::cube(2.0, 2.0, 2.0);
+	let edges: Vec<_> = cube.iter_edge().collect();
+	// d = 5 > a/2 = 1 → geometrically impossible; OCCT reports not-done.
+	let err = cube.chamfer_edges(5.0, edges).err().expect("oversized distance must fail");
+	assert!(matches!(err, Error::ChamferFailed),
+		"expected ChamferFailed, got {:?}", err);
+}


### PR DESCRIPTION
## 概要

Close #112

`BRepFilletAPI_MakeChamfer` をラップして均一 distance の chamfer を追加。#112 の後半 (#116 の対)。

```rust
cube.chamfer_edges(1.0, cube.iter_edge().filter(|e| /* selector */))?
```

### 設計決定
`fillet_edges` と**完全対称** — シグネチャ、所有権、no-op-on-empty セマンティクス、compound → solid 抽出、`HashMap::new()` colormap リセット、すべて fillet を鏡写し。
- 対称 chamfer (両側同 distance) のみ。非対称 `Dis1/Dis2` や distance+angle は別 issue。
- 失敗時は `Error::ChamferFailed` 新設 (payload なし)。
- 空 edges は no-op で入力 clone を返す。
- OCCT が compound で返したら `TopExp_Explorer TopAbs_SOLID` で最初の solid を取る (fillet と同じポリシー、パターン 2 の情報損失は受容)。

### 解析値テスト
立方体 (辺 a) を distance d で全 12 edges 面取りした除去体積を inclusion-exclusion で導出:
- 12 edge 楔: `6 a d²`
- 24 corner pair 交差: `-8 d³`
- 8 corner triple 交差: `+2 d³`
- **`V_removed = 6 d² (a − d)`**

a=10, d=1 で期待値 946、実測との rel_err < 1e-3 で pass。

## テスト計画
- [x] `cargo test --test chamfer` — 4 テスト (体積/面積減少、解析値照合、空 no-op、distance 過大 → ChamferFailed)
- [x] `cargo test` — 既存全 suite green
- [x] `cargo build --no-default-features`
- [x] `cargo run --example 11_chamfer` — beveled cube / beveled-top cube / beveled coin の 3 例を STEP + SVG 出力

🤖 Generated with [Claude Code](https://claude.com/claude-code)