### PR TITLE
feat(solid): introduce history field, drop *_with_metadata and opaque structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,11 +641,18 @@ fn halved_shelled_torus(thickness: f64) -> Result<Solid, Error> {
 	let torus = Solid::torus(6.0, 2.0, DVec3::Y);
 	// Bisect with Y=0 half-space (normal +Y): keep the +Y half of the ring — always 1 solid.
 	let cutter = Solid::half_space(DVec3::ZERO, -DVec3::Z);
-	// from_cutter is a flat [post_id, src_id, ...]: post_ids are TShape addresses
-	// in the result tree, src_ids live in the cutter tree. Both are globally
-	// unique pointers, so `contains` works without separating even/odd indices.
-	let (mut halves, [_, from_cutter]) = torus.intersect_with_metadata(&[cutter])?;
-	let half = halves.pop().ok_or(Error::BooleanOperationFailed)?;
+	// `iter_history()` yields [post_id, src_id] pairs for every result face.
+	// Filter to those whose src_id is one of the cutter's faces, then collect
+	// their post_ids — these are the planar cut faces in the result that we
+	// want to use as shell openings.
+	let cutter_face_ids: std::collections::HashSet<u64> =
+		cutter.iter_face().map(|f| f.tshape_id()).collect();
+	let halves = torus.intersect(&[cutter])?;
+	let half = halves.into_iter().next().ok_or(Error::BooleanOperationFailed)?;
+	let from_cutter: std::collections::HashSet<u64> = half
+		.iter_history()
+		.filter_map(|[post, src]| cutter_face_ids.contains(&src).then_some(post))
+		.collect();
 	half.shell(thickness, half.iter_face().filter(|f| from_cutter.contains(&f.tshape_id())))
 }
 

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -420,11 +420,14 @@ void compound_add(TopoDS_Shape& compound, const TopoDS_Shape& child) {
 //   the face still represents the same plane — it just has smaller bounds.
 //   Generated(tool_face) returns empty because no wholly NEW face was created.
 //
-// from_a / from_b (修正案2):
-//   For each face in src, collect_relay_mapping builds a map from the
-//   pre-copy TShape* of the result face to the TShape* of the original src face.
-//   After BRepBuilderAPI_Copy, copier.ModifiedShape() maps pre→post copy.
-//   The combined mapping (src → pre → post) is stored as flat [post_id, src_id] pairs.
+// out_history (rust::Vec<uint64_t>):
+//   For each face in src (both a and b), collect_relay_mapping builds a map
+//   from the pre-copy TShape* of the result face to the TShape* of the
+//   original src face. After BRepBuilderAPI_Copy, the pre→post mapping is
+//   resolved by index in the IndexedMap. emit_from_pairs pushes flat
+//   [post_id, src_id] pairs into out_history. a and b contributions are
+//   concatenated into the same out_history (no self/tool split — TShape*
+//   pointers are globally unique).
 
 // Helper: build relay map  pre_copy_result_tshape* → src_tshape*
 // Called before BRepBuilderAPI_Copy, while op history is alive.
@@ -457,7 +460,7 @@ static void emit_from_pairs(
     const TopoDS_Shape& pre_shape,
     const TopoDS_Shape& post_shape,
     const std::unordered_map<uint64_t, uint64_t>& relay,
-    std::vector<uint64_t>& out)
+    rust::Vec<uint64_t>& out)
 {
     NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> pre_map, post_map;
     TopExp::MapShapes(pre_shape, TopAbs_FACE, pre_map);
@@ -482,8 +485,12 @@ static void emit_from_pairs(
 // All three OCCT operations derive from BRepAlgoAPI_BooleanOperation, so the
 // post-build relay/copy logic is identical. Branching only at construction
 // avoids triplicating the bookkeeping.
-std::unique_ptr<BooleanShape> boolean_op(
-    const TopoDS_Shape& a, const TopoDS_Shape& b, uint32_t op_kind)
+//
+// out_history is appended-to (not cleared) — caller passes an empty rust::Vec.
+// Both a and b contributions are pushed into the same flat sequence.
+std::unique_ptr<TopoDS_Shape> boolean_op(
+    const TopoDS_Shape& a, const TopoDS_Shape& b, uint32_t op_kind,
+    rust::Vec<uint64_t>& out_history)
 {
     try {
         std::unique_ptr<BRepAlgoAPI_BooleanOperation> op;
@@ -501,30 +508,13 @@ std::unique_ptr<BooleanShape> boolean_op(
         collect_relay_mapping(*op, b, relay_b);
 
         BRepBuilderAPI_Copy copier(op->Shape(), true, false);
-        auto r = std::make_unique<BooleanShape>();
-        r->shape = copier.Shape();
-        emit_from_pairs(op->Shape(), copier.Shape(), relay_a, r->from_a);
-        emit_from_pairs(op->Shape(), copier.Shape(), relay_b, r->from_b);
-        return r;
+        auto shape = std::make_unique<TopoDS_Shape>(copier.Shape());
+        emit_from_pairs(op->Shape(), copier.Shape(), relay_a, out_history);
+        emit_from_pairs(op->Shape(), copier.Shape(), relay_b, out_history);
+        return shape;
     } catch (const Standard_Failure&) {
         return nullptr;
     }
-}
-
-std::unique_ptr<TopoDS_Shape> boolean_shape_shape(const BooleanShape& r) {
-    return std::make_unique<TopoDS_Shape>(r.shape);
-}
-
-rust::Vec<uint64_t> boolean_shape_from_a(const BooleanShape& r) {
-    rust::Vec<uint64_t> v;
-    for (uint64_t x : r.from_a) v.push_back(x);
-    return v;
-}
-
-rust::Vec<uint64_t> boolean_shape_from_b(const BooleanShape& r) {
-    rust::Vec<uint64_t> v;
-    for (uint64_t x : r.from_b) v.push_back(x);
-    return v;
 }
 
 // ==================== Shape Methods ====================
@@ -1837,14 +1827,16 @@ bool write_step_color_stream(
 
 // ==================== Clean with face-origin mapping ====================
 
-std::unique_ptr<CleanShape> clean_shape_full(const TopoDS_Shape& shape) {
+std::unique_ptr<TopoDS_Shape> clean_shape_full(
+    const TopoDS_Shape& shape,
+    rust::Vec<uint64_t>& out_mapping)
+{
     try {
         ShapeUpgrade_UnifySameDomain unifier(shape, true, true, true);
         unifier.AllowInternalEdges(false);
         unifier.Build();
 
-        auto r = std::make_unique<CleanShape>();
-        r->shape = unifier.Shape();
+        auto result = std::make_unique<TopoDS_Shape>(unifier.Shape());
 
         Handle(BRepTools_History) history = unifier.History();
         if (!history.IsNull()) {
@@ -1855,30 +1847,20 @@ std::unique_ptr<CleanShape> clean_shape_full(const TopoDS_Shape& shape) {
                 const NCollection_List<TopoDS_Shape>& mods = history->Modified(old_face);
                 if (mods.IsEmpty()) {
                     // Unchanged: TShape* is the same in the result.
-                    r->mapping.push_back(old_id);
-                    r->mapping.push_back(old_id);
+                    out_mapping.push_back(old_id);
+                    out_mapping.push_back(old_id);
                 } else {
                     // Merged: use only the first resulting face (first-found wins).
                     uint64_t new_id = reinterpret_cast<uint64_t>(mods.First().TShape().get());
-                    r->mapping.push_back(new_id);
-                    r->mapping.push_back(old_id);
+                    out_mapping.push_back(new_id);
+                    out_mapping.push_back(old_id);
                 }
             }
         }
-        return r;
+        return result;
     } catch (const Standard_Failure&) {
         return nullptr;
     }
-}
-
-std::unique_ptr<TopoDS_Shape> clean_shape_get(const CleanShape& r) {
-    return std::make_unique<TopoDS_Shape>(r.shape);
-}
-
-rust::Vec<uint64_t> clean_shape_mapping(const CleanShape& r) {
-    rust::Vec<uint64_t> v;
-    for (uint64_t x : r.mapping) v.push_back(x);
-    return v;
 }
 
 } // namespace cadrum

--- a/cpp/wrapper.h
+++ b/cpp/wrapper.h
@@ -122,25 +122,17 @@ std::unique_ptr<TopoDS_Shape> shallow_copy(const TopoDS_Shape& shape);
 
 // ==================== Boolean Operations ====================
 
-/// Result of a boolean operation.
-///
-/// from_a / from_b encode face-origin pairs as flat arrays:
-///   [post_copy_tshape_id, source_tshape_id, ...]
-/// Used to remap colormaps and derive new_face_ids on the Rust side.
-class BooleanShape {
-public:
-    TopoDS_Shape shape;
-    std::vector<uint64_t> from_a;  // pairs: [post_id, src_a_id, ...]
-    std::vector<uint64_t> from_b;  // pairs: [post_id, src_b_id, ...]
-};
-
 // Unified boolean operation: 0=Fuse(union), 1=Cut(a−b), 2=Common(intersect).
-std::unique_ptr<BooleanShape> boolean_op(
-    const TopoDS_Shape& a, const TopoDS_Shape& b, uint32_t op_kind);
-
-std::unique_ptr<TopoDS_Shape> boolean_shape_shape(const BooleanShape& r);
-rust::Vec<uint64_t> boolean_shape_from_a(const BooleanShape& r);
-rust::Vec<uint64_t> boolean_shape_from_b(const BooleanShape& r);
+//
+// `out_history` receives flat [post_id, src_id, post_id, src_id, ...] pairs
+// for every result face derived from either input (a or b). post_id is the
+// TShape* of the result face; src_id is the TShape* of the original face in
+// whichever input it came from. Self/tool distinction is intentionally
+// collapsed — TShape* pointers are globally unique so callers can filter by
+// matching src_id against either input's face id set.
+std::unique_ptr<TopoDS_Shape> boolean_op(
+    const TopoDS_Shape& a, const TopoDS_Shape& b, uint32_t op_kind,
+    rust::Vec<uint64_t>& out_history);
 
 // ==================== Shape Methods ====================
 
@@ -422,17 +414,12 @@ bool write_step_color_stream(
 
 // ==================== Clean with face-origin mapping ====================
 
-/// Result of clean_shape_full: carries face-origin mapping for color remapping.
-/// mapping is a flat array of [new_tshape_id, old_tshape_id, ...] pairs.
-class CleanShape {
-public:
-    TopoDS_Shape shape;
-    std::vector<uint64_t> mapping; // pairs: [new_id, old_id, ...]
-};
-
-std::unique_ptr<CleanShape> clean_shape_full(const TopoDS_Shape& shape);
-std::unique_ptr<TopoDS_Shape> clean_shape_get(const CleanShape& r);
-rust::Vec<uint64_t> clean_shape_mapping(const CleanShape& r);
+// Returns the cleaned shape; `out_mapping` is appended with flat
+// [new_tshape_id, old_tshape_id, ...] pairs encoding how each old face
+// maps onto the unified result (used to remap the colormap on the Rust side).
+std::unique_ptr<TopoDS_Shape> clean_shape_full(
+    const TopoDS_Shape& shape,
+    rust::Vec<uint64_t>& out_mapping);
 
 } // namespace cadrum
 

--- a/examples/08_shell.rs
+++ b/examples/08_shell.rs
@@ -24,11 +24,18 @@ fn halved_shelled_torus(thickness: f64) -> Result<Solid, Error> {
 	let torus = Solid::torus(6.0, 2.0, DVec3::Y);
 	// Bisect with Y=0 half-space (normal +Y): keep the +Y half of the ring — always 1 solid.
 	let cutter = Solid::half_space(DVec3::ZERO, -DVec3::Z);
-	// from_cutter is a flat [post_id, src_id, ...]: post_ids are TShape addresses
-	// in the result tree, src_ids live in the cutter tree. Both are globally
-	// unique pointers, so `contains` works without separating even/odd indices.
-	let (mut halves, [_, from_cutter]) = torus.intersect_with_metadata(&[cutter])?;
-	let half = halves.pop().ok_or(Error::BooleanOperationFailed)?;
+	// `iter_history()` yields [post_id, src_id] pairs for every result face.
+	// Filter to those whose src_id is one of the cutter's faces, then collect
+	// their post_ids — these are the planar cut faces in the result that we
+	// want to use as shell openings.
+	let cutter_face_ids: std::collections::HashSet<u64> =
+		cutter.iter_face().map(|f| f.tshape_id()).collect();
+	let halves = torus.intersect(&[cutter])?;
+	let half = halves.into_iter().next().ok_or(Error::BooleanOperationFailed)?;
+	let from_cutter: std::collections::HashSet<u64> = half
+		.iter_history()
+		.filter_map(|[post, src]| cutter_face_ids.contains(&src).then_some(post))
+		.collect();
 	half.shell(thickness, half.iter_face().filter(|f| from_cutter.contains(&f.tshape_id())))
 }
 

--- a/notes/20260425-Solid_history導入とCxxOpaqueStruct廃止.md
+++ b/notes/20260425-Solid_history導入とCxxOpaqueStruct廃止.md
@@ -1,0 +1,109 @@
+# Solid::history 導入と Cxx Opaque Struct 廃止
+
+## 背景
+
+これまで boolean 演算 (`union` / `subtract` / `intersect`) は派生情報を戻り値タプルの第 2 要素 `[Vec<u64>; 2]` で返す `*_with_metadata` API を持っていた:
+
+```rust
+// 旧 API (src/traits.rs)
+fn union_with_metadata(...) -> Result<(Vec<Self::Elem>, [Vec<u64>; 2]), Error>;
+fn union(...) -> Result<Vec<Self::Elem>, Error> { Ok(self.union_with_metadata(tool)?.0) }
+```
+
+第 0 要素が `from_self` (a 側由来 Face)、第 1 要素が `from_tool` (b 側由来 Face) で、それぞれ flat な `[post_id, src_id, ...]` ペア列。さらに C++ 側に `class BooleanShape { TopoDS_Shape shape; std::vector<uint64_t> from_a; std::vector<uint64_t> from_b; }` が存在し、FFI 関数 3 本で個別取り出しを行っていた。同じパターンの `class CleanShape` も clean 操作用に存在。
+
+## 問題
+
+- 戻り値型 `(Vec<Solid>, [Vec<u64>; 2])` がマジックインデックス的 (`metadata[0]` / `metadata[1]`)
+- 派生情報を後段に持ち回るとき毎回タプルを通さないといけない
+- C++ 側の opaque struct (`BooleanShape` / `CleanShape`) 1 個につき FFI 関数が 3 本に膨らむ
+- `*_with_metadata` と `*` の二重 API でメソッド数が多い
+- 既存 3 call sites (`08_shell.rs`, `tests/shape.rs` × 2) すべて tool 側 (`[1]`) しか見ていない → self/tool 二分割は実需が無い
+
+## 解決方針
+
+### 方針 1: Solid に派生情報を state として持たせる
+
+`Solid::history: Vec<u64>` フィールドを追加 (cfg ゲートなし、`colormap` と違い常に有効)。flat `[post_id, src_id, ...]` で内部表現。公開 API は `iter_history(&self) -> impl Iterator<Item = [u64; 2]>` 一本。
+
+#### 議論したが採用しなかった案
+
+1. **`Vec<FaceLineage { post: u64, src: u64 }>`** — 型で意味を明示できるが、cxx は POD struct を直接 Vec で受け渡せない (`ExternType` 経由の追加層が必要)。`Vec<u64>` なら cxx の primitive Vec サポートで FFI から直接編集可能。`iter_history` accessor で型安全性は確保できるので、内部 `Vec<u64>` + 出口で `[u64; 2]` の二層分業が最良。
+2. **`history` を累積 (世代をまたぐ)** — `A.subtract(B).subtract(C)` で `r.history` を全祖先累積する案。Vec が肥大化、post_id の名前空間が世代をまたいで曖昧化、設計規模が一段大きくなる。「直近の操作で生えた面に対して何かやりたい人のための情報源」という用途には上書きで十分。
+3. **self/tool 区別タグ (`Vec<[u64; 3]>` で input_idx も持つ)** — 表現複雑化、cxx の `Vec<u64>` 直接編集の利点が失われる。実需も無い (call site 全て tool 側のみ参照)。
+4. **scale / mirror / Clone で `remap_history_by_order` を書いて preserve** — colormap 用の `remap_*_by_order` をテンプレに同等のものを作る案。実装は可能だが、新しい topology を作る操作で history を持ち回す意味が薄い。`Default::default()` で捨てて将来「直近の builder の派生情報」として再利用できる空き枠にしておく方が筋が良い。
+
+#### 採用したルール
+
+| 操作 | history |
+|---|---|
+| 不変系: `translate` / `rotate` / `color` / `color_clear` | preserve |
+| トポロジ rebuild 系: `scale` / `mirror` / `Clone` | `Default::default()` (clear) |
+| 全プリミティブ + builder (`extrude` / `sweep` / `loft` / `bspline` / `shell` / `fillet` / `chamfer`) | `Default::default()` (現状) |
+| boolean (`union` / `subtract` / `intersect`) | C++ 側で from_a + from_b を flat union して populate |
+| `read_step` / `read_brep_*` | `Default::default()` |
+| シリアライズ | しない (ephemeral) |
+
+将来的には builder 系 (fillet / chamfer / sweep / extrude / loft / bspline / shell) も `BRepBuilderAPI_MakeShape::Modified()` / `Generated()` を使って history を populate できるよう、API は今の形で安定。
+
+### 方針 2: cxx opaque struct の out-parameter 化
+
+`BooleanShape` と `CleanShape` をそれぞれ廃止し、`std::unique_ptr<TopoDS_Shape>` を return + `rust::Vec<uint64_t>& out_*` を out-parameter として受ける形に倒す:
+
+```cpp
+// 旧
+std::unique_ptr<BooleanShape> boolean_op(const TopoDS_Shape&, const TopoDS_Shape&, uint32_t);
+std::unique_ptr<TopoDS_Shape> boolean_shape_shape(const BooleanShape&);
+rust::Vec<uint64_t> boolean_shape_from_a(const BooleanShape&);
+rust::Vec<uint64_t> boolean_shape_from_b(const BooleanShape&);
+
+// 新
+std::unique_ptr<TopoDS_Shape> boolean_op(
+    const TopoDS_Shape&, const TopoDS_Shape&, uint32_t,
+    rust::Vec<uint64_t>& out_history);
+```
+
+C++ 側 4 個の FFI 表面が 1 個に集約。`unsafe impl Send for BooleanShape {}` / `for CleanShape {}` も自動的に消える。同パターンを `CleanShape` (`clean_shape_full` / `clean_shape_get` / `clean_shape_mapping`) にも適用。
+
+#### 適用条件
+
+- C++ 側で当該 opaque struct を参照する関数が「生成 + getter のみ」で、Rust 側 caller が「生成 → 即座に getter 1 回ずつ → 破棄」で済んでいること
+- 遅延評価や intermediate state 共有がないこと
+
+→ `BooleanShape` も `CleanShape` も両方この条件を満たす。
+
+## API ergonomics 上の trade-off
+
+`08_shell.rs` の cutter 由来 Face 抽出が、self/tool 二分割の喪失で 3 行ほど冗長になった:
+
+```rust
+// 旧 (3 行)
+let (mut halves, [_, from_cutter]) = torus.intersect_with_metadata(&[cutter])?;
+let half = halves.pop().ok_or(Error::BooleanOperationFailed)?;
+half.shell(thickness, half.iter_face().filter(|f| from_cutter.contains(&f.tshape_id())))
+
+// 新 (cutter の Face ID を別途キャプチャしてから filter_map)
+let cutter_face_ids: HashSet<u64> = cutter.iter_face().map(|f| f.tshape_id()).collect();
+let halves = torus.intersect(&[cutter])?;
+let half = halves.into_iter().next().ok_or(Error::BooleanOperationFailed)?;
+let from_cutter: HashSet<u64> = half.iter_history()
+    .filter_map(|[post, src]| cutter_face_ids.contains(&src).then_some(post))
+    .collect();
+half.shell(thickness, half.iter_face().filter(|f| from_cutter.contains(&f.tshape_id())))
+```
+
+許容範囲。AGENTS.md「ユーザーに誤解を招くか僅かな手間を強いるかで迷ったら後者を取る」と整合。
+
+## 結果
+
+12 ファイル変更、+223/-192 行。
+
+- C++ opaque struct 2 個削除 (`BooleanShape`, `CleanShape`) → FFI 表面 −6 関数 / −2 type
+- `Solid::history` field と `iter_history()` accessor 追加
+- `*_with_metadata` × 3 + `is_tool_face` / `is_shape_face` helper 削除
+- 全 Solid::new 呼び出し (約 25 ヵ所) を `Default::default()` で history 初期化するよう更新
+- 検証: `cargo test` 全 pass、11 example 全実行、touched code clippy clean
+
+## 関連
+
+- `notes/20260420-OCCTトポロジ不変性と設計含意.md` — 不変性ルールと colormap の preserve/clear 方針 (history も同型)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,20 +42,5 @@ pub use common::mesh::{EdgeData, Mesh};
 pub use glam::{DMat3, DMat4, DQuat, DVec2, DVec3};
 pub use glam;
 
-// ==================== Boolean metadata helpers ====================
-//
-// Free functions over the active backend's concrete `Face`. They live here
-// (not in `traits.rs`) so the trait layer stays free of backend type names.
-
-/// Check if a face came from the tool (b-side) of a boolean operation.
-pub fn is_tool_face(metadata: &[Vec<u64>; 2], face: &Face) -> bool {
-	metadata[1].contains(&face.tshape_id())
-}
-
-/// Check if a face came from the shape (a-side) of a boolean operation.
-pub fn is_shape_face(metadata: &[Vec<u64>; 2], face: &Face) -> bool {
-	metadata[0].contains(&face.tshape_id())
-}
-
 // Auto-generated inherent method delegations (trait methods → pub fn on concrete types)
 include!(concat!(env!("OUT_DIR"), "/generated_delegation.rs"));

--- a/src/occt/compound.rs
+++ b/src/occt/compound.rs
@@ -10,10 +10,15 @@ pub(crate) struct CompoundShape {
 	inner: cxx::UniquePtr<ffi::TopoDS_Shape>,
 	#[cfg(feature = "color")]
 	colormap: std::collections::HashMap<u64, Color>,
+	history: Vec<u64>,
 }
 
 impl CompoundShape {
 	/// Assemble solids into a compound, merging their colormaps.
+	///
+	/// Inputs' `history` is intentionally dropped — a compound assembled for
+	/// a boolean call has no meaningful history of its own; the boolean
+	/// result will populate one fresh.
 	pub fn new<'a>(solids: impl IntoIterator<Item = &'a Solid>) -> Self {
 		let mut inner = ffi::make_empty();
 		#[cfg(feature = "color")]
@@ -27,15 +32,21 @@ impl CompoundShape {
 			inner,
 			#[cfg(feature = "color")]
 			colormap,
+			history: Default::default(),
 		}
 	}
 
 	/// Create a compound from a raw `TopoDS_Shape` (e.g. from I/O or boolean ops).
-	pub fn from_raw(inner: cxx::UniquePtr<ffi::TopoDS_Shape>, #[cfg(feature = "color")] colormap: std::collections::HashMap<u64, Color>) -> Self {
+	pub fn from_raw(
+		inner: cxx::UniquePtr<ffi::TopoDS_Shape>,
+		#[cfg(feature = "color")] colormap: std::collections::HashMap<u64, Color>,
+		history: Vec<u64>,
+	) -> Self {
 		CompoundShape {
 			inner,
 			#[cfg(feature = "color")]
 			colormap,
+			history,
 		}
 	}
 
@@ -51,6 +62,10 @@ impl CompoundShape {
 	}
 
 	/// Decompose into individual solids, consuming the compound.
+	///
+	/// Each result solid receives a clone of the full `history` — over-inclusion
+	/// is harmless because `iter_history()` consumers filter pairs by checking
+	/// `src_id` against the original input's face IDs.
 	pub fn decompose(self) -> Vec<Solid> {
 		let solid_shapes = ffi::decompose_into_solids(&self.inner);
 		solid_shapes
@@ -60,6 +75,7 @@ impl CompoundShape {
 					ffi::shallow_copy(s),
 					#[cfg(feature = "color")]
 					self.colormap.clone(),
+					self.history.clone(),
 				)
 			})
 			.collect()

--- a/src/occt/ffi.rs
+++ b/src/occt/ffi.rs
@@ -30,7 +30,6 @@ mod ffi_bridge {
 		type TopoDS_Shape;
 		type TopoDS_Face;
 		type TopoDS_Edge;
-		type BooleanShape;
 
 		// ==================== Shape I/O (streambuf callback) ====================
 
@@ -67,11 +66,8 @@ mod ffi_bridge {
 		// ==================== Boolean Operations ====================
 
 		// Unified boolean op. `op_kind`: 0 = fuse(union), 1 = cut(a − b), 2 = common(intersect).
-		fn boolean_op(a: &TopoDS_Shape, b: &TopoDS_Shape, op_kind: u32) -> UniquePtr<BooleanShape>;
-
-		fn boolean_shape_shape(r: &BooleanShape) -> UniquePtr<TopoDS_Shape>;
-		fn boolean_shape_from_a(r: &BooleanShape) -> Vec<u64>;
-		fn boolean_shape_from_b(r: &BooleanShape) -> Vec<u64>;
+		// `out_history` is appended with flat [post_id, src_id, ...] pairs covering both inputs.
+		fn boolean_op(a: &TopoDS_Shape, b: &TopoDS_Shape, op_kind: u32, out_history: &mut Vec<u64>) -> UniquePtr<TopoDS_Shape>;
 
 		// ==================== Colored STEP I/O (color feature only) ====================
 
@@ -102,13 +98,7 @@ mod ffi_bridge {
 		fn clean_shape(shape: &TopoDS_Shape) -> UniquePtr<TopoDS_Shape>;
 
 		#[cfg(feature = "color")]
-		type CleanShape;
-		#[cfg(feature = "color")]
-		fn clean_shape_full(shape: &TopoDS_Shape) -> UniquePtr<CleanShape>;
-		#[cfg(feature = "color")]
-		fn clean_shape_get(r: &CleanShape) -> UniquePtr<TopoDS_Shape>;
-		#[cfg(feature = "color")]
-		fn clean_shape_mapping(r: &CleanShape) -> Vec<u64>;
+		fn clean_shape_full(shape: &TopoDS_Shape, out_mapping: &mut Vec<u64>) -> UniquePtr<TopoDS_Shape>;
 
 		fn translate_shape(shape: &TopoDS_Shape, tx: f64, ty: f64, tz: f64) -> UniquePtr<TopoDS_Shape>;
 
@@ -207,8 +197,5 @@ pub use ffi_bridge::*;
 unsafe impl Send for TopoDS_Shape {}
 unsafe impl Send for TopoDS_Face {}
 unsafe impl Send for TopoDS_Edge {}
-unsafe impl Send for BooleanShape {}
-#[cfg(feature = "color")]
-unsafe impl Send for CleanShape {}
 #[cfg(feature = "color")]
 unsafe impl Send for ColoredStepData {}

--- a/src/occt/io.rs
+++ b/src/occt/io.rs
@@ -95,7 +95,7 @@ impl IoModule for Io {
 			for i in 0..ids.len() {
 				colormap.insert(ids[i], Color { r: r[i], g: g[i], b: b[i] });
 			}
-			Ok(CompoundShape::from_raw(inner, colormap).decompose())
+			Ok(CompoundShape::from_raw(inner, colormap, Default::default()).decompose())
 		}
 		#[cfg(not(feature = "color"))]
 		{
@@ -104,7 +104,7 @@ impl IoModule for Io {
 			if inner.is_null() {
 				return Err(Error::StepReadFailed);
 			}
-			Ok(CompoundShape::from_raw(inner).decompose())
+			Ok(CompoundShape::from_raw(inner, Default::default()).decompose())
 		}
 	}
 
@@ -125,7 +125,7 @@ impl IoModule for Io {
 				return Err(Error::BrepReadFailed);
 			}
 			let colormap = resolve_color_trailer(&inner, &index_colormap);
-			Ok(CompoundShape::from_raw(inner, colormap).decompose())
+			Ok(CompoundShape::from_raw(inner, colormap, Default::default()).decompose())
 		}
 		#[cfg(not(feature = "color"))]
 		{
@@ -134,7 +134,7 @@ impl IoModule for Io {
 			if inner.is_null() {
 				return Err(Error::BrepReadFailed);
 			}
-			Ok(CompoundShape::from_raw(inner).decompose())
+			Ok(CompoundShape::from_raw(inner, Default::default()).decompose())
 		}
 	}
 
@@ -155,7 +155,7 @@ impl IoModule for Io {
 				return Err(Error::BrepReadFailed);
 			}
 			let colormap = resolve_color_trailer(&inner, &index_colormap);
-			Ok(CompoundShape::from_raw(inner, colormap).decompose())
+			Ok(CompoundShape::from_raw(inner, colormap, Default::default()).decompose())
 		}
 		#[cfg(not(feature = "color"))]
 		{
@@ -164,7 +164,7 @@ impl IoModule for Io {
 			if inner.is_null() {
 				return Err(Error::BrepReadFailed);
 			}
-			Ok(CompoundShape::from_raw(inner).decompose())
+			Ok(CompoundShape::from_raw(inner, Default::default()).decompose())
 		}
 	}
 

--- a/src/occt/solid.rs
+++ b/src/occt/solid.rs
@@ -61,6 +61,20 @@ pub struct Solid {
 	faces: OnceLock<Vec<Face>>,
 	#[cfg(feature = "color")]
 	colormap: std::collections::HashMap<u64, crate::common::color::Color>,
+	/// Face-derivation history from the most recent boolean operation.
+	///
+	/// Flat `[post_id, src_id, post_id, src_id, ...]` pairs:
+	/// - `post_id` is the TShape* of a face in this Solid (or, after
+	///   decompose, possibly in a sibling result Solid — over-inclusion
+	///   is harmless because consumers filter by `src_id`).
+	/// - `src_id` is the TShape* of the originating face in either
+	///   boolean input (a or b — distinction is intentionally lost;
+	///   TShape* is globally unique so callers filter by membership).
+	///
+	/// Empty for primitives, builders (extrude/sweep/loft/bspline/shell/
+	/// fillet/chamfer), I/O reads, and after scale/mirror/Clone (which
+	/// rebuild topology). Preserved across translate/rotate/color.
+	history: Vec<u64>,
 }
 
 impl Solid {
@@ -68,7 +82,11 @@ impl Solid {
 	///
 	/// # Panics
 	/// Panics if `inner` is not `TopAbs_SOLID` (and not null).
-	pub(crate) fn new(inner: cxx::UniquePtr<ffi::TopoDS_Shape>, #[cfg(feature = "color")] colormap: std::collections::HashMap<u64, crate::common::color::Color>) -> Self {
+	pub(crate) fn new(
+		inner: cxx::UniquePtr<ffi::TopoDS_Shape>,
+		#[cfg(feature = "color")] colormap: std::collections::HashMap<u64, crate::common::color::Color>,
+		history: Vec<u64>,
+	) -> Self {
 		debug_assert!(ffi::shape_is_null(&inner) || ffi::shape_is_solid(&inner), "Solid::new called with a non-SOLID shape");
 		Solid {
 			inner,
@@ -76,6 +94,7 @@ impl Solid {
 			faces: OnceLock::new(),
 			#[cfg(feature = "color")]
 			colormap,
+			history,
 		}
 	}
 
@@ -89,6 +108,16 @@ impl Solid {
 	/// Return the underlying `TopoDS_TShape*` address as a `u64`.
 	pub fn tshape_id(&self) -> u64 {
 		ffi::shape_tshape_id(&self.inner)
+	}
+
+	/// Iterate over face-derivation pairs `[post_id, src_id]` from the most
+	/// recent boolean operation that produced this Solid (or its source
+	/// chain, while it stays through translate/rotate/color).
+	///
+	/// Empty after primitive/builder construction, I/O read, scale/mirror,
+	/// or Clone. See the `history` field doc on `Solid` for the full list.
+	pub fn iter_history(&self) -> impl Iterator<Item = [u64; 2]> + '_ {
+		self.history.chunks_exact(2).map(|c| [c[0], c[1]])
 	}
 
 	// ==================== Color accessors ====================
@@ -157,6 +186,7 @@ impl SolidStruct for Solid {
 			inner,
 			#[cfg(feature = "color")]
 			std::collections::HashMap::new(),
+			Default::default(),
 		)
 	}
 
@@ -166,6 +196,7 @@ impl SolidStruct for Solid {
 			inner,
 			#[cfg(feature = "color")]
 			std::collections::HashMap::new(),
+			Default::default(),
 		)
 	}
 
@@ -175,6 +206,7 @@ impl SolidStruct for Solid {
 			inner,
 			#[cfg(feature = "color")]
 			std::collections::HashMap::new(),
+			Default::default(),
 		)
 	}
 
@@ -184,6 +216,7 @@ impl SolidStruct for Solid {
 			inner,
 			#[cfg(feature = "color")]
 			std::collections::HashMap::new(),
+			Default::default(),
 		)
 	}
 
@@ -193,6 +226,7 @@ impl SolidStruct for Solid {
 			inner,
 			#[cfg(feature = "color")]
 			std::collections::HashMap::new(),
+			Default::default(),
 		)
 	}
 
@@ -202,6 +236,7 @@ impl SolidStruct for Solid {
 			inner,
 			#[cfg(feature = "color")]
 			std::collections::HashMap::new(),
+			Default::default(),
 		)
 	}
 
@@ -220,6 +255,7 @@ impl SolidStruct for Solid {
 			shape,
 			#[cfg(feature = "color")]
 			std::collections::HashMap::new(),
+			Default::default(),
 		))
 	}
 
@@ -238,6 +274,7 @@ impl SolidStruct for Solid {
 			shape,
 			#[cfg(feature = "color")]
 			std::collections::HashMap::new(),
+			Default::default(),
 		))
 	}
 
