### PR TITLE
release: bump version to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "cadrum"
-version = "0.6.5"
+version = "0.7.0"
 dependencies = [
  "cmake",
  "cxx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cadrum"
-version = "0.6.5"
+version = "0.7.0"
 edition = "2021"
 description = "Rust CAD library powered by statically linked, headless OpenCASCADE (OCCT 8.0.0-rc5)"
 license = "MIT"


### PR DESCRIPTION
## 概要
0.6.5 以降の変更が大きいため minor bump。

### Breaking
- `Compound::shell_count` → `area` / `center` / `inertia` に置換 (#114)
- `Wire` トレイトに `end_point` / `end_tangent` を追加 — 外部 impl があれば破壊的

### New features
- `Solid::shell` — `BRepOffsetAPI_MakeThickSolid` ラッパー、sealed-void モード含む (#108, #109)
- `Solid::fillet_edges` — `BRepFilletAPI_MakeFillet` ラッパー (#116)
- `Solid::chamfer_edges` — `BRepFilletAPI_MakeChamfer` ラッパー (#117)

## Test plan
- [x] `cargo build` / `cargo build --no-default-features`
- [x] `cargo test` — 全 suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)