### PR TITLE
Close #121: add Wire::project for closest-point / tangent query

### DIFF
--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -82,6 +82,7 @@
 #include <GCPnts_TangentialDeflection.hxx>
 #include <GeomAPI_Interpolate.hxx>
 #include <GeomAPI_PointsToBSplineSurface.hxx>
+#include <GeomAPI_ProjectPointOnCurve.hxx>
 #include <Geom_BSplineCurve.hxx>
 #include <Geom_BSplineSurface.hxx>
 #include <NCollection_Array2.hxx>
@@ -1073,6 +1074,44 @@ bool edge_is_closed(const TopoDS_Edge& edge) {
         gp_Pnt p_start = curve.Value(curve.FirstParameter());
         gp_Pnt p_end   = curve.Value(curve.LastParameter());
         return p_start.Distance(p_end) < Precision::Confusion();
+    } catch (const Standard_Failure&) {
+        return false;
+    }
+}
+
+bool edge_project_point(const TopoDS_Edge& edge,
+    double px, double py, double pz,
+    double& cpx, double& cpy, double& cpz,
+    double& tx, double& ty, double& tz)
+{
+    cpx = 0.0; cpy = 0.0; cpz = 0.0;
+    tx = 0.0; ty = 0.0; tz = 0.0;
+    try {
+        double first = 0.0, last = 0.0;
+        Handle(Geom_Curve) gcurve = BRep_Tool::Curve(edge, first, last);
+        if (gcurve.IsNull()) return false;
+        gp_Pnt target(px, py, pz);
+        GeomAPI_ProjectPointOnCurve projector(target, gcurve, first, last);
+        double u;
+        if (projector.NbPoints() > 0) {
+            u = projector.LowerDistanceParameter();
+        } else {
+            // No interior extremum within [first, last] — distance is monotonic
+            // along the curve segment (e.g. line segment with target beyond an
+            // endpoint). Clamp to whichever endpoint is closer.
+            double d_first = target.Distance(gcurve->Value(first));
+            double d_last  = target.Distance(gcurve->Value(last));
+            u = (d_first <= d_last) ? first : last;
+        }
+        gp_Pnt p;
+        gp_Vec v;
+        gcurve->D1(u, p, v);
+        cpx = p.X(); cpy = p.Y(); cpz = p.Z();
+        if (v.Magnitude() > Precision::Confusion()) {
+            v.Normalize();
+            tx = v.X(); ty = v.Y(); tz = v.Z();
+        }
+        return true;
     } catch (const Standard_Failure&) {
         return false;
     }

--- a/cpp/wrapper.h
+++ b/cpp/wrapper.h
@@ -272,6 +272,13 @@ void edge_tangents(const TopoDS_Edge& edge,
     double& ex, double& ey, double& ez);
 bool edge_is_closed(const TopoDS_Edge& edge);
 
+// Project a world point onto the edge's underlying curve. Returns false if
+// the curve is missing or the projector cannot converge (leaves outputs 0).
+bool edge_project_point(const TopoDS_Edge& edge,
+    double px, double py, double pz,
+    double& cpx, double& cpy, double& cpz,
+    double& tx, double& ty, double& tz);
+
 // Edge clone (deep copy of underlying TShape).
 std::unique_ptr<TopoDS_Edge> deep_copy_edge(const TopoDS_Edge& edge);
 

--- a/src/occt/edge.rs
+++ b/src/occt/edge.rs
@@ -173,6 +173,20 @@ impl Wire for Edge {
 			.map(|c| DVec3::new(c[0], c[1], c[2]))
 			.collect()
 	}
+
+	fn project(&self, p: DVec3) -> (DVec3, DVec3) {
+		let (mut cpx, mut cpy, mut cpz) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut tx, mut ty, mut tz) = (0.0_f64, 0.0_f64, 0.0_f64);
+		// FFI returns false only on truly degenerate edges (no 3D Geom_Curve,
+		// or OCCT internal exception). All cadrum-constructed edges carry a
+		// Geom_Curve, so this is effectively unreachable — treat as a bug and
+		// fail fast rather than returning silent zero.
+		assert!(
+			ffi::edge_project_point(&self.inner, p.x, p.y, p.z, &mut cpx, &mut cpy, &mut cpz, &mut tx, &mut ty, &mut tz),
+			"Edge::project: edge has no 3D curve or OCCT projector threw (this is a bug)"
+		);
+		(DVec3::new(cpx, cpy, cpz), DVec3::new(tx, ty, tz))
+	}
 }
 
 // Transform は trait 要件で `-> Self` を返すため Result にできない。

