### PR TITLE
chore(cpp): drop dead/duplicate includes, gate STEP, fix make_loft doc

### DIFF
--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -13,6 +13,7 @@
 #include <TopoDS_Compound.hxx>
 #include <TopAbs_ShapeEnum.hxx>
 #include <TopExp.hxx>
+#include <TopExp_Explorer.hxx>
 #include <TopLoc_Location.hxx>
 #include <NCollection_IndexedMap.hxx>
 #include <NCollection_List.hxx>
@@ -22,7 +23,6 @@
 #include <gp_Ax1.hxx>
 #include <gp_Ax2.hxx>
 #include <gp_Circ.hxx>
-#include <gp_Lin.hxx>
 #include <gp_Pln.hxx>
 #include <gp_Trsf.hxx>
 #include <Geom_CylindricalSurface.hxx>
@@ -71,7 +71,6 @@
 // --- Mesh, classification, mass / surface properties ---
 #include <BRepMesh_IncrementalMesh.hxx>
 #include <Poly_Triangulation.hxx>
-#include <BRepClass3d_SolidClassifier.hxx>
 #include <BRepBndLib.hxx>
 #include <Bnd_Box.hxx>
 #include <BRepGProp.hxx>
@@ -90,11 +89,16 @@
 #include <Precision.hxx>
 
 // --- I/O (BREP / STEP / progress) ---
+// STEP-specific headers are only needed by the non-color STEP path
+// (`read_step_stream` / `write_step_stream`); with color, STEP routes
+// through XCAF in the CADRUM_COLOR section below.
 #include <BRepTools.hxx>
 #include <BinTools.hxx>
+#ifndef CADRUM_COLOR
 #include <STEPControl_Reader.hxx>
 #include <STEPControl_Writer.hxx>
 #include <Message_ProgressRange.hxx>
+#endif
 #include <Message.hxx>
 
 // --- C++ standard library ---
@@ -1468,28 +1472,11 @@ std::unique_ptr<TopoDS_Shape> make_pipe_shell(
 
 // Loft (skin) a smooth solid through a sequence of cross-section wires.
 //
-// `all_edges` is a flattened list of all edges across all sections; the
-// `section_sizes` array tells how many edges belong to each section. Example:
-//   sections [[a, b, c], [d, e], [f, g, h, i]]
-//   → all_edges = [a, b, c, d, e, f, g, h, i]
-//     section_sizes = [3, 2, 4]
-//
-// When `closed == true`, the first section's TopoDS_Wire is reused (NOT
-// copied) as the last section. OCCT's BRepOffsetAPI_ThruSections checks
-// `myWires(1).IsSame(myWires(nbSects))` (TShape* pointer identity) and
-// switches to a v-direction periodic surface internally — see
-// BRepOffsetAPI_ThruSections.cxx lines 539, 691, and 1187-1189. The
-// resulting surface is C² continuous across the wrap-around because the
-// underlying GeomFill_AppSurf processes all sections at once with periodic
-// boundary conditions. Crucially we must NOT BRepBuilderAPI_Copy the wire
-// — that would assign a fresh TShape* and the IsSame() check would fail,
-// silently degrading to an open loft.
-//
-// `isSolid=true` requests OCCT cap the open ends with planar faces (when
-// `closed=false`); `isRuled=false` requests B-spline (smoothed) interpolation
-// rather than panel-by-panel ruled surfaces — necessary for the C² guarantee.
-// Loft (skin) through cross-section wires.  Sections in `all_edges` are
-// separated by null-edge sentinels.
+// `all_edges` is a flat edge list with sections delimited by null-edge
+// sentinels (TopoDS_Edge().IsNull()); ≥2 sections required. Built via
+// BRepOffsetAPI_ThruSections with isSolid=true (cap open ends with planar
+// faces) and isRuled=false (B-spline / C² smoothed interpolation rather
+// than per-panel ruled surfaces).
 std::unique_ptr<TopoDS_Shape> make_loft(
     const std::vector<TopoDS_Edge>& all_edges)
 {

--- a/cpp/wrapper.h
+++ b/cpp/wrapper.h
@@ -7,7 +7,6 @@
 #include <TopoDS_Shape.hxx>
 #include <TopoDS_Face.hxx>
 #include <TopoDS_Edge.hxx>
-#include <TopExp_Explorer.hxx>
 
 #include <cstdint>
 #include <streambuf>

--- a/src/occt/ffi.rs
+++ b/src/occt/ffi.rs
@@ -1,4 +1,4 @@
-use super::stream::{rust_reader_read, rust_writer_flush, rust_writer_write};
+use super::stream::{rust_reader_read, rust_writer_write};
 use super::stream::{RustReader, RustWriter};
 
 #[cxx::bridge(namespace = "cadrum")]
@@ -20,7 +20,6 @@ mod ffi_bridge {
 
 		fn rust_reader_read(reader: &mut RustReader, buf: &mut [u8]) -> usize;
 		fn rust_writer_write(writer: &mut RustWriter, buf: &[u8]) -> usize;
-		fn rust_writer_flush(writer: &mut RustWriter) -> bool;
 	}
 
 	unsafe extern "C++" {

--- a/src/occt/stream.rs
+++ b/src/occt/stream.rs
@@ -59,8 +59,3 @@ pub fn rust_reader_read(reader: &mut RustReader, buf: &mut [u8]) -> usize {
 pub fn rust_writer_write(writer: &mut RustWriter, buf: &[u8]) -> usize {
 	unsafe { (*writer.inner).write(buf).unwrap_or(0) }
 }
-
-/// FFI callback: flush the RustWriter.
-pub fn rust_writer_flush(writer: &mut RustWriter) -> bool {
-	unsafe { (*writer.inner).flush().is_ok() }
-}


### PR DESCRIPTION
## Summary

機械的な C++ FFI レイヤ清掃:

1. \`gp_Lin.hxx\` 未使用 → 削除
2. \`BRepClass3d_SolidClassifier.hxx\` 重複 include (line 44 と 74) → 1 つに
3. \`STEPControl_Reader/Writer\` + \`Message_ProgressRange\` を \`#ifndef CADRUM_COLOR\` ガード内へ (使用箇所はすべて非 color パス)
4. \`TopExp_Explorer.hxx\` を wrapper.h → wrapper.cpp へ移動 (signature に登場せず実装でのみ 13 ヵ所使用、wrapper.h の冒頭コメント方針通り)
5. 未使用 FFI \`rust_writer_flush\` 削除 (C++ 側から一度も呼ばれず、\`RustWriteStreambuf::sync\` は \`flush_buf\` を直接叩いている)
6. \`make_loft\` の doc を実 API に合わせて書き直し (削除済みの \`section_sizes\` / \`closed\` パラメータを参照していた)

## Stacked on

\`refactor/rename-shallow-copy\` の上に積んでいるので merge は #134 → 本 PR の順で。

## 削減

- 行数: 4 files, +12 / -32
- include: 3 個削除 + 1 個 cfg ガード + 1 個 h→cpp 移動
- FFI シンボル: \`rust_writer_flush\` 1 個削除

## Test plan

- [x] \`cargo build --features color\` / \`--no-default-features\`
- [x] \`cargo test --features color\` 全 pass