### PR TITLE
Close #123: add up_dir parameter to Mesh::write_svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,13 @@ Rust CAD library powered by statically linked, headless [OpenCASCADE](https://de
 | [bspline](#bspline) | [fillet](#fillet) | [chamfer](#chamfer) |  |
 | [<img src="https://lzpel.github.io/cadrum/09_bspline.svg" width="180" alt="bspline"/>](#bspline) | [<img src="https://lzpel.github.io/cadrum/10_fillet.svg" width="180" alt="fillet"/>](#fillet) | [<img src="https://lzpel.github.io/cadrum/11_chamfer.svg" width="180" alt="chamfer"/>](#chamfer) |  |
 
-The image at the top is a stellarator built with cadrum — see [lzpel/alphastell](https://github.com/lzpel/alphastell).
-
 More examples with source code are available at [lzpel.github.io/cadrum](https://lzpel.github.io/cadrum).
 
 Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-cadrum = "^0.6"
+cadrum = "^0.7"
 ```
 
 ## Build
@@ -97,7 +95,7 @@ fn main() {
     cadrum::write_step(&solids, &mut f).expect("failed to write STEP");
 
     let mut svg = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-    cadrum::mesh(&solids, 0.5).and_then(|m| m.write_svg(DVec3::ONE, true, false, &mut svg)).expect("failed to write SVG");
+    cadrum::mesh(&solids, 0.5).and_then(|m| m.write_svg(DVec3::ONE, DVec3::Z, true, false, &mut svg)).expect("failed to write SVG");
 }
 
 ```
@@ -157,7 +155,7 @@ fn main() -> Result<(), cadrum::Error> {
         .collect();
 
     let mut svg = std::fs::File::create(format!("{example_name}.svg")).expect("create file");
-    cadrum::mesh(&all, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), true, false, &mut svg))?;
+    cadrum::mesh(&all, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, false, &mut svg))?;
 
     let mut stl = std::fs::File::create(format!("{example_name}.stl")).expect("create file");
     cadrum::mesh(&all, 0.1).and_then(|m| m.write_stl(&mut stl))?;
@@ -230,7 +228,7 @@ fn main() {
     cadrum::write_step(&solids, &mut f).expect("failed to write STEP");
 
     let mut svg = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-    cadrum::mesh(&solids, 0.5).and_then(|m| m.write_svg(DVec3::ONE, true, false, &mut svg)).expect("failed to write SVG");
+    cadrum::mesh(&solids, 0.5).and_then(|m| m.write_svg(DVec3::ONE, DVec3::Z, true, false, &mut svg)).expect("failed to write SVG");
 }
 
 ```
@@ -282,7 +280,7 @@ fn main() -> Result<(), cadrum::Error> {
     cadrum::write_step(&shapes, &mut f).expect("failed to write STEP");
 
     let mut svg = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-    cadrum::mesh(&shapes, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), true, false, &mut svg)).expect("failed to write SVG");
+    cadrum::mesh(&shapes, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, false, &mut svg)).expect("failed to write SVG");
 
     Ok(())
 }
@@ -374,7 +372,7 @@ fn main() -> Result<(), Error> {
 	cadrum::write_step(&result, &mut f).expect("failed to write STEP");
 
 	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-	cadrum::mesh(&result, 0.5).and_then(|m| m.write_svg(DVec3::ONE, true, false, &mut f)).expect("failed to write SVG");
+	cadrum::mesh(&result, 0.5).and_then(|m| m.write_svg(DVec3::ONE, DVec3::Z, true, false, &mut f)).expect("failed to write SVG");
 
 	println!("wrote {example_name}.step / {example_name}.svg");
 	Ok(())
@@ -449,7 +447,7 @@ fn main() -> Result<(), Error> {
 	cadrum::write_step(&result, &mut f).expect("failed to write STEP");
 
 	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-	cadrum::mesh(&result, 0.5).and_then(|m| m.write_svg(DVec3::ONE, true, false, &mut f)).expect("failed to write SVG");
+	cadrum::mesh(&result, 0.5).and_then(|m| m.write_svg(DVec3::ONE, DVec3::Z, true, false, &mut f)).expect("failed to write SVG");
 
 	println!("wrote {example_name}.step / {example_name}.svg");
 	Ok(())
@@ -596,7 +594,7 @@ fn main() -> Result<(), Error> {
 	cadrum::write_step(&all, &mut f)?;
 	let mut f_svg = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
 	// Helical threads have dense hidden lines that clutter the SVG; disable them.
-	cadrum::mesh(&all, 0.5)?.write_svg(DVec3::new(1.0, 1.0, -1.0), false, false, &mut f_svg)?;
+	cadrum::mesh(&all, 0.5)?.write_svg(DVec3::new(1.0, 1.0, -1.0), DVec3::Z, false, false, &mut f_svg)?;
 	println!("wrote {example_name}.step / {example_name}.svg ({} solids)", all.len());
 	Ok(())
 }
@@ -667,7 +665,7 @@ fn main() -> Result<(), Error> {
 	// Isometric view from (1, 1, 2) with shading so the cavity depth reads
 	// naturally.
 	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-	cadrum::mesh(&result, 0.2).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), true, true, &mut f)).expect("failed to write SVG");
+	cadrum::mesh(&result, 0.2).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, true, &mut f)).expect("failed to write SVG");
 
 	println!("wrote {example_name}.step / {example_name}.svg");
 	Ok(())
@@ -731,7 +729,7 @@ fn main() {
 	let mut f = std::fs::File::create(format!("{example_name}.step")).unwrap();
 	cadrum::write_step(&objects, &mut f).unwrap();
 	let mut f_svg = std::fs::File::create(format!("{example_name}.svg")).unwrap();
-	cadrum::mesh(&objects, 0.1).and_then(|m| m.write_svg(DVec3::new(0.05, 0.05, 1.0), false, true, &mut f_svg)).unwrap();
+	cadrum::mesh(&objects, 0.1).and_then(|m| m.write_svg(DVec3::new(0.05, 0.05, 1.0), DVec3::Y, false, true, &mut f_svg)).unwrap();
 	println!("wrote {example_name}.step / {example_name}.svg");
 }
 
@@ -797,7 +795,7 @@ fn main() -> Result<(), Error> {
 	cadrum::write_step(&result, &mut f).expect("failed to write STEP");
 
 	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-	cadrum::mesh(&result, 0.2).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), true, true, &mut f)).expect("failed to write SVG");
+	cadrum::mesh(&result, 0.2).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, true, &mut f)).expect("failed to write SVG");
 
 	println!("wrote {example_name}.step / {example_name}.svg");
 	Ok(())
@@ -865,7 +863,7 @@ fn main() -> Result<(), Error> {
 	cadrum::write_step(&result, &mut f).expect("failed to write STEP");
 
 	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-	cadrum::mesh(&result, 0.2).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), true, true, &mut f)).expect("failed to write SVG");
+	cadrum::mesh(&result, 0.2).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, true, &mut f)).expect("failed to write SVG");
 
 	println!("wrote {example_name}.step / {example_name}.svg");
 	Ok(())

--- a/examples/01_primitives.rs
+++ b/examples/01_primitives.rs
@@ -26,5 +26,5 @@ fn main() {
     cadrum::write_step(&solids, &mut f).expect("failed to write STEP");
 
     let mut svg = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-    cadrum::mesh(&solids, 0.5).and_then(|m| m.write_svg(DVec3::ONE, true, false, &mut svg)).expect("failed to write SVG");
+    cadrum::mesh(&solids, 0.5).and_then(|m| m.write_svg(DVec3::ONE, DVec3::Z, true, false, &mut svg)).expect("failed to write SVG");
 }

--- a/examples/02_write_read.rs
+++ b/examples/02_write_read.rs
@@ -39,7 +39,7 @@ fn main() -> Result<(), cadrum::Error> {
         .collect();
 
     let mut svg = std::fs::File::create(format!("{example_name}.svg")).expect("create file");
-    cadrum::mesh(&all, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), true, false, &mut svg))?;
+    cadrum::mesh(&all, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, false, &mut svg))?;
 
     let mut stl = std::fs::File::create(format!("{example_name}.stl")).expect("create file");
     cadrum::mesh(&all, 0.1).and_then(|m| m.write_stl(&mut stl))?;

--- a/examples/03_transform.rs
+++ b/examples/03_transform.rs
@@ -37,5 +37,5 @@ fn main() {
     cadrum::write_step(&solids, &mut f).expect("failed to write STEP");
 
     let mut svg = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-    cadrum::mesh(&solids, 0.5).and_then(|m| m.write_svg(DVec3::ONE, true, false, &mut svg)).expect("failed to write SVG");
+    cadrum::mesh(&solids, 0.5).and_then(|m| m.write_svg(DVec3::ONE, DVec3::Z, true, false, &mut svg)).expect("failed to write SVG");
 }

--- a/examples/04_boolean.rs
+++ b/examples/04_boolean.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), cadrum::Error> {
     cadrum::write_step(&shapes, &mut f).expect("failed to write STEP");
 
     let mut svg = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-    cadrum::mesh(&shapes, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), true, false, &mut svg)).expect("failed to write SVG");
+    cadrum::mesh(&shapes, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, false, &mut svg)).expect("failed to write SVG");
 
     Ok(())
 }

--- a/examples/05_extrude.rs
+++ b/examples/05_extrude.rs
@@ -69,7 +69,7 @@ fn main() -> Result<(), Error> {
 	cadrum::write_step(&result, &mut f).expect("failed to write STEP");
 
 	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-	cadrum::mesh(&result, 0.5).and_then(|m| m.write_svg(DVec3::ONE, true, false, &mut f)).expect("failed to write SVG");
+	cadrum::mesh(&result, 0.5).and_then(|m| m.write_svg(DVec3::ONE, DVec3::Z, true, false, &mut f)).expect("failed to write SVG");
 
 	println!("wrote {example_name}.step / {example_name}.svg");
 	Ok(())

--- a/examples/06_loft.rs
+++ b/examples/06_loft.rs
@@ -51,7 +51,7 @@ fn main() -> Result<(), Error> {
 	cadrum::write_step(&result, &mut f).expect("failed to write STEP");
 
 	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-	cadrum::mesh(&result, 0.5).and_then(|m| m.write_svg(DVec3::ONE, true, false, &mut f)).expect("failed to write SVG");
+	cadrum::mesh(&result, 0.5).and_then(|m| m.write_svg(DVec3::ONE, DVec3::Z, true, false, &mut f)).expect("failed to write SVG");
 
 	println!("wrote {example_name}.step / {example_name}.svg");
 	Ok(())

--- a/examples/07_sweep.rs
+++ b/examples/07_sweep.rs
@@ -123,7 +123,7 @@ fn main() -> Result<(), Error> {
 	cadrum::write_step(&all, &mut f)?;
 	let mut f_svg = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
 	// Helical threads have dense hidden lines that clutter the SVG; disable them.
-	cadrum::mesh(&all, 0.5)?.write_svg(DVec3::new(1.0, 1.0, -1.0), false, false, &mut f_svg)?;
+	cadrum::mesh(&all, 0.5)?.write_svg(DVec3::new(1.0, 1.0, -1.0), DVec3::Z, false, false, &mut f_svg)?;
 	println!("wrote {example_name}.step / {example_name}.svg ({} solids)", all.len());
 	Ok(())
 }

--- a/examples/08_shell.rs
+++ b/examples/08_shell.rs
@@ -48,7 +48,7 @@ fn main() -> Result<(), Error> {
 	// Isometric view from (1, 1, 2) with shading so the cavity depth reads
 	// naturally.
 	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-	cadrum::mesh(&result, 0.2).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), true, true, &mut f)).expect("failed to write SVG");
+	cadrum::mesh(&result, 0.2).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, true, &mut f)).expect("failed to write SVG");
 
 	println!("wrote {example_name}.step / {example_name}.svg");
 	Ok(())

--- a/examples/09_bspline.rs
+++ b/examples/09_bspline.rs
@@ -42,6 +42,6 @@ fn main() {
 	let mut f = std::fs::File::create(format!("{example_name}.step")).unwrap();
 	cadrum::write_step(&objects, &mut f).unwrap();
 	let mut f_svg = std::fs::File::create(format!("{example_name}.svg")).unwrap();
-	cadrum::mesh(&objects, 0.1).and_then(|m| m.write_svg(DVec3::new(0.05, 0.05, 1.0), false, true, &mut f_svg)).unwrap();
+	cadrum::mesh(&objects, 0.1).and_then(|m| m.write_svg(DVec3::new(0.05, 0.05, 1.0), DVec3::Y, false, true, &mut f_svg)).unwrap();
 	println!("wrote {example_name}.step / {example_name}.svg");
 }

--- a/examples/10_fillet.rs
+++ b/examples/10_fillet.rs
@@ -44,7 +44,7 @@ fn main() -> Result<(), Error> {
 	cadrum::write_step(&result, &mut f).expect("failed to write STEP");
 
 	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-	cadrum::mesh(&result, 0.2).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), true, true, &mut f)).expect("failed to write SVG");
+	cadrum::mesh(&result, 0.2).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, true, &mut f)).expect("failed to write SVG");
 
 	println!("wrote {example_name}.step / {example_name}.svg");
 	Ok(())

--- a/examples/11_chamfer.rs
+++ b/examples/11_chamfer.rs
@@ -44,7 +44,7 @@ fn main() -> Result<(), Error> {
 	cadrum::write_step(&result, &mut f).expect("failed to write STEP");
 
 	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-	cadrum::mesh(&result, 0.2).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), true, true, &mut f)).expect("failed to write SVG");
+	cadrum::mesh(&result, 0.2).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, true, &mut f)).expect("failed to write SVG");
 
 	println!("wrote {example_name}.step / {example_name}.svg");
 	Ok(())

--- a/examples/chijin.rs
+++ b/examples/chijin.rs
@@ -61,7 +61,7 @@ fn main() -> Result<(), cadrum::Error> {
 	cadrum::write_step(&result, &mut f).expect("failed to write STEP");
 
 	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-	cadrum::mesh(&result, 0.5).and_then(|m| m.write_svg(DVec3::ONE, true, false, &mut f)).expect("failed to write SVG");
+	cadrum::mesh(&result, 0.5).and_then(|m| m.write_svg(DVec3::ONE, DVec3::Z, true, false, &mut f)).expect("failed to write SVG");
 
 	println!("wrote {example_name}.step / {example_name}.svg");
 	Ok(())

--- a/src/common/mesh.rs
+++ b/src/common/mesh.rs
@@ -89,40 +89,40 @@ impl Mesh {
 impl Mesh {
 	/// Render this mesh as an SVG string.
 	///
-	/// `view_dir` is the viewing direction (the direction the camera looks from;
-	/// points with higher `dot(view_dir)` are closer to the camera).
+	/// `view` is the viewing direction (the direction the camera looks from;
+	/// points with higher `dot(view)` are closer to the camera).
 	///
-	/// `up_dir` controls which world-space direction points up on the output
-	/// SVG. It is Gram-Schmidt-orthogonalized against `view_dir`, so it need
+	/// `up` controls which world-space direction points up on the output
+	/// SVG. It is Gram-Schmidt-orthogonalized against `view`, so it need
 	/// not be exactly perpendicular — only non-zero and non-parallel to
-	/// `view_dir`. Engineering convention (Z-up, e.g. VMEC / parastell / most
-	/// CAD tools) maps directly: pass `DVec3::Z`. Panics if `view_dir` is
-	/// zero, `up_dir` is zero, or `up_dir` is parallel to `view_dir` — all of
-	/// which are programmer errors, treated like the degenerate-input panics
-	/// in `Transform::align_x`.
+	/// `view`. Engineering convention (Z-up, e.g. VMEC / parastell / most
+	/// CAD tools) maps directly: pass `DVec3::Z`. Panics if `view` is zero,
+	/// `up` is zero, or `up` is parallel to `view` — all of which are
+	/// programmer errors, treated like the degenerate-input panics in
+	/// `Transform::align_x`.
 	///
 	/// `hidden_lines` controls whether occluded edges are rendered as faint dashed
 	/// lines. Set to `false` for cleaner output on dense models (e.g. helical
 	/// sweeps) where hidden lines dominate the image.
 	///
 	/// `shading` enables Lambertian shading with head-on light
-	/// (light direction == `view_dir`). Front-facing triangles get
-	/// `shade = 0.5 + 0.5 * (normal · dir)`, so glancing faces darken to
+	/// (light direction == `view`). Front-facing triangles get
+	/// `shade = 0.5 + 0.5 * (normal · view)`, so glancing faces darken to
 	/// half intensity. Turn this on for curved/organic shapes where flat
 	/// fill makes the 3D form hard to read; leave it off for clean flat
 	/// rendering matching earlier cadrum output.
 	///
 	/// The method:
-	/// 1. Projects triangles onto the plane perpendicular to `view_dir`
+	/// 1. Projects triangles onto the plane perpendicular to `view`
 	/// 2. Detects silhouette edges from mesh adjacency
 	/// 3. Classifies edges as visible or hidden (only when `hidden_lines`)
 	/// 4. Renders colored triangles, visible edges (black), and optionally hidden edges
-	pub fn write_svg<W: std::io::Write>(&self, view_dir: DVec3, up_dir: DVec3, hidden_lines: bool, shading: bool, writer: &mut W) -> Result<(), super::error::Error> {
-		writer.write_all(self.to_svg(view_dir, up_dir, hidden_lines, shading).as_bytes()).map_err(|_| super::error::Error::SvgExportFailed)
+	pub fn write_svg<W: std::io::Write>(&self, view: DVec3, up: DVec3, hidden_lines: bool, shading: bool, writer: &mut W) -> Result<(), super::error::Error> {
+		writer.write_all(self.to_svg(view, up, hidden_lines, shading).as_bytes()).map_err(|_| super::error::Error::SvgExportFailed)
 	}
 
-	pub fn to_svg(&self, view_dir: DVec3, up_dir: DVec3, hidden_lines: bool, shading: bool) -> String {
-		let (u, v, dir) = projection_basis(view_dir, up_dir);
+	pub fn to_svg(&self, view: DVec3, up: DVec3, hidden_lines: bool, shading: bool) -> String {
+		let (u, v, dir) = projection_basis(view, up);
 
 		// 1. Project and sort triangles for rendering
 		let face_triangles = project_and_sort_triangles(self, dir, u, v, shading);
@@ -161,23 +161,23 @@ struct OcclusionTri {
 }
 
 /// Build an orthonormal camera frame `(u, v, dir)` from user-supplied
-/// `view_dir` and `up_dir`:
+/// `view` and `up`:
 ///
-/// - `dir` = normalized `view_dir` (points from the scene toward the camera)
-/// - `v`   = `up_dir` Gram-Schmidt-orthogonalized against `dir` and normalized
+/// - `dir` = normalized `view` (points from the scene toward the camera)
+/// - `v`   = `up` Gram-Schmidt-orthogonalized against `dir` and normalized
 ///           (the "up" axis on the output SVG)
 /// - `u`   = `v × dir` (the "right" axis on the output SVG; right-handed)
 ///
 /// Panics with a descriptive `expect` message when any input is degenerate
-/// (`view_dir` zero, `up_dir` zero, or `up_dir` parallel to `view_dir`) —
-/// consistent with `Transform::align_x` / `align_y` / `align_z` which also
-/// treat degenerate geometric inputs as programmer errors rather than
-/// recoverable runtime conditions.
-fn projection_basis(view_dir: DVec3, up_dir: DVec3) -> (DVec3, DVec3, DVec3) {
-	let dir = view_dir.try_normalize().expect("write_svg: view_dir is zero");
-	let v = (up_dir - dir * up_dir.dot(dir))
+/// (`view` zero, `up` zero, or `up` parallel to `view`) — consistent with
+/// `Transform::align_x` / `align_y` / `align_z` which also treat degenerate
+/// geometric inputs as programmer errors rather than recoverable runtime
+/// conditions.
+fn projection_basis(view: DVec3, up: DVec3) -> (DVec3, DVec3, DVec3) {
+	let dir = view.try_normalize().expect("write_svg: view is zero");
+	let v = (up - dir * up.dot(dir))
 		.try_normalize()
-		.expect("write_svg: up_dir is zero or parallel to view_dir");
+		.expect("write_svg: up is zero or parallel to view");
 	let u = v.cross(dir);
 	(u, v, dir)
 }

--- a/src/common/mesh.rs
+++ b/src/common/mesh.rs
@@ -89,32 +89,40 @@ impl Mesh {
 impl Mesh {
 	/// Render this mesh as an SVG string.
 	///
-	/// `direction` is the viewing direction (the direction the camera looks from;
-	/// points with higher `dot(direction)` are closer to the camera).
+	/// `view_dir` is the viewing direction (the direction the camera looks from;
+	/// points with higher `dot(view_dir)` are closer to the camera).
+	///
+	/// `up_dir` controls which world-space direction points up on the output
+	/// SVG. It is Gram-Schmidt-orthogonalized against `view_dir`, so it need
+	/// not be exactly perpendicular — only non-zero and non-parallel to
+	/// `view_dir`. Engineering convention (Z-up, e.g. VMEC / parastell / most
+	/// CAD tools) maps directly: pass `DVec3::Z`. Panics if `view_dir` is
+	/// zero, `up_dir` is zero, or `up_dir` is parallel to `view_dir` — all of
+	/// which are programmer errors, treated like the degenerate-input panics
+	/// in `Transform::align_x`.
 	///
 	/// `hidden_lines` controls whether occluded edges are rendered as faint dashed
 	/// lines. Set to `false` for cleaner output on dense models (e.g. helical
 	/// sweeps) where hidden lines dominate the image.
 	///
 	/// `shading` enables Lambertian shading with head-on light
-	/// (light direction == `direction`). Front-facing triangles get
+	/// (light direction == `view_dir`). Front-facing triangles get
 	/// `shade = 0.5 + 0.5 * (normal · dir)`, so glancing faces darken to
 	/// half intensity. Turn this on for curved/organic shapes where flat
 	/// fill makes the 3D form hard to read; leave it off for clean flat
 	/// rendering matching earlier cadrum output.
 	///
 	/// The method:
-	/// 1. Projects triangles onto the plane perpendicular to `direction`
+	/// 1. Projects triangles onto the plane perpendicular to `view_dir`
 	/// 2. Detects silhouette edges from mesh adjacency
 	/// 3. Classifies edges as visible or hidden (only when `hidden_lines`)
 	/// 4. Renders colored triangles, visible edges (black), and optionally hidden edges
-	pub fn write_svg<W: std::io::Write>(&self, direction: DVec3, hidden_lines: bool, shading: bool, writer: &mut W) -> Result<(), super::error::Error> {
-		writer.write_all(self.to_svg(direction, hidden_lines, shading).as_bytes()).map_err(|_| super::error::Error::SvgExportFailed)
+	pub fn write_svg<W: std::io::Write>(&self, view_dir: DVec3, up_dir: DVec3, hidden_lines: bool, shading: bool, writer: &mut W) -> Result<(), super::error::Error> {
+		writer.write_all(self.to_svg(view_dir, up_dir, hidden_lines, shading).as_bytes()).map_err(|_| super::error::Error::SvgExportFailed)
 	}
 
-	pub fn to_svg(&self, direction: DVec3, hidden_lines: bool, shading: bool) -> String {
-		let dir = direction.normalize();
-		let (u, v) = projection_basis(dir);
+	pub fn to_svg(&self, view_dir: DVec3, up_dir: DVec3, hidden_lines: bool, shading: bool) -> String {
+		let (u, v, dir) = projection_basis(view_dir, up_dir);
 
 		// 1. Project and sort triangles for rendering
 		let face_triangles = project_and_sort_triangles(self, dir, u, v, shading);
@@ -152,35 +160,26 @@ struct OcclusionTri {
 	depths: [f64; 3],
 }
 
-/// Compute an orthonormal basis (x_dir, y_dir) for the projection plane
-/// perpendicular to `dir`. Matches OpenCASCADE's gp_Ax2 convention.
-fn projection_basis(dir: DVec3) -> (DVec3, DVec3) {
-	let (a, b, c) = (dir.x, dir.y, dir.z);
-	let (a_abs, b_abs, c_abs) = (a.abs(), b.abs(), c.abs());
-
-	let perp = if b_abs <= a_abs && b_abs <= c_abs {
-		if a_abs > c_abs {
-			DVec3::new(-c, 0.0, a)
-		} else {
-			DVec3::new(c, 0.0, -a)
-		}
-	} else if a_abs <= b_abs && a_abs <= c_abs {
-		if b_abs > c_abs {
-			DVec3::new(0.0, -c, b)
-		} else {
-			DVec3::new(0.0, c, -b)
-		}
-	} else {
-		if a_abs > b_abs {
-			DVec3::new(-b, a, 0.0)
-		} else {
-			DVec3::new(b, -a, 0.0)
-		}
-	};
-
-	let x_dir = perp.normalize();
-	let y_dir = dir.cross(x_dir);
-	(x_dir, y_dir)
+/// Build an orthonormal camera frame `(u, v, dir)` from user-supplied
+/// `view_dir` and `up_dir`:
+///
+/// - `dir` = normalized `view_dir` (points from the scene toward the camera)
+/// - `v`   = `up_dir` Gram-Schmidt-orthogonalized against `dir` and normalized
+///           (the "up" axis on the output SVG)
+/// - `u`   = `v × dir` (the "right" axis on the output SVG; right-handed)
+///
+/// Panics with a descriptive `expect` message when any input is degenerate
+/// (`view_dir` zero, `up_dir` zero, or `up_dir` parallel to `view_dir`) —
+/// consistent with `Transform::align_x` / `align_y` / `align_z` which also
+/// treat degenerate geometric inputs as programmer errors rather than
+/// recoverable runtime conditions.
+fn projection_basis(view_dir: DVec3, up_dir: DVec3) -> (DVec3, DVec3, DVec3) {
+	let dir = view_dir.try_normalize().expect("write_svg: view_dir is zero");
+	let v = (up_dir - dir * up_dir.dot(dir))
+		.try_normalize()
+		.expect("write_svg: up_dir is zero or parallel to view_dir");
+	let u = v.cross(dir);
+	(u, v, dir)
 }
 
 fn project_and_sort_triangles(mesh: &Mesh, dir: DVec3, u: DVec3, v: DVec3, shading: bool) -> Vec<SvgTriangle> {

--- a/tests/bspline.rs
+++ b/tests/bspline.rs
@@ -18,7 +18,7 @@ fn write_outputs(solids: &[Solid], name: &str) {
 	let mut f = std::fs::File::create(format!("out/{name}.stl")).unwrap();
 	cadrum::mesh(solids, 0.1).and_then(|m| m.write_stl(&mut f)).expect("stl write");
 	let mut f = std::fs::File::create(format!("out/{name}.svg")).unwrap();
-	cadrum::mesh(solids, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), true, false, &mut f)).expect("svg write");
+	cadrum::mesh(solids, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, false, &mut f)).expect("svg write");
 }
 
 /// XZ 平面(法線 Y)と YZ 平面(法線 X)で 4 象限に分割し、180° 回転対称

--- a/tests/loft.rs
+++ b/tests/loft.rs
@@ -18,7 +18,7 @@ fn write_outputs(solids: &[Solid], name: &str) {
 	let mut f = std::fs::File::create(format!("out/{name}.stl")).unwrap();
 	cadrum::mesh(solids, 0.1).and_then(|m| m.write_stl(&mut f)).expect("stl write");
 	let mut f = std::fs::File::create(format!("out/{name}.svg")).unwrap();
-	cadrum::mesh(solids, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), true, false, &mut f)).expect("svg write");
+	cadrum::mesh(solids, 0.5).and_then(|m| m.write_svg(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, false, &mut f)).expect("svg write");
 }
 
 // ==================== (1) 数値検証: 円錐台 ====================

--- a/tests/svg.rs
+++ b/tests/svg.rs
@@ -7,7 +7,10 @@ fn dvec3(x: f64, y: f64, z: f64) -> DVec3 {
 
 fn svg_string(shape: &[Solid], direction: DVec3, tol: f64) -> String {
 	let mut buf = Vec::new();
-	cadrum::mesh(shape, tol).and_then(|m| m.write_svg(direction, true, false, &mut buf)).unwrap();
+	// Pick a sensible up for each view: Z-up for oblique/side views,
+	// Y-up when looking straight down Z (view_dir ‖ Z would make Z-up degenerate).
+	let up = if direction.normalize().dot(DVec3::Z).abs() > 0.999 { DVec3::Y } else { DVec3::Z };
+	cadrum::mesh(shape, tol).and_then(|m| m.write_svg(direction, up, true, false, &mut buf)).unwrap();
 	String::from_utf8(buf).unwrap()
 }
 


### PR DESCRIPTION
Closes #123.

## Summary
- Add `up_dir: DVec3` parameter to `Mesh::write_svg` / `Mesh::to_svg`, placed right after `view_dir`. The projection basis now derives its "up" axis from this explicit input (Gram-Schmidt-orthogonalized against `view_dir`) instead of picking one deterministically from `view_dir`'s components, so callers control which world direction ends up pointing up on the rendered SVG.
- Degenerate inputs (`view_dir` zero, `up_dir` zero, or `up_dir` parallel to `view_dir`) panic via `try_normalize().expect(...)` — matching the panic convention of `Transform::align_x` / `align_y` / `align_z` on degenerate geometric inputs. No new `Error` variant is introduced; `Error::SvgExportFailed` remains the I/O-failure branch only.
- `Mesh` struct itself is unchanged — it stays a pure view-independent data container. Only the rendering method signatures grow.

## Call-site updates
- All examples and tests pass `DVec3::Z` (engineering convention). The two near-top-down views (`09_bspline` with `view_dir = (0.05, 0.05, 1.0)` and the `test_svg_box_top_down` test with `view_dir = Z`) pass `DVec3::Y` instead to avoid parallel view/up.
- `README.md` example blocks regenerated from the updated `examples/` via `examples/markdown.rs`.

## Test plan
- [x] `cargo test` — all tests pass (`svg` 5/5, full suite no regressions).
- [x] `cargo run --example markdown -- out/markdown/SUMMARY.md ./README.md` — regenerated SVGs and README embeds without error.