--- a/src/occt/ffi.rs
+++ b/src/occt/ffi.rs
@@ -163,6 +163,7 @@ mod ffi_bridge {
 		fn edge_endpoints(edge: &TopoDS_Edge, sx: &mut f64, sy: &mut f64, sz: &mut f64, ex: &mut f64, ey: &mut f64, ez: &mut f64);
 		fn edge_tangents(edge: &TopoDS_Edge, sx: &mut f64, sy: &mut f64, sz: &mut f64, ex: &mut f64, ey: &mut f64, ez: &mut f64);
 		fn edge_is_closed(edge: &TopoDS_Edge) -> bool;
+		fn edge_project_point(edge: &TopoDS_Edge, px: f64, py: f64, pz: f64, cpx: &mut f64, cpy: &mut f64, cpz: &mut f64, tx: &mut f64, ty: &mut f64, tz: &mut f64) -> bool;
 
 		fn deep_copy_edge(edge: &TopoDS_Edge) -> UniquePtr<TopoDS_Edge>;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -286,6 +286,9 @@ pub enum BSplineEnd {
 ///   For a `Vec<Edge>`, whether the first edge's start equals the last edge's end.
 /// - `approximation_segments` — polyline approximation. For a wire, all
 ///   sub-edges' segments are concatenated in order.
+/// - `project` — closest point on the wire to a given world point, with the
+///   unit tangent at that point. For a `Vec<Edge>`, projects onto every
+///   sub-edge and returns the result with the smallest distance to `p`.
 ///
 /// Spatial transforms live on the (crate-private) supertrait `Transform`.
 /// Since `Transform` is not re-exported from the crate root, users cannot
@@ -305,6 +308,15 @@ pub trait Wire: Transform {
 	fn end_tangent(&self) -> DVec3;
 	fn is_closed(&self) -> bool;
 	fn approximation_segments(&self, tolerance: f64) -> Vec<DVec3>;
+	/// Project `p` onto the wire and return `(closest_point, unit_tangent)`.
+	/// The tangent follows the curve's native parameter direction.
+	///
+	/// An empty wire returns `(DVec3::ZERO, DVec3::ZERO)`, matching the
+	/// silent-zero convention of `start_point` / `start_tangent`. A single
+	/// `Edge` that lacks a 3D geometric curve (i.e. FFI-level failure,
+	/// which cadrum-built edges never produce) panics — that case
+	/// indicates a bug, not a degenerate user input.
+	fn project(&self, p: DVec3) -> (DVec3, DVec3);
 
 	// --- Transform forwarders ---
 	// Let `use cadrum::Wire;` alone pull the Transform surface into scope.
@@ -745,6 +757,10 @@ impl<T: EdgeStruct> Wire for Vec<T> {
 		}
 		out
 	}
+
+	fn project(&self, p: DVec3) -> (DVec3, DVec3) {
+		project_over_edges(self.iter(), p)
+	}
 }
 
 impl<T: EdgeStruct, const N: usize> Wire for [T; N] {
@@ -789,6 +805,18 @@ impl<T: EdgeStruct, const N: usize> Wire for [T; N] {
 		}
 		out
 	}
+
+	fn project(&self, p: DVec3) -> (DVec3, DVec3) {
+		project_over_edges(self.iter(), p)
+	}
+}
+
+fn project_over_edges<'a, T: 'a + EdgeStruct + Wire>(edges: impl IntoIterator<Item = &'a T>, p: DVec3) -> (DVec3, DVec3) {
+	edges
+		.into_iter()
+		.map(|e| e.project(p))
+		.min_by(|(a, _), (b, _)| (a - p).length_squared().partial_cmp(&(b - p).length_squared()).unwrap_or(std::cmp::Ordering::Equal))
+		.unwrap_or((DVec3::ZERO, DVec3::ZERO))
 }
 
 // ==================== I/O ====================