@@ -256,6 +293,7 @@ impl SolidStruct for Solid {
 			shape,
 			#[cfg(feature = "color")]
 			std::collections::HashMap::new(),
+			Default::default(),
 		))
 	}
 
@@ -272,6 +310,7 @@ impl SolidStruct for Solid {
 			shape,
 			#[cfg(feature = "color")]
 			std::collections::HashMap::new(),
+			Default::default(),
 		))
 	}
 
@@ -295,6 +334,7 @@ impl SolidStruct for Solid {
 			shape,
 			#[cfg(feature = "color")]
 			std::collections::HashMap::new(),
+			Default::default(),
 		))
 	}
 
@@ -343,6 +383,7 @@ impl SolidStruct for Solid {
 			shape,
 			#[cfg(feature = "color")]
 			std::collections::HashMap::new(),
+			Default::default(),
 		))
 	}
 
@@ -370,20 +411,21 @@ impl SolidStruct for Solid {
 			shape,
 			#[cfg(feature = "color")]
 			std::collections::HashMap::new(),
+			Default::default(),
 		))
 	}
 
 	// ==================== Boolean primitives ====================
 
-	fn boolean_union<'a, 'b>(a: impl IntoIterator<Item = &'a Self>, b: impl IntoIterator<Item = &'b Self>) -> Result<(Vec<Self>, [Vec<u64>; 2]), Error> where Self: 'a + 'b {
+	fn boolean_union<'a, 'b>(a: impl IntoIterator<Item = &'a Self>, b: impl IntoIterator<Item = &'b Self>) -> Result<Vec<Self>, Error> where Self: 'a + 'b {
 		Self::boolean_union_impl(a, b)
 	}
 
-	fn boolean_subtract<'a, 'b>(a: impl IntoIterator<Item = &'a Self>, b: impl IntoIterator<Item = &'b Self>) -> Result<(Vec<Self>, [Vec<u64>; 2]), Error> where Self: 'a + 'b {
+	fn boolean_subtract<'a, 'b>(a: impl IntoIterator<Item = &'a Self>, b: impl IntoIterator<Item = &'b Self>) -> Result<Vec<Self>, Error> where Self: 'a + 'b {
 		Self::boolean_subtract_impl(a, b)
 	}
 
-	fn boolean_intersect<'a, 'b>(a: impl IntoIterator<Item = &'a Self>, b: impl IntoIterator<Item = &'b Self>) -> Result<(Vec<Self>, [Vec<u64>; 2]), Error> where Self: 'a + 'b {
+	fn boolean_intersect<'a, 'b>(a: impl IntoIterator<Item = &'a Self>, b: impl IntoIterator<Item = &'b Self>) -> Result<Vec<Self>, Error> where Self: 'a + 'b {
 		Self::boolean_intersect_impl(a, b)
 	}
 }
@@ -396,10 +438,12 @@ impl Transform for Solid {
 		// translate/rotate use shape.Moved() — TShape is shared but Location
 		// changes, so cached edges/faces (which embed Location) would go stale.
 		// Solid::new gives a fresh OnceLock::new() cache matching the new Location.
+		// `history` is preserved because TShape* (= post_id) is unchanged.
 		Solid::new(
 			inner,
 			#[cfg(feature = "color")]
 			self.colormap,
+			self.history,
 		)
 	}
 
@@ -409,6 +453,7 @@ impl Transform for Solid {
 			inner,
 			#[cfg(feature = "color")]
 			self.colormap,
+			self.history,
 		)
 	}
 
@@ -426,10 +471,14 @@ impl Transform for Solid {
 		let inner = ffi::scale_shape(&self.inner, center.x, center.y, center.z, factor);
 		#[cfg(feature = "color")]
 		let colormap = remap_colormap_by_order(&self.inner, &inner, &self.colormap);
+		// scale/mirror rebuild topology via BRepBuilderAPI_Transform → post_ids
+		// in old `history` no longer exist. Drop history (caller must re-derive
+		// from a fresh boolean call).
 		Solid::new(
 			inner,
 			#[cfg(feature = "color")]
 			colormap,
+			Default::default(),
 		)
 	}
 
@@ -441,6 +490,7 @@ impl Transform for Solid {
 			inner,
 			#[cfg(feature = "color")]
 			colormap,
+			Default::default(),
 		)
 	}
 }
