### PR TITLE
refactor(clean): unify clean_shape variants, populate Solid::history

### DIFF
--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -519,21 +519,45 @@ std::unique_ptr<TopoDS_Shape> boolean_op(
 
 // ==================== Shape Methods ====================
 
-#ifndef CADRUM_COLOR
-// Plain clean — used only when CADRUM_COLOR is not defined.
-// With color, clean goes through `clean_shape_full` which also returns a
-// face-id remapping table so the colormap can follow merged faces.
-std::unique_ptr<TopoDS_Shape> clean_shape(const TopoDS_Shape& shape) {
+// Unify shared faces / collinear edges. `out_history` is populated with
+// flat [new_id, old_id, ...] pairs covering every old face that survived
+// (either unchanged, or merged into a result face); identical layout to
+// `boolean_op`'s history.
+std::unique_ptr<TopoDS_Shape> clean_shape(
+    const TopoDS_Shape& shape,
+    rust::Vec<uint64_t>& out_history)
+{
     try {
         ShapeUpgrade_UnifySameDomain unifier(shape, true, true, true);
         unifier.AllowInternalEdges(false);
         unifier.Build();
-        return std::make_unique<TopoDS_Shape>(unifier.Shape());
+
+        auto result = std::make_unique<TopoDS_Shape>(unifier.Shape());
+
+        Handle(BRepTools_History) history = unifier.History();
+        if (!history.IsNull()) {
+            for (TopExp_Explorer ex(shape, TopAbs_FACE); ex.More(); ex.Next()) {
+                const TopoDS_Shape& old_face = ex.Current();
+                uint64_t old_id = reinterpret_cast<uint64_t>(old_face.TShape().get());
+                if (history->IsRemoved(old_face)) continue;
+                const NCollection_List<TopoDS_Shape>& mods = history->Modified(old_face);
+                if (mods.IsEmpty()) {
+                    // Unchanged: TShape* is the same in the result.
+                    out_history.push_back(old_id);
+                    out_history.push_back(old_id);
+                } else {
+                    // Merged: use only the first resulting face (first-found wins).
+                    uint64_t new_id = reinterpret_cast<uint64_t>(mods.First().TShape().get());
+                    out_history.push_back(new_id);
+                    out_history.push_back(old_id);
+                }
+            }
+        }
+        return result;
     } catch (const Standard_Failure&) {
         return nullptr;
     }
 }
-#endif // !CADRUM_COLOR
 
 std::unique_ptr<TopoDS_Shape> translate_shape(
     const TopoDS_Shape& shape,
@@ -1793,44 +1817,6 @@ bool write_step_color_stream(
         return cafwriter.ChangeWriter().WriteStream(os) == IFSelect_RetDone;
     } catch (const Standard_Failure&) {
         return false;
-    }
-}
-
-// ==================== Clean with face-origin mapping ====================
-
-std::unique_ptr<TopoDS_Shape> clean_shape_full(
-    const TopoDS_Shape& shape,
-    rust::Vec<uint64_t>& out_mapping)
-{
-    try {
-        ShapeUpgrade_UnifySameDomain unifier(shape, true, true, true);
-        unifier.AllowInternalEdges(false);
-        unifier.Build();
-
-        auto result = std::make_unique<TopoDS_Shape>(unifier.Shape());
-
-        Handle(BRepTools_History) history = unifier.History();
-        if (!history.IsNull()) {
-            for (TopExp_Explorer ex(shape, TopAbs_FACE); ex.More(); ex.Next()) {
-                const TopoDS_Shape& old_face = ex.Current();
-                uint64_t old_id = reinterpret_cast<uint64_t>(old_face.TShape().get());
-                if (history->IsRemoved(old_face)) continue;
-                const NCollection_List<TopoDS_Shape>& mods = history->Modified(old_face);
-                if (mods.IsEmpty()) {
-                    // Unchanged: TShape* is the same in the result.
-                    out_mapping.push_back(old_id);
-                    out_mapping.push_back(old_id);
-                } else {
-                    // Merged: use only the first resulting face (first-found wins).
-                    uint64_t new_id = reinterpret_cast<uint64_t>(mods.First().TShape().get());
-                    out_mapping.push_back(new_id);
-                    out_mapping.push_back(old_id);
-                }
-            }
-        }
-        return result;
-    } catch (const Standard_Failure&) {
-        return nullptr;
     }
 }
 

--- a/cpp/wrapper.h
+++ b/cpp/wrapper.h
@@ -136,11 +136,14 @@ std::unique_ptr<TopoDS_Shape> boolean_op(
 
 // ==================== Shape Methods ====================
 
-// Plain clean — only built without CADRUM_COLOR; with color, clean goes
-// through `clean_shape_full` to remap face IDs onto the colormap.
-#ifndef CADRUM_COLOR
-std::unique_ptr<TopoDS_Shape> clean_shape(const TopoDS_Shape& shape);
-#endif
+// Unify shared faces / collinear edges via ShapeUpgrade_UnifySameDomain.
+// `out_history` is appended with flat [new_id, old_id, ...] pairs encoding
+// how each old face maps onto the unified result (mirrors `boolean_op`'s
+// history layout). The Rust side stores these in `Solid::history` and uses
+// them to remap the colormap when the `color` feature is enabled.
+std::unique_ptr<TopoDS_Shape> clean_shape(
+    const TopoDS_Shape& shape,
+    rust::Vec<uint64_t>& out_history);
 std::unique_ptr<TopoDS_Shape> translate_shape(
     const TopoDS_Shape& shape, double tx, double ty, double tz);
 std::unique_ptr<TopoDS_Shape> rotate_shape(
@@ -403,15 +406,6 @@ bool write_step_color_stream(
     rust::Slice<const uint64_t> ids,
     rust::Slice<const float>    rgb,
     RustWriter&                 writer);
-
-// ==================== Clean with face-origin mapping ====================
-
-// Returns the cleaned shape; `out_mapping` is appended with flat
-// [new_tshape_id, old_tshape_id, ...] pairs encoding how each old face
-// maps onto the unified result (used to remap the colormap on the Rust side).
-std::unique_ptr<TopoDS_Shape> clean_shape_full(
-    const TopoDS_Shape& shape,
-    rust::Vec<uint64_t>& out_mapping);
 
 } // namespace cadrum
 

--- a/src/occt/ffi.rs
+++ b/src/occt/ffi.rs
@@ -79,13 +79,10 @@ mod ffi_bridge {
 
 		// ==================== Shape Methods ====================
 
-		// Plain clean — used only without `color` feature.
-		// With color, clean goes through `clean_shape_full` to remap face IDs.
-		#[cfg(not(feature = "color"))]
-		fn clean_shape(shape: &TopoDS_Shape) -> UniquePtr<TopoDS_Shape>;
-
-		#[cfg(feature = "color")]
-		fn clean_shape_full(shape: &TopoDS_Shape, out_mapping: &mut Vec<u64>) -> UniquePtr<TopoDS_Shape>;
+		// Unify shared faces. `out_history` receives flat [new_id, old_id, ...]
+		// pairs (same layout as `boolean_op`), used by Solid::clean to populate
+		// `Solid::history` and remap the colormap when color is enabled.
+		fn clean_shape(shape: &TopoDS_Shape, out_history: &mut Vec<u64>) -> UniquePtr<TopoDS_Shape>;
 
 		fn translate_shape(shape: &TopoDS_Shape, tx: f64, ty: f64, tz: f64) -> UniquePtr<TopoDS_Shape>;
 

--- a/src/occt/solid.rs
+++ b/src/occt/solid.rs
@@ -503,31 +503,22 @@ impl Compound for Solid {
 	type Elem = Solid;
 
 	fn clean(&self) -> Result<Self, Error> {
+		let mut history: Vec<u64> = Default::default();
+		let inner = ffi::clean_shape(&self.inner, &mut history);
+		if inner.is_null() {
+			return Err(Error::CleanFailed);
+		}
 		#[cfg(feature = "color")]
-		{
-			let mut mapping: Vec<u64> = Default::default();
-			let inner = ffi::clean_shape_full(&self.inner, &mut mapping);
-			if inner.is_null() {
-				return Err(Error::CleanFailed);
-			}
-			let mut colormap = std::collections::HashMap::new();
-			for pair in mapping.chunks_exact(2) {
-				let new_id = pair[0];
-				let old_id = pair[1];
-				if let Some(&color) = self.colormap.get(&old_id) {
-					colormap.entry(new_id).or_insert(color);
+		let colormap = {
+			let mut m = std::collections::HashMap::new();
+			for pair in history.chunks_exact(2) {
+				if let Some(&color) = self.colormap.get(&pair[1]) {
+					m.entry(pair[0]).or_insert(color);
 				}
 			}
-			return Ok(Solid::new(inner, colormap, Default::default()));
-		}
-		#[cfg(not(feature = "color"))]
-		{
-			let inner = ffi::clean_shape(&self.inner);
-			if inner.is_null() {
-				return Err(Error::CleanFailed);
-			}
-			Ok(Solid::new(inner, Default::default()))
-		}
+			m
+		};
+		Ok(Solid::new(inner, #[cfg(feature = "color")] colormap, history))
 	}
 
 	// ==================== Queries ====================


### PR DESCRIPTION
## Summary

`clean_shape_full` の `out_mapping` (flat `[new_id, old_id, ...]`) は `boolean_op` の `out_history` と構造的にも意味的にも同一なので、`Solid::history` に統合。`clean_shape` / `clean_shape_full` の二系統を 1 本の `clean_shape(shape, out_history)` に集約した。

副次効果として `iter_history()` で clean 後の Solid からも \"old → new face\" derivation が引けるようになる (boolean op と同じ挙動)。

## Stacked on

このブランチは #131 の上に積んでいるため、merge は #131 → 本 PR の順で。

## 削減

- FFI 関数: `clean_shape` / `clean_shape_full` 2 種 → 1 種
- cxx bridge の `#[cfg]` 分岐: -2
- C++ 側 `#ifndef CADRUM_COLOR` ガード: 1 ヵ所削除
- \"mapping\" という local 概念が消え、history で統一
- 行数: -32 (4 files, +56 / -88)

## Test plan

- [x] \`cargo build --features color\` / \`--no-default-features\`
- [x] \`cargo test --features color\` 全 75 tests pass (\`integration_color_step::clean_colored_step_preserves_colors\` 含む)
- [x] \`cargo test --no-default-features --lib --tests\` 全 pass
- [x] \`cargo build --features color --examples\` 全 example ビルド通る