--- a/tests/edge.rs
+++ b/tests/edge.rs
@@ -1,0 +1,90 @@
+//! Integration tests for `Edge` query APIs — currently only `Wire::project`.
+//!
+//! Covers single `Edge` and multi-edge wire (`Vec<Edge>`) paths across a
+//! mix of curve kinds (line, circle, polygon, B-spline). The expected
+//! closest point is computed analytically from the curve definition and
+//! compared to the FFI result.
+
+use cadrum::{BSplineEnd, Edge, Wire};
+use glam::DVec3;
+
+const TOL: f64 = 1e-6;
+
+fn approx_eq(a: DVec3, b: DVec3, tol: f64) -> bool {
+	(a - b).length() < tol
+}
+
+#[test]
+fn project_on_line_midpoint() {
+	// Line from -X to +X along X axis; query above the midpoint -> projects to origin.
+	let e = Edge::line(DVec3::new(-1.0, 0.0, 0.0), DVec3::new(1.0, 0.0, 0.0)).unwrap();
+	let (cp, tg) = e.project(DVec3::new(0.0, 1.0, 0.0));
+	assert!(approx_eq(cp, DVec3::ZERO, TOL), "cp={cp:?}");
+	// Tangent is ±X (normalized).
+	assert!((tg.x.abs() - 1.0).abs() < TOL && tg.y.abs() < TOL && tg.z.abs() < TOL, "tg={tg:?}");
+}
+
+#[test]
+fn project_on_circle_returns_radius() {
+	// Unit circle in XY plane; project (2, 0, 0) -> expect (1, 0, 0).
+	let e = Edge::circle(1.0, DVec3::Z).unwrap();
+	let (cp, tg) = e.project(DVec3::new(2.0, 0.0, 0.0));
+	assert!(approx_eq(cp, DVec3::new(1.0, 0.0, 0.0), TOL), "cp={cp:?}");
+	// At (1,0,0) the unit-tangent to a CCW-parameterized circle is ±Y.
+	assert!(tg.x.abs() < TOL && (tg.y.abs() - 1.0).abs() < TOL && tg.z.abs() < TOL, "tg={tg:?}");
+	// Off-plane query still lands on the circle in XY.
+	let (cp2, _) = e.project(DVec3::new(3.0, 0.0, 5.0));
+	assert!(approx_eq(cp2, DVec3::new(1.0, 0.0, 0.0), TOL), "cp2={cp2:?}");
+}
+
+#[test]
+fn project_on_polygon_picks_nearest_edge() {
+	// Closed square in XY plane: edges (±1, ±1, 0). Query point near +X edge.
+	let square = Edge::polygon([
+		DVec3::new(1.0, 1.0, 0.0),
+		DVec3::new(-1.0, 1.0, 0.0),
+		DVec3::new(-1.0, -1.0, 0.0),
+		DVec3::new(1.0, -1.0, 0.0),
+	].iter()).unwrap();
+	// (2, 0, 0) is closest to the right edge x=1, y∈[-1,1] -> (1, 0, 0).
+	let (cp, _) = square.project(DVec3::new(2.0, 0.0, 0.0));
+	assert!(approx_eq(cp, DVec3::new(1.0, 0.0, 0.0), TOL), "cp={cp:?}");
+	// (-2, -3, 0) is closest to the corner (-1, -1, 0).
+	let (cp2, _) = square.project(DVec3::new(-2.0, -3.0, 0.0));
+	assert!(approx_eq(cp2, DVec3::new(-1.0, -1.0, 0.0), TOL), "cp2={cp2:?}");
+}
+
+#[test]
+fn project_on_bspline_converges_to_interpolant() {
+	// Periodic cubic B-spline through four XY ring points. Origin should
+	// project somewhere on the ring; its distance is roughly the ring's
+	// mean radius (≈1.0 here since all control points are unit-distant).
+	let pts = [
+		DVec3::new(1.0, 0.0, 0.0),
+		DVec3::new(0.0, 1.0, 0.0),
+		DVec3::new(-1.0, 0.0, 0.0),
+		DVec3::new(0.0, -1.0, 0.0),
+	];
+	let e = Edge::bspline(pts.iter(), BSplineEnd::Periodic).unwrap();
+	let (cp, tg) = e.project(DVec3::ZERO);
+	// A periodic cubic B-spline interpolating 4 unit-distance points is
+	// not a perfect circle — it "cuts the corner" between knots, so the
+	// closest-to-origin point sits strictly inside the unit circle.
+	// Confirm the projection is on the curve (not at origin) and within
+	// the sensible envelope (chord midpoint = √0.5 ≈ 0.707 .. unit = 1.0).
+	let r = cp.length();
+	assert!((0.7..=1.0).contains(&r), "radius out of envelope: {r}");
+	// Tangent is unit-length.
+	assert!((tg.length() - 1.0).abs() < TOL, "|tg|={}", tg.length());
+}
+
+#[test]
+fn project_empty_wire_returns_zero() {
+	// Matches the silent-zero convention of `start_point` / `start_tangent`
+	// on empty `Vec<Edge>` — degenerate inputs yield (ZERO, ZERO) rather
+	// than an error, keeping the Wire API uniformly total.
+	let empty: Vec<Edge> = Vec::new();
+	let (cp, tg) = empty.project(DVec3::ONE);
+	assert_eq!(cp, DVec3::ZERO);
+	assert_eq!(tg, DVec3::ZERO);
+}