@@ -455,24 +505,20 @@ impl Compound for Solid {
 	fn clean(&self) -> Result<Self, Error> {
 		#[cfg(feature = "color")]
 		{
-			let r = ffi::clean_shape_full(&self.inner);
-			if r.is_null() {
-				return Err(Error::CleanFailed);
-			}
-			let inner = ffi::clean_shape_get(&r);
+			let mut mapping: Vec<u64> = Default::default();
+			let inner = ffi::clean_shape_full(&self.inner, &mut mapping);
 			if inner.is_null() {
 				return Err(Error::CleanFailed);
 			}
-			let mapping = ffi::clean_shape_mapping(&r);
 			let mut colormap = std::collections::HashMap::new();
-			for pair in mapping.chunks(2) {
+			for pair in mapping.chunks_exact(2) {
 				let new_id = pair[0];
 				let old_id = pair[1];
 				if let Some(&color) = self.colormap.get(&old_id) {
 					colormap.entry(new_id).or_insert(color);
 				}
 			}
-			return Ok(Solid::new(inner, colormap));
+			return Ok(Solid::new(inner, colormap, Default::default()));
 		}
 		#[cfg(not(feature = "color"))]
 		{
@@ -480,7 +526,7 @@ impl Compound for Solid {
 			if inner.is_null() {
 				return Err(Error::CleanFailed);
 			}
-			Ok(Solid::new(inner))
+			Ok(Solid::new(inner, Default::default()))
 		}
 	}
 
@@ -534,25 +580,25 @@ impl Compound for Solid {
 	fn color(self, color: impl Into<crate::common::color::Color>) -> Self {
 		let c = color.into();
 		let colormap = ffi::shape_faces(&self.inner).iter().map(|f| (ffi::face_tshape_id(f), c)).collect();
-		Self::new(self.inner, colormap)
+		Self::new(self.inner, colormap, self.history)
 	}
 
 	#[cfg(feature = "color")]
 	fn color_clear(self) -> Self {
-		Self::new(self.inner, std::collections::HashMap::new())
+		Self::new(self.inner, std::collections::HashMap::new(), self.history)
 	}
 
-	// ==================== Boolean wrappers ====================
+	// ==================== Boolean ====================
 
-	fn union_with_metadata<'a>(&self, tool: impl IntoIterator<Item = &'a Solid>) -> Result<(Vec<Solid>, [Vec<u64>; 2]), Error> {
+	fn union<'a>(&self, tool: impl IntoIterator<Item = &'a Solid>) -> Result<Vec<Solid>, Error> {
 		<Solid as SolidStruct>::boolean_union([self], tool)
 	}
 
-	fn subtract_with_metadata<'a>(&self, tool: impl IntoIterator<Item = &'a Solid>) -> Result<(Vec<Solid>, [Vec<u64>; 2]), Error> {
+	fn subtract<'a>(&self, tool: impl IntoIterator<Item = &'a Solid>) -> Result<Vec<Solid>, Error> {
 		<Solid as SolidStruct>::boolean_subtract([self], tool)
 	}
 
-	fn intersect_with_metadata<'a>(&self, tool: impl IntoIterator<Item = &'a Solid>) -> Result<(Vec<Solid>, [Vec<u64>; 2]), Error> {
+	fn intersect<'a>(&self, tool: impl IntoIterator<Item = &'a Solid>) -> Result<Vec<Solid>, Error> {
 		<Solid as SolidStruct>::boolean_intersect([self], tool)
 	}
 }
