### PR TITLE
refactor(color): drop ColoredStepData opaque struct, flatten RGB FFI

### DIFF
--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -1680,7 +1680,11 @@ static void collect_face_colors(
     }
 }
 
-std::unique_ptr<ColoredStepData> read_step_color_stream(RustReader& reader) {
+std::unique_ptr<TopoDS_Shape> read_step_color_stream(
+    RustReader&          reader,
+    rust::Vec<uint64_t>& out_ids,
+    rust::Vec<float>&    out_rgb)
+{
     try {
         // Create XDE document directly — avoids XCAFApp_Application which
         // pulls in visualization libs (TKXCAFPrs/TKTPrsStd) built with
@@ -1719,61 +1723,28 @@ std::unique_ptr<ColoredStepData> read_step_color_stream(RustReader& reader) {
         std::unordered_map<uint64_t, std::array<float, 3>> colorMap;
         collect_face_colors(doc, colorTool, colorMap);
 
-        auto result = std::make_unique<ColoredStepData>();
-        result->shape = compound;
-
         // Emit colors for each face that has a color entry.
         for (TopExp_Explorer ex(compound, TopAbs_FACE); ex.More(); ex.Next()) {
             uint64_t id =
                 reinterpret_cast<uint64_t>(ex.Current().TShape().get());
             auto it = colorMap.find(id);
             if (it == colorMap.end()) continue;
-            result->ids.push_back(id);
-            result->r.push_back(it->second[0]);
-            result->g.push_back(it->second[1]);
-            result->b.push_back(it->second[2]);
+            out_ids.push_back(id);
+            out_rgb.push_back(it->second[0]);
+            out_rgb.push_back(it->second[1]);
+            out_rgb.push_back(it->second[2]);
         }
 
-        return result;
+        return std::make_unique<TopoDS_Shape>(compound);
     } catch (const Standard_Failure&) {
         return nullptr;
     }
 }
 
-std::unique_ptr<TopoDS_Shape> colored_step_shape(const ColoredStepData& d) {
-    return std::make_unique<TopoDS_Shape>(d.shape);
-}
-
-rust::Vec<uint64_t> colored_step_ids(const ColoredStepData& d) {
-    rust::Vec<uint64_t> v;
-    for (uint64_t x : d.ids) v.push_back(x);
-    return v;
-}
-
-rust::Vec<float> colored_step_colors_r(const ColoredStepData& d) {
-    rust::Vec<float> v;
-    for (float x : d.r) v.push_back(x);
-    return v;
-}
-
-rust::Vec<float> colored_step_colors_g(const ColoredStepData& d) {
-    rust::Vec<float> v;
-    for (float x : d.g) v.push_back(x);
-    return v;
-}
-
-rust::Vec<float> colored_step_colors_b(const ColoredStepData& d) {
-    rust::Vec<float> v;
-    for (float x : d.b) v.push_back(x);
-    return v;
-}
-
 bool write_step_color_stream(
     const TopoDS_Shape&         shape,
     rust::Slice<const uint64_t> ids,
-    rust::Slice<const float>    cr,
-    rust::Slice<const float>    cg,
-    rust::Slice<const float>    cb,
+    rust::Slice<const float>    rgb,
     RustWriter&                 writer)
 {
     try {
@@ -1790,7 +1761,7 @@ bool write_step_color_stream(
         // Build TShape* → color lookup from the Rust-supplied arrays.
         std::unordered_map<uint64_t, std::array<float, 3>> colorLookup;
         for (size_t i = 0; i < ids.size(); i++) {
-            colorLookup[ids[i]] = {cr[i], cg[i], cb[i]};
+            colorLookup[ids[i]] = {rgb[3*i], rgb[3*i+1], rgb[3*i+2]};
         }
 
         // For each colored face, find/create its sub-shape label and set color.

--- a/cpp/wrapper.h
+++ b/cpp/wrapper.h
@@ -386,30 +386,22 @@ namespace cadrum {
 
 // ==================== Colored STEP I/O ====================
 
-/// Result of read_step_color_stream.
-/// shape  — the geometry compound.
-/// ids    — TShape* addresses of colored faces (parallel to r/g/b).
-/// r/g/b  — face color components in OCC native space (0.0–1.0).
-class ColoredStepData {
-public:
-    TopoDS_Shape shape;
-    std::vector<uint64_t> ids;
-    std::vector<float>    r, g, b;
-};
+// Read a colored STEP stream. Returns the geometry shape; appends to
+// `out_ids` the TShape* address of each colored face, and to `out_rgb` its
+// RGB components in OCC native space (0.0–1.0) as a flat
+// [r0,g0,b0, r1,g1,b1, ...] sequence (length = 3 * out_ids.size()).
+// Returns nullptr on failure.
+std::unique_ptr<TopoDS_Shape> read_step_color_stream(
+    RustReader&          reader,
+    rust::Vec<uint64_t>& out_ids,
+    rust::Vec<float>&    out_rgb);
 
-std::unique_ptr<ColoredStepData> read_step_color_stream(RustReader& reader);
-std::unique_ptr<TopoDS_Shape>    colored_step_shape(const ColoredStepData& d);
-rust::Vec<uint64_t>              colored_step_ids(const ColoredStepData& d);
-rust::Vec<float>                 colored_step_colors_r(const ColoredStepData& d);
-rust::Vec<float>                 colored_step_colors_g(const ColoredStepData& d);
-rust::Vec<float>                 colored_step_colors_b(const ColoredStepData& d);
-
+// Write a colored STEP stream. `ids` lists TShape* of colored faces; `rgb`
+// is the matching flat [r,g,b,...] sequence (length = 3 * ids.size()).
 bool write_step_color_stream(
     const TopoDS_Shape&         shape,
     rust::Slice<const uint64_t> ids,
-    rust::Slice<const float>    cr,
-    rust::Slice<const float>    cg,
-    rust::Slice<const float>    cb,
+    rust::Slice<const float>    rgb,
     RustWriter&                 writer);
 
 // ==================== Clean with face-origin mapping ====================

--- a/src/occt/ffi.rs
+++ b/src/occt/ffi.rs
@@ -72,23 +72,10 @@ mod ffi_bridge {
 		// ==================== Colored STEP I/O (color feature only) ====================
 
 		#[cfg(feature = "color")]
-		type ColoredStepData;
+		fn read_step_color_stream(reader: &mut RustReader, out_ids: &mut Vec<u64>, out_rgb: &mut Vec<f32>) -> UniquePtr<TopoDS_Shape>;
 
 		#[cfg(feature = "color")]
-		fn read_step_color_stream(reader: &mut RustReader) -> UniquePtr<ColoredStepData>;
-		#[cfg(feature = "color")]
-		fn colored_step_shape(d: &ColoredStepData) -> UniquePtr<TopoDS_Shape>;
-		#[cfg(feature = "color")]
-		fn colored_step_ids(d: &ColoredStepData) -> Vec<u64>;
-		#[cfg(feature = "color")]
-		fn colored_step_colors_r(d: &ColoredStepData) -> Vec<f32>;
-		#[cfg(feature = "color")]
-		fn colored_step_colors_g(d: &ColoredStepData) -> Vec<f32>;
-		#[cfg(feature = "color")]
-		fn colored_step_colors_b(d: &ColoredStepData) -> Vec<f32>;
-
-		#[cfg(feature = "color")]
-		fn write_step_color_stream(shape: &TopoDS_Shape, ids: &[u64], cr: &[f32], cg: &[f32], cb: &[f32], writer: &mut RustWriter) -> bool;
+		fn write_step_color_stream(shape: &TopoDS_Shape, ids: &[u64], rgb: &[f32], writer: &mut RustWriter) -> bool;
 
 		// ==================== Shape Methods ====================
 
@@ -197,5 +184,3 @@ pub use ffi_bridge::*;
 unsafe impl Send for TopoDS_Shape {}
 unsafe impl Send for TopoDS_Face {}
 unsafe impl Send for TopoDS_Edge {}
-#[cfg(feature = "color")]
-unsafe impl Send for ColoredStepData {}

--- a/src/occt/io.rs
+++ b/src/occt/io.rs
@@ -79,22 +79,16 @@ impl IoModule for Io {
 		#[cfg(feature = "color")]
 		{
 			let mut rust_reader = RustReader::from_ref(reader);
-			let d = ffi::read_step_color_stream(&mut rust_reader);
-			if d.is_null() {
-				return Err(Error::StepReadFailed);
-			}
-			let inner = ffi::colored_step_shape(&d);
+			let mut ids: Vec<u64> = Default::default();
+			let mut rgb: Vec<f32> = Default::default();
+			let inner = ffi::read_step_color_stream(&mut rust_reader, &mut ids, &mut rgb);
 			if inner.is_null() {
 				return Err(Error::StepReadFailed);
 			}
-			let ids = ffi::colored_step_ids(&d);
-			let r = ffi::colored_step_colors_r(&d);
-			let g = ffi::colored_step_colors_g(&d);
-			let b = ffi::colored_step_colors_b(&d);
-			let mut colormap = std::collections::HashMap::new();
-			for i in 0..ids.len() {
-				colormap.insert(ids[i], Color { r: r[i], g: g[i], b: b[i] });
-			}
+			let colormap: std::collections::HashMap<u64, Color> = ids.into_iter()
+				.zip(rgb.chunks_exact(3))
+				.map(|(id, c)| (id, Color { r: c[0], g: c[1], b: c[2] }))
+				.collect();
 			Ok(CompoundShape::from_raw(inner, colormap, Default::default()).decompose())
 		}
 		#[cfg(not(feature = "color"))]
@@ -179,12 +173,14 @@ impl IoModule for Io {
 		#[cfg(feature = "color")]
 		{
 			let colormap = compound.colormap();
-			let ids: Vec<u64> = colormap.keys().copied().collect();
-			let r: Vec<f32> = ids.iter().map(|&id| colormap[&id].r).collect();
-			let g: Vec<f32> = ids.iter().map(|&id| colormap[&id].g).collect();
-			let b: Vec<f32> = ids.iter().map(|&id| colormap[&id].b).collect();
+			let mut ids: Vec<u64> = Vec::with_capacity(colormap.len());
+			let mut rgb: Vec<f32> = Vec::with_capacity(colormap.len() * 3);
+			for (&id, c) in colormap {
+				ids.push(id);
+				rgb.extend_from_slice(&[c.r, c.g, c.b]);
+			}
 			let mut rust_writer = RustWriter::from_ref(writer);
-			if ffi::write_step_color_stream(compound.inner(), &ids, &r, &g, &b, &mut rust_writer) {
+			if ffi::write_step_color_stream(compound.inner(), &ids, &rgb, &mut rust_writer) {
 				Ok(())
 			} else {
 				Err(Error::StepWriteFailed)


### PR DESCRIPTION
## Summary

`#[cfg(feature = "color")]` 配下に残っていた `ColoredStepData` opaque struct + 5 アクセサを廃止し、`read_step_color_stream` を out-parameter 形式に変更。`notes/20260425-Solid_history導入とCxxOpaqueStruct廃止.md` で `BooleanShape` / `CleanShape` に適用済みの「opaque struct を out-parameter 化して廃止する」パターンを `ColoredStepData` にも適用したもの。

合わせて `write_step_color_stream` の `cr/cg/cb` 3 並列スライスを flat `rgb` 1 本に統一し、read/write を対称化。

## 削減

- C++ opaque type: -1 (`ColoredStepData`)
- FFI 関数: -5 (`colored_step_shape` / `colored_step_ids` / `colored_step_colors_{r,g,b}`)
- `unsafe impl Send`: -1
- 行数: -56 (4 files, +41 / -97)
- `io.rs` read 分岐: 6 FFI 呼び出し → 1 呼び出し

API 表面 (`Io::read_step` / `Io::write_step`) は不変のため下流 (tests / examples) への変更なし。

## Test plan

- [x] `cargo build --features color`
- [x] `cargo build --no-default-features`
- [x] `cargo test --features color` — 全 75 tests pass (`integration_color_step` 5/5 含む)
- [x] `cargo run --example 02_write_read --features color` — STEP/BRep round-trip 成功