### PR TITLE
refactor(ffi): rename to builder_*/transform_* and group by section

### DIFF
--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -405,7 +405,7 @@ void compound_add(TopoDS_Shape& compound, const TopoDS_Shape& child) {
     builder.Add(compound, child);
 }
 
-// ==================== Boolean Operations ====================
+// ==================== Builders (solid → solid with history) ====================
 // Bug 1 fix: All boolean results are deep-copied via BRepBuilderAPI_Copy
 // so the result shares no Handle<Geom_XXX> with the input shapes.
 // This prevents STATUS_HEAP_CORRUPTION when shapes are dropped in any order.
@@ -488,7 +488,7 @@ static void emit_from_pairs(
 //
 // out_history is appended-to (not cleared) — caller passes an empty rust::Vec.
 // Both a and b contributions are pushed into the same flat sequence.
-std::unique_ptr<TopoDS_Shape> boolean_op(
+std::unique_ptr<TopoDS_Shape> builder_boolean(
     const TopoDS_Shape& a, const TopoDS_Shape& b, uint32_t op_kind,
     rust::Vec<uint64_t>& out_history)
 {
@@ -517,13 +517,11 @@ std::unique_ptr<TopoDS_Shape> boolean_op(
     }
 }
 
-// ==================== Shape Methods ====================
-
 // Unify shared faces / collinear edges. `out_history` is populated with
 // flat [new_id, old_id, ...] pairs covering every old face that survived
 // (either unchanged, or merged into a result face); identical layout to
-// `boolean_op`'s history.
-std::unique_ptr<TopoDS_Shape> clean_shape(
+// `builder_boolean`'s history.
+std::unique_ptr<TopoDS_Shape> builder_clean(
     const TopoDS_Shape& shape,
     rust::Vec<uint64_t>& out_history)
 {
@@ -559,7 +557,9 @@ std::unique_ptr<TopoDS_Shape> clean_shape(
     }
 }
 
-std::unique_ptr<TopoDS_Shape> translate_shape(
+// ==================== Transforms (solid → solid, no history) ====================
+
+std::unique_ptr<TopoDS_Shape> transform_translate(
     const TopoDS_Shape& shape,
     double tx, double ty, double tz)
 {
@@ -568,7 +568,7 @@ std::unique_ptr<TopoDS_Shape> translate_shape(
     return std::make_unique<TopoDS_Shape>(shape.Moved(TopLoc_Location(trsf)));
 }
 
-std::unique_ptr<TopoDS_Shape> rotate_shape(
+std::unique_ptr<TopoDS_Shape> transform_rotate(
     const TopoDS_Shape& shape,
     double ox, double oy, double oz,
     double dx, double dy, double dz,
@@ -583,7 +583,7 @@ std::unique_ptr<TopoDS_Shape> rotate_shape(
     }
 }
 
-std::unique_ptr<TopoDS_Shape> scale_shape(
+std::unique_ptr<TopoDS_Shape> transform_scale(
     const TopoDS_Shape& shape,
     double cx, double cy, double cz,
     double factor)
@@ -598,7 +598,7 @@ std::unique_ptr<TopoDS_Shape> scale_shape(
     }
 }
 
-std::unique_ptr<TopoDS_Shape> mirror_shape(
+std::unique_ptr<TopoDS_Shape> transform_mirror(
     const TopoDS_Shape& shape,
     double ox, double oy, double oz,
     double nx, double ny, double nz)
@@ -612,6 +612,8 @@ std::unique_ptr<TopoDS_Shape> mirror_shape(
         return nullptr;
     }
 }
+
+// ==================== Shape Queries ====================
 
 bool shape_is_null(const TopoDS_Shape& shape) {
     return shape.IsNull();
@@ -1224,7 +1226,7 @@ void face_vec_push(std::vector<TopoDS_Face>& v, const TopoDS_Face& f) {
     v.push_back(f);
 }
 
-std::unique_ptr<TopoDS_Shape> make_thick_solid(
+std::unique_ptr<TopoDS_Shape> builder_thick_solid(
     const TopoDS_Shape& solid,
     const std::vector<TopoDS_Face>& open_faces,
     double thickness)
@@ -1289,7 +1291,7 @@ std::unique_ptr<TopoDS_Shape> make_thick_solid(
     }
 }
 
-std::unique_ptr<TopoDS_Shape> make_fillet(
+std::unique_ptr<TopoDS_Shape> builder_fillet(
     const TopoDS_Shape& solid,
     const std::vector<TopoDS_Edge>& edges,
     double radius)
@@ -1322,7 +1324,7 @@ std::unique_ptr<TopoDS_Shape> make_fillet(
     }
 }
 
-std::unique_ptr<TopoDS_Shape> make_chamfer(
+std::unique_ptr<TopoDS_Shape> builder_chamfer(
     const TopoDS_Shape& solid,
     const std::vector<TopoDS_Edge>& edges,
     double distance)

--- a/cpp/wrapper.h
+++ b/cpp/wrapper.h
@@ -118,45 +118,92 @@ std::unique_ptr<TopoDS_Shape> make_torus(
 std::unique_ptr<TopoDS_Shape> make_empty();
 std::unique_ptr<TopoDS_Shape> deep_copy(const TopoDS_Shape& shape);
 
-// ==================== Boolean Operations ====================
+// ==================== Builders (solid → solid with history) ====================
+//
+// Functions in this section take one or more solid inputs, rebuild topology,
+// and append flat [post_id, src_id, ...] face derivation pairs to
+// `out_history`. The Rust side stores these in `Solid::history`.
 
 // Unified boolean operation: 0=Fuse(union), 1=Cut(a−b), 2=Common(intersect).
 //
-// `out_history` receives flat [post_id, src_id, post_id, src_id, ...] pairs
-// for every result face derived from either input (a or b). post_id is the
-// TShape* of the result face; src_id is the TShape* of the original face in
-// whichever input it came from. Self/tool distinction is intentionally
+// `out_history` is appended with pairs covering every result face derived
+// from either input (a or b). Self/tool distinction is intentionally
 // collapsed — TShape* pointers are globally unique so callers can filter by
 // matching src_id against either input's face id set.
-std::unique_ptr<TopoDS_Shape> boolean_op(
+std::unique_ptr<TopoDS_Shape> builder_boolean(
     const TopoDS_Shape& a, const TopoDS_Shape& b, uint32_t op_kind,
     rust::Vec<uint64_t>& out_history);
 
-// ==================== Shape Methods ====================
-
 // Unify shared faces / collinear edges via ShapeUpgrade_UnifySameDomain.
-// `out_history` is appended with flat [new_id, old_id, ...] pairs encoding
-// how each old face maps onto the unified result (mirrors `boolean_op`'s
-// history layout). The Rust side stores these in `Solid::history` and uses
-// them to remap the colormap when the `color` feature is enabled.
-std::unique_ptr<TopoDS_Shape> clean_shape(
+// `out_history` encodes how each old face maps onto the unified result.
+// Rust uses it to remap the colormap when the `color` feature is enabled.
+std::unique_ptr<TopoDS_Shape> builder_clean(
     const TopoDS_Shape& shape,
     rust::Vec<uint64_t>& out_history);
-std::unique_ptr<TopoDS_Shape> translate_shape(
+
+// Shell (hollow) the solid by removing `open_faces` and offsetting the
+// remaining faces by `thickness` via BRepOffsetAPI_MakeThickSolid. Negative
+// thickness hollows inward, positive thickens outward. Returns nullptr on
+// failure (e.g. self-intersecting offset at sharp corners).
+//
+// TODO: populate `out_history` via BRepOffsetAPI_MakeThickSolid::Modified()
+// — currently the Rust side stores an empty history.
+std::unique_ptr<TopoDS_Shape> builder_thick_solid(
+    const TopoDS_Shape& solid,
+    const std::vector<TopoDS_Face>& open_faces,
+    double thickness);
+
+// Fillet the given edges of `solid` with a uniform radius using
+// BRepFilletAPI_MakeFillet. Empty `edges` is a no-op (returns a shallow
+// copy of `solid`). Returns nullptr on OCCT failure (radius too large,
+// tangent discontinuity, edges not belonging to `solid`, etc.).
+//
+// TODO: populate `out_history` via BRepFilletAPI_MakeFillet::Modified() /
+// Generated() — currently the Rust side stores an empty history.
+std::unique_ptr<TopoDS_Shape> builder_fillet(
+    const TopoDS_Shape& solid,
+    const std::vector<TopoDS_Edge>& edges,
+    double radius);
+
+// Chamfer (symmetric bevel) the given edges of `solid` with a uniform
+// distance using BRepFilletAPI_MakeChamfer. Empty `edges` is a no-op
+// (returns a shallow copy of `solid`). Returns nullptr on OCCT failure
+// (distance too large, tangent discontinuity, edges not belonging to
+// `solid`, etc.).
+//
+// TODO: populate `out_history` via BRepFilletAPI_MakeChamfer::Modified() /
+// Generated() — currently the Rust side stores an empty history.
+std::unique_ptr<TopoDS_Shape> builder_chamfer(
+    const TopoDS_Shape& solid,
+    const std::vector<TopoDS_Edge>& edges,
+    double distance);
+
+// ==================== Transforms (solid → solid, no history) ====================
+//
+// 3D transforms. translate/rotate use TopLoc_Location and preserve TShape*
+// (Rust side keeps colormap and history intact). scale/mirror rebuild
+// topology via BRepBuilderAPI_Transform; OCCT does not expose a face
+// derivation table, so out_history is intentionally absent and the Rust
+// side clears Solid::history (colormap is remapped by face order instead).
+
+std::unique_ptr<TopoDS_Shape> transform_translate(
     const TopoDS_Shape& shape, double tx, double ty, double tz);
-std::unique_ptr<TopoDS_Shape> rotate_shape(
+std::unique_ptr<TopoDS_Shape> transform_rotate(
     const TopoDS_Shape& shape,
     double ox, double oy, double oz,
     double dx, double dy, double dz,
     double angle);
-std::unique_ptr<TopoDS_Shape> scale_shape(
+std::unique_ptr<TopoDS_Shape> transform_scale(
     const TopoDS_Shape& shape,
     double cx, double cy, double cz,
     double factor);
-std::unique_ptr<TopoDS_Shape> mirror_shape(
+std::unique_ptr<TopoDS_Shape> transform_mirror(
     const TopoDS_Shape& shape,
     double ox, double oy, double oz,
     double nx, double ny, double nz);
+
+// ==================== Shape Queries ====================
+
 bool shape_is_null(const TopoDS_Shape& shape);
 bool shape_is_solid(const TopoDS_Shape& shape);
 double shape_volume(const TopoDS_Shape& shape);
@@ -329,34 +376,6 @@ void edge_vec_push_null(std::vector<TopoDS_Edge>& v);
 // Helpers for the Rust side to construct a std::vector<TopoDS_Face>.
 std::unique_ptr<std::vector<TopoDS_Face>> face_vec_new();
 void face_vec_push(std::vector<TopoDS_Face>& v, const TopoDS_Face& f);
-
-// Shell (hollow) the solid by removing `open_faces` and offsetting the
-// remaining faces by `thickness` via BRepOffsetAPI_MakeThickSolid. Negative
-// thickness hollows inward, positive thickens outward. Returns nullptr on
-// failure (e.g. self-intersecting offset at sharp corners).
-std::unique_ptr<TopoDS_Shape> make_thick_solid(
-    const TopoDS_Shape& solid,
-    const std::vector<TopoDS_Face>& open_faces,
-    double thickness);
-
-// Fillet the given edges of `solid` with a uniform radius using
-// BRepFilletAPI_MakeFillet. Empty `edges` is a no-op (returns a shallow
-// copy of `solid`). Returns nullptr on OCCT failure (radius too large,
-// tangent discontinuity, edges not belonging to `solid`, etc.).
-std::unique_ptr<TopoDS_Shape> make_fillet(
-    const TopoDS_Shape& solid,
-    const std::vector<TopoDS_Edge>& edges,
-    double radius);
-
-// Chamfer (symmetric bevel) the given edges of `solid` with a uniform
-// distance using BRepFilletAPI_MakeChamfer. Empty `edges` is a no-op
-// (returns a shallow copy of `solid`). Returns nullptr on OCCT failure
-// (distance too large, tangent discontinuity, edges not belonging to
-// `solid`, etc.).
-std::unique_ptr<TopoDS_Shape> make_chamfer(
-    const TopoDS_Shape& solid,
-    const std::vector<TopoDS_Edge>& edges,
-    double distance);
 
 // Loft (skin) a smooth solid through N cross-section wires.
 // Sections in `all_edges` are separated by null-edge sentinels.

--- a/src/occt/ffi.rs
+++ b/src/occt/ffi.rs
@@ -61,12 +61,6 @@ mod ffi_bridge {
 
 		fn deep_copy(shape: &TopoDS_Shape) -> UniquePtr<TopoDS_Shape>;
 
-		// ==================== Boolean Operations ====================
-
-		// Unified boolean op. `op_kind`: 0 = fuse(union), 1 = cut(a − b), 2 = common(intersect).
-		// `out_history` is appended with flat [post_id, src_id, ...] pairs covering both inputs.
-		fn boolean_op(a: &TopoDS_Shape, b: &TopoDS_Shape, op_kind: u32, out_history: &mut Vec<u64>) -> UniquePtr<TopoDS_Shape>;
-
 		// ==================== Colored STEP I/O (color feature only) ====================
 
 		#[cfg(feature = "color")]
@@ -75,20 +69,35 @@ mod ffi_bridge {
 		#[cfg(feature = "color")]
 		fn write_step_color_stream(shape: &TopoDS_Shape, ids: &[u64], rgb: &[f32], writer: &mut RustWriter) -> bool;
 
-		// ==================== Shape Methods ====================
+		// ==================== Builders (solid → solid with history) ====================
+
+		// Unified boolean op. `op_kind`: 0 = fuse(union), 1 = cut(a − b), 2 = common(intersect).
+		// `out_history` is appended with flat [post_id, src_id, ...] pairs covering both inputs.
+		fn builder_boolean(a: &TopoDS_Shape, b: &TopoDS_Shape, op_kind: u32, out_history: &mut Vec<u64>) -> UniquePtr<TopoDS_Shape>;
 
 		// Unify shared faces. `out_history` receives flat [new_id, old_id, ...]
-		// pairs (same layout as `boolean_op`), used by Solid::clean to populate
+		// pairs (same layout as `builder_boolean`), used by Solid::clean to populate
 		// `Solid::history` and remap the colormap when color is enabled.
-		fn clean_shape(shape: &TopoDS_Shape, out_history: &mut Vec<u64>) -> UniquePtr<TopoDS_Shape>;
+		fn builder_clean(shape: &TopoDS_Shape, out_history: &mut Vec<u64>) -> UniquePtr<TopoDS_Shape>;
 
-		fn translate_shape(shape: &TopoDS_Shape, tx: f64, ty: f64, tz: f64) -> UniquePtr<TopoDS_Shape>;
+		// TODO: builder_thick_solid / builder_fillet / builder_chamfer should
+		// also gain `out_history` populated via OCCT's Modified()/Generated()
+		// — currently no history (Rust side stores Default::default()).
+		fn builder_thick_solid(solid: &TopoDS_Shape, open_faces: &CxxVector<TopoDS_Face>, thickness: f64) -> UniquePtr<TopoDS_Shape>;
+		fn builder_fillet(solid: &TopoDS_Shape, edges: &CxxVector<TopoDS_Edge>, radius: f64) -> UniquePtr<TopoDS_Shape>;
+		fn builder_chamfer(solid: &TopoDS_Shape, edges: &CxxVector<TopoDS_Edge>, distance: f64) -> UniquePtr<TopoDS_Shape>;
 
-		fn rotate_shape(shape: &TopoDS_Shape, ox: f64, oy: f64, oz: f64, dx: f64, dy: f64, dz: f64, angle: f64) -> UniquePtr<TopoDS_Shape>;
+		// ==================== Transforms (solid → solid, no history) ====================
 
-		fn scale_shape(shape: &TopoDS_Shape, cx: f64, cy: f64, cz: f64, factor: f64) -> UniquePtr<TopoDS_Shape>;
+		fn transform_translate(shape: &TopoDS_Shape, tx: f64, ty: f64, tz: f64) -> UniquePtr<TopoDS_Shape>;
 
-		fn mirror_shape(shape: &TopoDS_Shape, ox: f64, oy: f64, oz: f64, nx: f64, ny: f64, nz: f64) -> UniquePtr<TopoDS_Shape>;
+		fn transform_rotate(shape: &TopoDS_Shape, ox: f64, oy: f64, oz: f64, dx: f64, dy: f64, dz: f64, angle: f64) -> UniquePtr<TopoDS_Shape>;
+
+		fn transform_scale(shape: &TopoDS_Shape, cx: f64, cy: f64, cz: f64, factor: f64) -> UniquePtr<TopoDS_Shape>;
+
+		fn transform_mirror(shape: &TopoDS_Shape, ox: f64, oy: f64, oz: f64, nx: f64, ny: f64, nz: f64) -> UniquePtr<TopoDS_Shape>;
+
+		// ==================== Shape Queries ====================
 
 		fn shape_is_null(shape: &TopoDS_Shape) -> bool;
 		fn shape_is_solid(shape: &TopoDS_Shape) -> bool;
@@ -157,9 +166,6 @@ mod ffi_bridge {
 		fn face_vec_new() -> UniquePtr<CxxVector<TopoDS_Face>>;
 		fn face_vec_push(v: Pin<&mut CxxVector<TopoDS_Face>>, f: &TopoDS_Face);
 
-		fn make_thick_solid(solid: &TopoDS_Shape, open_faces: &CxxVector<TopoDS_Face>, thickness: f64) -> UniquePtr<TopoDS_Shape>;
-		fn make_fillet(solid: &TopoDS_Shape, edges: &CxxVector<TopoDS_Edge>, radius: f64) -> UniquePtr<TopoDS_Shape>;
-		fn make_chamfer(solid: &TopoDS_Shape, edges: &CxxVector<TopoDS_Edge>, distance: f64) -> UniquePtr<TopoDS_Shape>;
 	}
 }
 

--- a/src/occt/solid.rs
+++ b/src/occt/solid.rs
@@ -266,7 +266,7 @@ impl SolidStruct for Solid {
 		for f in open_faces {
 			ffi::face_vec_push(face_vec.pin_mut(), &f.inner);
 		}
-		let shape = ffi::make_thick_solid(&self.inner, &face_vec, thickness);
+		let shape = ffi::builder_thick_solid(&self.inner, &face_vec, thickness);
 		if shape.is_null() {
 			return Err(Error::ShellFailed);
 		}
@@ -285,7 +285,7 @@ impl SolidStruct for Solid {
 		for e in edges {
 			ffi::edge_vec_push(edge_vec.pin_mut(), &e.inner);
 		}
-		let shape = ffi::make_fillet(&self.inner, &edge_vec, radius);
+		let shape = ffi::builder_fillet(&self.inner, &edge_vec, radius);
 		if shape.is_null() {
 			return Err(Error::FilletFailed);
 		}
@@ -302,7 +302,7 @@ impl SolidStruct for Solid {
 		for e in edges {
 			ffi::edge_vec_push(edge_vec.pin_mut(), &e.inner);
 		}
-		let shape = ffi::make_chamfer(&self.inner, &edge_vec, distance);
+		let shape = ffi::builder_chamfer(&self.inner, &edge_vec, distance);
 		if shape.is_null() {
 			return Err(Error::ChamferFailed);
 		}
@@ -434,7 +434,7 @@ impl SolidStruct for Solid {
 
 impl Transform for Solid {
 	fn translate(self, translation: DVec3) -> Self {
-		let inner = ffi::translate_shape(&self.inner, translation.x, translation.y, translation.z);
+		let inner = ffi::transform_translate(&self.inner, translation.x, translation.y, translation.z);
 		// translate/rotate use shape.Moved() — TShape is shared but Location
 		// changes, so cached edges/faces (which embed Location) would go stale.
 		// Solid::new gives a fresh OnceLock::new() cache matching the new Location.
@@ -448,7 +448,7 @@ impl Transform for Solid {
 	}
 
 	fn rotate(self, axis_origin: DVec3, axis_direction: DVec3, angle: f64) -> Self {
-		let inner = ffi::rotate_shape(&self.inner, axis_origin.x, axis_origin.y, axis_origin.z, axis_direction.x, axis_direction.y, axis_direction.z, angle);
+		let inner = ffi::transform_rotate(&self.inner, axis_origin.x, axis_origin.y, axis_origin.z, axis_direction.x, axis_direction.y, axis_direction.z, angle);
 		Solid::new(
 			inner,
 			#[cfg(feature = "color")]
@@ -463,12 +463,12 @@ impl Transform for Solid {
 	// rejects gp_Trsf with scale != 1 or negative determinant, because downstream
 	// algorithms (meshing, booleans) break on non-rigid transforms in locations.
 	// Therefore BRepBuilderAPI_Transform is required, which rebuilds topology.
-	// C++ impl: cpp/wrapper.cpp scale_shape() / mirror_shape()
+	// C++ impl: cpp/wrapper.cpp transform_scale() / transform_mirror()
 	// See: https://dev.opencascade.org/content/how-scale-or-mirror-shape
 	//      BRepBuilderAPI_Transform.cxx:48-49 (myUseModif branch)
 
 	fn scale(self, center: DVec3, factor: f64) -> Self {
-		let inner = ffi::scale_shape(&self.inner, center.x, center.y, center.z, factor);
+		let inner = ffi::transform_scale(&self.inner, center.x, center.y, center.z, factor);
 		#[cfg(feature = "color")]
 		let colormap = remap_colormap_by_order(&self.inner, &inner, &self.colormap);
 		// scale/mirror rebuild topology via BRepBuilderAPI_Transform → post_ids
@@ -483,7 +483,7 @@ impl Transform for Solid {
 	}
 
 	fn mirror(self, plane_origin: DVec3, plane_normal: DVec3) -> Self {
-		let inner = ffi::mirror_shape(&self.inner, plane_origin.x, plane_origin.y, plane_origin.z, plane_normal.x, plane_normal.y, plane_normal.z);
+		let inner = ffi::transform_mirror(&self.inner, plane_origin.x, plane_origin.y, plane_origin.z, plane_normal.x, plane_normal.y, plane_normal.z);
 		#[cfg(feature = "color")]
 		let colormap = remap_colormap_by_order(&self.inner, &inner, &self.colormap);
 		Solid::new(
@@ -504,7 +504,7 @@ impl Compound for Solid {
 
 	fn clean(&self) -> Result<Self, Error> {
 		let mut history: Vec<u64> = Default::default();
-		let inner = ffi::clean_shape(&self.inner, &mut history);
+		let inner = ffi::builder_clean(&self.inner, &mut history);
 		if inner.is_null() {
 			return Err(Error::CleanFailed);
 		}
@@ -653,7 +653,7 @@ impl Solid {
 		let ca = CompoundShape::new(a);
 		let cb = CompoundShape::new(b);
 		let mut history: Vec<u64> = Default::default();
-		let inner = ffi::boolean_op(ca.inner(), cb.inner(), op_kind, &mut history);
+		let inner = ffi::builder_boolean(ca.inner(), cb.inner(), op_kind, &mut history);
 		if inner.is_null() { return Err(Error::BooleanOperationFailed); }
 		build_boolean_result(inner, history, ca, cb)
 	}


### PR DESCRIPTION
## Summary

solid → solid な FFI 関数を意味付けで 2 グループに分類:

### `builder_*` (out_history あり / 将来追加予定)
- `boolean_op` → `builder_boolean` (out_history あり)
- `clean_shape` → `builder_clean` (out_history あり)
- `make_thick_solid` → `builder_thick_solid` (TODO: 将来 out_history)
- `make_fillet` → `builder_fillet` (TODO: 将来 out_history)
- `make_chamfer` → `builder_chamfer` (TODO: 将来 out_history)

### `transform_*` (no history)
- `translate_shape` → `transform_translate` (TShape preserve, Moved())
- `rotate_shape` → `transform_rotate` (TShape preserve, Moved())
- `scale_shape` → `transform_scale` (rebuild, no derivation API)
- `mirror_shape` → `transform_mirror` (rebuild, no derivation API)

`wrapper.{h,cpp}` / `ffi.rs` のセクション境界も新分類に揃えた。fillet/chamfer/thick_solid は今回 rename + 配置移動のみで `out_history` 引数は未追加 (OCCT の `Modified()/Generated()` を呼ぶ実装変更が要るため別 PR で対応)。

純リネーム + セクション並び替えのみ、シグネチャ・挙動の変更なし。

## Stacked on

`chore/cpp-cleanup` (#135) の上。merge は #134 → #135 → 本 PR の順で。

## Test plan

- [x] \`cargo build --features color\` / \`--no-default-features\`
- [x] \`cargo test --features color\` 全 pass