@@ -562,10 +608,13 @@ impl Clone for Solid {
 		let inner = ffi::deep_copy(&self.inner);
 		#[cfg(feature = "color")]
 		let colormap = remap_colormap_by_order(&self.inner, &inner, &self.colormap);
+		// deep_copy rebuilds topology — post_ids in `history` no longer point
+		// to faces of the new shape. Drop history rather than remapping.
 		Solid::new(
 			inner,
 			#[cfg(feature = "color")]
 			colormap,
+			Default::default(),
 		)
 	}
 }
@@ -573,15 +622,12 @@ impl Clone for Solid {
 // ==================== Boolean operations ====================
 
 #[cfg(feature = "color")]
-fn merge_colormaps(from_a: &[u64], from_b: &[u64], colormap_a: &std::collections::HashMap<u64, crate::common::color::Color>, colormap_b: &std::collections::HashMap<u64, crate::common::color::Color>) -> std::collections::HashMap<u64, crate::common::color::Color> {
+fn merge_colormaps(history: &[u64], colormap_a: &std::collections::HashMap<u64, crate::common::color::Color>, colormap_b: &std::collections::HashMap<u64, crate::common::color::Color>) -> std::collections::HashMap<u64, crate::common::color::Color> {
 	let mut result = std::collections::HashMap::new();
-	for pair in from_a.chunks(2) {
-		if let Some(&color) = colormap_a.get(&pair[1]) {
-			result.insert(pair[0], color);
-		}
-	}
-	for pair in from_b.chunks(2) {
-		if let Some(&color) = colormap_b.get(&pair[1]) {
+	for pair in history.chunks_exact(2) {
+		// TShape* pointers are globally unique across both inputs, so a
+		// single lookup against either colormap suffices (no collision).
+		if let Some(&color) = colormap_a.get(&pair[1]).or_else(|| colormap_b.get(&pair[1])) {
 			result.insert(pair[0], color);
 		}
 	}
@@ -589,24 +635,21 @@ fn merge_colormaps(from_a: &[u64], from_b: &[u64], colormap_a: &std::collections
 }
 
 // `ca` / `cb` carry the source colormaps and are only consulted by the
-// `color` feature; the boolean result and metadata are derived purely from
-// the FFI BooleanShape, so they go unused without `color`.
+// `color` feature; the boolean result and history are derived purely from
+// the FFI out-parameter, so they go unused without `color`.
 #[cfg_attr(not(feature = "color"), allow(unused_variables))]
-fn build_boolean_result(r: cxx::UniquePtr<ffi::BooleanShape>, ca: CompoundShape, cb: CompoundShape) -> Result<(Vec<Solid>, [Vec<u64>; 2]), Error> {
-	let from_a = ffi::boolean_shape_from_a(&r);
-	let from_b = ffi::boolean_shape_from_b(&r);
-	let inner = ffi::boolean_shape_shape(&r);
-
+fn build_boolean_result(inner: cxx::UniquePtr<ffi::TopoDS_Shape>, history: Vec<u64>, ca: CompoundShape, cb: CompoundShape) -> Result<Vec<Solid>, Error> {
 	#[cfg(feature = "color")]
-	let colormap = merge_colormaps(&from_a, &from_b, ca.colormap(), cb.colormap());
+	let colormap = merge_colormaps(&history, ca.colormap(), cb.colormap());
 
 	let compound = CompoundShape::from_raw(
 		inner,
 		#[cfg(feature = "color")]
 		colormap,
+		history,
 	);
 
-	Ok((compound.decompose(), [from_a, from_b]))
+	Ok(compound.decompose())
 }
 
 // Op kind tags matching the C++ side `boolean_op` switch.
@@ -615,23 +658,24 @@ const BOOLEAN_OP_CUT: u32 = 1;
 const BOOLEAN_OP_COMMON: u32 = 2;
 
 impl Solid {
-	fn boolean_op_impl<'a, 'b>(a: impl IntoIterator<Item = &'a Solid>, b: impl IntoIterator<Item = &'b Solid>, op_kind: u32) -> Result<(Vec<Solid>, [Vec<u64>; 2]), Error> {
+	fn boolean_op_impl<'a, 'b>(a: impl IntoIterator<Item = &'a Solid>, b: impl IntoIterator<Item = &'b Solid>, op_kind: u32) -> Result<Vec<Solid>, Error> {
 		let ca = CompoundShape::new(a);
 		let cb = CompoundShape::new(b);
-		let r = ffi::boolean_op(ca.inner(), cb.inner(), op_kind);
-		if r.is_null() { return Err(Error::BooleanOperationFailed); }
-		build_boolean_result(r, ca, cb)
+		let mut history: Vec<u64> = Default::default();
+		let inner = ffi::boolean_op(ca.inner(), cb.inner(), op_kind, &mut history);
+		if inner.is_null() { return Err(Error::BooleanOperationFailed); }
+		build_boolean_result(inner, history, ca, cb)
 	}
 
-	pub(crate) fn boolean_union_impl<'a, 'b>(a: impl IntoIterator<Item = &'a Solid>, b: impl IntoIterator<Item = &'b Solid>) -> Result<(Vec<Solid>, [Vec<u64>; 2]), Error> {
+	pub(crate) fn boolean_union_impl<'a, 'b>(a: impl IntoIterator<Item = &'a Solid>, b: impl IntoIterator<Item = &'b Solid>) -> Result<Vec<Solid>, Error> {
 		Self::boolean_op_impl(a, b, BOOLEAN_OP_FUSE)
 	}
 
-	pub(crate) fn boolean_subtract_impl<'a, 'b>(a: impl IntoIterator<Item = &'a Solid>, b: impl IntoIterator<Item = &'b Solid>) -> Result<(Vec<Solid>, [Vec<u64>; 2]), Error> {
+	pub(crate) fn boolean_subtract_impl<'a, 'b>(a: impl IntoIterator<Item = &'a Solid>, b: impl IntoIterator<Item = &'b Solid>) -> Result<Vec<Solid>, Error> {
 		Self::boolean_op_impl(a, b, BOOLEAN_OP_CUT)
 	}
 
-	pub(crate) fn boolean_intersect_impl<'a, 'b>(a: impl IntoIterator<Item = &'a Solid>, b: impl IntoIterator<Item = &'b Solid>) -> Result<(Vec<Solid>, [Vec<u64>; 2]), Error> {
+	pub(crate) fn boolean_intersect_impl<'a, 'b>(a: impl IntoIterator<Item = &'a Solid>, b: impl IntoIterator<Item = &'b Solid>) -> Result<Vec<Solid>, Error> {
 		Self::boolean_op_impl(a, b, BOOLEAN_OP_COMMON)
 	}
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -540,10 +540,12 @@ pub trait SolidStruct: Sized + Clone + Compound {
 	/// wraps the surface in a face, caps it if needed, sews, and makes a solid.
 	fn bspline<const M: usize, const N: usize>(grid: [[DVec3; N]; M], periodic: bool) -> Result<Self, Error>;
 
-	// --- Boolean primitives (consumed by Compound::*_with_metadata wrappers) ---
-	fn boolean_union<'a, 'b>(a: impl IntoIterator<Item = &'a Self>, b: impl IntoIterator<Item = &'b Self>) -> Result<(Vec<Self>, [Vec<u64>; 2]), Error> where Self: 'a + 'b;
-	fn boolean_subtract<'a, 'b>(a: impl IntoIterator<Item = &'a Self>, b: impl IntoIterator<Item = &'b Self>) -> Result<(Vec<Self>, [Vec<u64>; 2]), Error> where Self: 'a + 'b;
-	fn boolean_intersect<'a, 'b>(a: impl IntoIterator<Item = &'a Self>, b: impl IntoIterator<Item = &'b Self>) -> Result<(Vec<Self>, [Vec<u64>; 2]), Error> where Self: 'a + 'b;
+	// --- Boolean primitives (consumed by Compound::union/subtract/intersect wrappers) ---
+	// Per-result-Solid face derivation history is attached to each Solid via
+	// `Solid::iter_history()`; no separate metadata channel.
+	fn boolean_union<'a, 'b>(a: impl IntoIterator<Item = &'a Self>, b: impl IntoIterator<Item = &'b Self>) -> Result<Vec<Self>, Error> where Self: 'a + 'b;
+	fn boolean_subtract<'a, 'b>(a: impl IntoIterator<Item = &'a Self>, b: impl IntoIterator<Item = &'b Self>) -> Result<Vec<Self>, Error> where Self: 'a + 'b;
+	fn boolean_intersect<'a, 'b>(a: impl IntoIterator<Item = &'a Self>, b: impl IntoIterator<Item = &'b Self>) -> Result<Vec<Self>, Error> where Self: 'a + 'b;
 }
 
 // ==================== Compound ====================
@@ -600,12 +602,11 @@ pub trait Compound: Transform {
 	fn color_clear(self) -> Self;
 
 	// --- Boolean (-> Vec<Self::Elem>) ---
-	fn union_with_metadata<'a>(&self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<(Vec<Self::Elem>, [Vec<u64>; 2]), Error> where Self::Elem: 'a;
-	fn subtract_with_metadata<'a>(&self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<(Vec<Self::Elem>, [Vec<u64>; 2]), Error> where Self::Elem: 'a;
-	fn intersect_with_metadata<'a>(&self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<(Vec<Self::Elem>, [Vec<u64>; 2]), Error> where Self::Elem: 'a;
-	fn union<'a>(&self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<Vec<Self::Elem>, Error> where Self::Elem: 'a { Ok(self.union_with_metadata(tool)?.0) }
-	fn subtract<'a>(&self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<Vec<Self::Elem>, Error> where Self::Elem: 'a { Ok(self.subtract_with_metadata(tool)?.0) }
-	fn intersect<'a>(&self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<Vec<Self::Elem>, Error> where Self::Elem: 'a { Ok(self.intersect_with_metadata(tool)?.0) }
+	// Each result Solid carries its face-derivation history; access via
+	// `Solid::iter_history()`.
+	fn union<'a>(&self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<Vec<Self::Elem>, Error> where Self::Elem: 'a;
+	fn subtract<'a>(&self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<Vec<Self::Elem>, Error> where Self::Elem: 'a;
+	fn intersect<'a>(&self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<Vec<Self::Elem>, Error> where Self::Elem: 'a;
 }
 
 // `impl Compound for Solid` lives in the backend module (e.g. src/occt/solid.rs)
@@ -646,13 +647,13 @@ impl<T: SolidStruct> Compound for Vec<T> {
 	fn color_clear(self) -> Self {
 		self.into_iter().map(|s| s.color_clear()).collect()
 	}
-	fn union_with_metadata<'a>(&self, tool: impl IntoIterator<Item = &'a T>) -> Result<(Vec<T>, [Vec<u64>; 2]), Error> where T: 'a {
+	fn union<'a>(&self, tool: impl IntoIterator<Item = &'a T>) -> Result<Vec<T>, Error> where T: 'a {
 		T::boolean_union(self.iter(), tool)
 	}
-	fn subtract_with_metadata<'a>(&self, tool: impl IntoIterator<Item = &'a T>) -> Result<(Vec<T>, [Vec<u64>; 2]), Error> where T: 'a {
+	fn subtract<'a>(&self, tool: impl IntoIterator<Item = &'a T>) -> Result<Vec<T>, Error> where T: 'a {
 		T::boolean_subtract(self.iter(), tool)
 	}
-	fn intersect_with_metadata<'a>(&self, tool: impl IntoIterator<Item = &'a T>) -> Result<(Vec<T>, [Vec<u64>; 2]), Error> where T: 'a {
+	fn intersect<'a>(&self, tool: impl IntoIterator<Item = &'a T>) -> Result<Vec<T>, Error> where T: 'a {
 		T::boolean_intersect(self.iter(), tool)
 	}
 }
@@ -695,13 +696,13 @@ impl<T: SolidStruct, const N: usize> Compound for [T; N] {
 	fn color_clear(self) -> Self {
 		self.map(|s| s.color_clear())
 	}
-	fn union_with_metadata<'a>(&self, tool: impl IntoIterator<Item = &'a T>) -> Result<(Vec<T>, [Vec<u64>; 2]), Error> where T: 'a {
+	fn union<'a>(&self, tool: impl IntoIterator<Item = &'a T>) -> Result<Vec<T>, Error> where T: 'a {
 		T::boolean_union(self.iter(), tool)
 	}