### PR DESCRIPTION
Closes #121.

## Summary
- Add `Wire::project(&self, p: DVec3) -> (DVec3, DVec3)` returning `(closest_point, unit_tangent)` for any wire — `Edge`, `Vec<Edge>`, or `[Edge; N]`.
- Backed by OCCT's `GeomAPI_ProjectPointOnCurve`; when the projector finds no interior extremum within `[first, last]` (e.g. a line segment whose perpendicular foot falls outside), the implementation clamps to whichever endpoint is closer rather than failing.
- Multi-edge wires project onto every sub-edge and return the result with the smallest distance to `p`.

## Design notes
- Signature returns a plain tuple (no `Result`). Empty wires yield `(ZERO, ZERO)` — matching the silent-zero convention of `start_point` / `start_tangent`. A single `Edge` lacking a 3D `Geom_Curve` asserts (unreachable for cadrum-constructed edges; signals a bug instead of propagating garbage).
- Does not expose the OCCT curve parameter `u` to users. `u`'s meaning is curve-kind-dependent (angle on circle, chord-length on B-spline, …) and `|dp/du|` is generally not constant, so exposing it would shift semantic weight onto the caller. `project(p)` stays entirely in world coordinates; callers that need whole-curve sampling use the existing `approximation_segments(tolerance)`.

## Test plan
- [x] `cargo test --test edge` — 5 new cases covering line midpoint projection, circle radial projection (in-plane and off-plane), polygon corner clamping, periodic B-spline envelope, and empty-wire zero fallback.
- [x] `cargo test` full suite — no regressions.