-	fn subtract_with_metadata<'a>(&self, tool: impl IntoIterator<Item = &'a T>) -> Result<(Vec<T>, [Vec<u64>; 2]), Error> where T: 'a {
+	fn subtract<'a>(&self, tool: impl IntoIterator<Item = &'a T>) -> Result<Vec<T>, Error> where T: 'a {
 		T::boolean_subtract(self.iter(), tool)
 	}
-	fn intersect_with_metadata<'a>(&self, tool: impl IntoIterator<Item = &'a T>) -> Result<(Vec<T>, [Vec<u64>; 2]), Error> where T: 'a {
+	fn intersect<'a>(&self, tool: impl IntoIterator<Item = &'a T>) -> Result<Vec<T>, Error> where T: 'a {
 		T::boolean_intersect(self.iter(), tool)
 	}
 }

--- a/tests/bspline.rs
+++ b/tests/bspline.rs
@@ -34,8 +34,8 @@ fn assert_quadrant_point_symmetry(solid: &Solid, tol: f64) {
 	let minus_y = Solid::half_space(DVec3::ZERO, -DVec3::Y);
 
 	let quadrant = |hs1: &Solid, hs2: &Solid| -> f64 {
-		let (ab, _) = Solid::boolean_intersect(std::slice::from_ref(solid), std::slice::from_ref(hs1)).expect("intersect hs1");
-		let (q, _) = Solid::boolean_intersect(&ab, std::slice::from_ref(hs2)).expect("intersect hs2");
+		let ab = Solid::boolean_intersect(std::slice::from_ref(solid), std::slice::from_ref(hs1)).expect("intersect hs1");
+		let q = Solid::boolean_intersect(&ab, std::slice::from_ref(hs2)).expect("intersect hs2");
 		q.iter().map(|s| s.volume()).sum::<f64>()
 	};
 

--- a/tests/shape.rs
+++ b/tests/shape.rs
@@ -118,17 +118,26 @@ fn test_preserves_face_ids() {
 	assert_eq!(ids, face_ids([&rotated]), "rotate should preserve face IDs");
 }
 
-// ==================== is_tool_face / is_shape_face (B fully inside A) ====================
+// ==================== iter_history (B fully inside A) ====================
 
 #[test]
 fn test_new_faces_subtract_b_inside_a() {
 	// small_box が big_box に完全に収まる → small の 6 面はすべて Modified されない
-	// 旧実装（collect_generated_faces）では Modified() が空 → tool faces = 0
-	// 新実装（from_b post_ids）では unchanged 面も from_b に入る → tool faces = 6
+	// 新実装（iter_history の post_id 集合）では unchanged 面も history に入る → tool faces = 6
 	let big = [Solid::cube(10.0, 10.0, 10.0)];
 	let small = [Solid::cube(4.0, 4.0, 4.0).translate(dvec3(3.0, 3.0, 3.0))];
-	let (solids, meta) = big.subtract_with_metadata(&small).unwrap();
-	assert_eq!(solids.iter().flat_map(|s| s.iter_face()).filter(|f| cadrum::is_tool_face(&meta, f)).count(), 6, "subtract with B fully inside A: tool faces should be all 6 inner walls");
+	let small_face_ids: std::collections::HashSet<u64> =
+		small.iter().flat_map(|s| s.iter_face()).map(|f| f.tshape_id()).collect();
+	let solids = big.subtract(&small).unwrap();
+	let tool_post_ids: std::collections::HashSet<u64> = solids.iter()
+		.flat_map(|s| s.iter_history())
+		.filter_map(|[post, src]| small_face_ids.contains(&src).then_some(post))
+		.collect();
+	assert_eq!(
+		solids.iter().flat_map(|s| s.iter_face()).filter(|f| tool_post_ids.contains(&f.tshape_id())).count(),
+		6,
+		"subtract with B fully inside A: tool faces should be all 6 inner walls"
+	);
 }
 
 #[test]
@@ -137,8 +146,14 @@ fn test_new_faces_intersect_b_inside_a() {
 	// small の 6 面はすべて unchanged → tool faces = 結果の全フェイス = 6
 	let big = [Solid::cube(10.0, 10.0, 10.0)];
 	let small = [Solid::cube(4.0, 4.0, 4.0).translate(dvec3(3.0, 3.0, 3.0))];
-	let (solids, meta) = big.intersect_with_metadata(&small).unwrap();
-	let tool_count = solids.iter().flat_map(|s| s.iter_face()).filter(|f| cadrum::is_tool_face(&meta, f)).count();
+	let small_face_ids: std::collections::HashSet<u64> =
+		small.iter().flat_map(|s| s.iter_face()).map(|f| f.tshape_id()).collect();
+	let solids = big.intersect(&small).unwrap();
+	let tool_post_ids: std::collections::HashSet<u64> = solids.iter()
+		.flat_map(|s| s.iter_history())
+		.filter_map(|[post, src]| small_face_ids.contains(&src).then_some(post))
+		.collect();
+	let tool_count = solids.iter().flat_map(|s| s.iter_face()).filter(|f| tool_post_ids.contains(&f.tshape_id())).count();
 	assert_eq!(tool_count, 6, "intersect with B fully inside A: tool faces should equal all faces of result");
 	assert_eq!(solids.iter().flat_map(|s| s.iter_face()).count(), tool_count, "intersect with B fully inside A: tool faces should cover all result faces");
 }


### PR DESCRIPTION
## Summary

- Add `Solid::history: Vec<u64>` (flat `[post_id, src_id, ...]` pairs) populated by boolean ops, exposed via `iter_history() -> [u64; 2]`
- Replace C++ opaque structs `BooleanShape` / `CleanShape` with `rust::Vec<uint64_t>&` out-parameter signatures, collapsing 6 FFI functions to 2
- Remove `*_with_metadata` trait methods and `is_tool_face` / `is_shape_face` helpers; `union/subtract/intersect` now return `Result<Vec<Solid>, Error>` directly

Design discussion and trade-offs in `notes/20260425-Solid_history導入とCxxOpaqueStruct廃止.md`.

## Behavior

| Operation | history |
|---|---|
| translate / rotate / color / color_clear | preserved (TShape stable) |
| scale / mirror / Clone / all builders / I/O reads | empty (`Default::default()`) |
| union / subtract / intersect | populated (from_a + from_b flat union, no self/tool distinction) |

API surface for builders is shaped to allow later population via OCCT `Modified()` / `Generated()` without breaking `iter_history()` consumers.

## Migration example

```rust
// before
let (mut halves, [_, from_cutter]) = torus.intersect_with_metadata(&[cutter])?;
let half = halves.pop().ok_or(Error::BooleanOperationFailed)?;
half.shell(t, half.iter_face().filter(|f| from_cutter.contains(&f.tshape_id())))

// after
let cutter_face_ids: HashSet<u64> = cutter.iter_face().map(|f| f.tshape_id()).collect();
let halves = torus.intersect(&[cutter])?;
let half = halves.into_iter().next().ok_or(Error::BooleanOperationFailed)?;
let from_cutter: HashSet<u64> = half.iter_history()
    .filter_map(|[post, src]| cutter_face_ids.contains(&src).then_some(post))
    .collect();
half.shell(t, half.iter_face().filter(|f| from_cutter.contains(&f.tshape_id())))
```

## Test plan

- [x] `cargo build` / `cargo check` (default features)
- [x] `cargo test` — full suite passes (79 tests)
- [x] All 11 numbered examples (`01_primitives` through `11_chamfer`) run and produce expected output
- [x] `examples/markdown.rs` regenerates README without diff outside the migrated `08_shell` block
- [x] No new clippy warnings on touched code