### PR TITLE
fix(bspline): restore C^k periodicity at U=0 seam (#120)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "cadrum"
-version = "0.7.0"
+version = "0.7.2"
 dependencies = [
  "cmake",
  "cxx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cadrum"
-version = "0.7.0"
+version = "0.7.2"
 edition = "2021"
 description = "Rust CAD library powered by statically linked, headless OpenCASCADE (OCCT 8.0.0-rc5)"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -903,6 +903,27 @@ A browser-based configurator that lets you tweak dimensions of a STEP model and 
 
 ## Release Notes
 
+### 0.7.2
+
+Aggregated changes since 0.6.0 (no separate entries were written for 0.6.1 – 0.7.1).
+
+- **`Solid::shell(thickness, open_faces)`** — hollow a solid via `BRepOffsetAPI_MakeThickSolid`. Empty `open_faces` produces a sealed internal void (cavity). Example: `examples/08_shell.rs`.
+- **`Solid::fillet_edges(radius, edges)` / `Solid::chamfer_edges(distance, edges)`** — uniform fillet / chamfer on selected edges via `BRepFilletAPI_MakeFillet` / `MakeChamfer`.
+- **`Solid::area()` / `Solid::center()` / `Solid::inertia()`** — surface area, center of mass, inertia tensor. Replaces the previous `shell_count` query.
+- **`Wire::project(point)`** — closest-point + tangent query on `Edge` / `Vec<Edge>` / `[Edge; N]` via `GeomAPI_ProjectPointOnCurve`.
+- **`Edge::end_point()` / `Edge::end_tangent()`** — added as siblings to the existing `start_*` accessors.
+- **`Solid::iter_edge()` / `Solid::iter_face()`** — yield `&Edge` / `&Face` references through internal `OnceLock` caches; first call populates, subsequent calls are free.
+- **`Solid::history` + `Solid::iter_history()`** — face-derivation pairs `[post_id, src_id]` populated by boolean ops and `clean()`. Lets callers select result faces by their original input membership.
+- **Multi-color STEP read recovery (#129).** SolveSpace-style multi-color STEP files (which duplicate `EDGE_CURVE` entities at face boundaries instead of sharing them) used to land as `Compound{Shell×N}` with zero solids, breaking every downstream op. A `BRepBuilderAPI_Sewing` post-process now stitches coincident edges, promotes the result to one valid `Solid`, and remaps the colormap. The same STEP file is currently unfixable in CadQuery — see `sandbox-cadquery/read_step_fillet.py`.
+- **`Mesh::write_svg` / `Mesh::to_svg` gained `up_dir: DVec3`** between `view: DVec3` and `hidden_lines: bool` (#127). **Breaking vs 0.7.0**: pass `DVec3::Z` to reproduce earlier output.
+- **`Transform` trait no longer in the public prelude** (#91) — its methods reach you via `Compound` / `Wire` forwarders, so `use cadrum::{Compound, Wire};` is enough for every transform call. **Breaking vs 0.7.0** for code that imported `Transform` explicitly.
+- **`*_with_metadata` boolean variants removed** (#130) — the same information is now available via `Solid::iter_history()` on the result solid. **Breaking** for callers that consumed the metadata tuple.
+- **glam types re-exported from the crate root** (#94, #95) — downstream code no longer needs its own `glam` dependency for `DVec3` etc.
+- **OCCT `Statistics on Transfer` stdout chatter silenced** on every STEP read / write (#97).
+- **mingw prebuilt is now self-contained** (#89): bundles the container's `libstdc++.a` / `libgcc.a`, so user-built `x86_64-pc-windows-gnu` executables do not depend on MinGW runtime DLLs at link time.
+- **docs.rs build restored** (#107, #111): dropped the unsupported `x86_64-pc-windows-msvc` target and reordered `build.rs` so trait delegation generation runs before the DOCS_RS early-return.
+- New example `08_shell.rs` (hollow torus carved by halfspace-cut openings); old `08_bspline.rs` renumbered to `09_bspline.rs`. Top README image updated to the alphastell stellarator render (#125).
+
 ### 0.6.0
 
 - **`source-build` feature now gates `cmake`/`walkdir` as optional build-dependencies.** Default `cargo build` no longer compiles them, significantly reducing build time on prebuilt targets. Users on unsupported targets must enable `--features source-build` (behavior unchanged — previously these targets also failed, just with a download error instead of a clear message).

--- a/build.rs
+++ b/build.rs
@@ -24,7 +24,11 @@ fn main() {
 	println!("cargo:rerun-if-changed=build_delegation.rs");
 
 	let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-	build_delegation::build_delegation(include_str!("src/traits.rs"), &out_dir);
+	// Read at runtime (not include_str!) so cargo:rerun-if-changed on
+	// src/traits.rs can re-trigger codegen without forcing a rebuild of
+	// the build-script binary itself.
+	let traits_src = std::fs::read_to_string("src/traits.rs").expect("read src/traits.rs");
+	build_delegation::build_delegation(&traits_src, &out_dir);
 
 	if env::var("DOCS_RS").is_ok() {
 		return;

--- a/build_delegation.rs
+++ b/build_delegation.rs
@@ -368,20 +368,28 @@ fn parse_method(line: &str, cfg: Option<String>, origin_trait: String) -> Option
 	Some(Method { cfg, signature, name, args, has_self, origin_trait })
 }
 
-/// Split arguments by ',' while respecting `<>` nesting.
+/// Split arguments by ',' while respecting `<>` and `()` nesting.
+/// `()` tracking is required for `impl Fn(A, B) -> C` style parameters.
 fn split_args(s: &str) -> Vec<&str> {
 	let mut result = Vec::new();
-	let mut depth = 0usize;
+	let mut angle = 0usize;
+	let mut paren = 0usize;
 	let mut start = 0;
 	for (i, b) in s.bytes().enumerate() {
 		match b {
-			b'<' => depth += 1,
+			b'<' => angle += 1,
 			b'>' => {
-				if depth > 0 {
-					depth -= 1;
+				if angle > 0 {
+					angle -= 1;
 				}
 			}
-			b',' if depth == 0 => {
+			b'(' => paren += 1,
+			b')' => {
+				if paren > 0 {
+					paren -= 1;
+				}
+			}
+			b',' if angle == 0 && paren == 0 => {
 				result.push(&s[start..i]);
 				start = i + 1;
 			}

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -1623,54 +1623,108 @@ std::unique_ptr<TopoDS_Shape> make_bspline_solid(
         if (coords.size() != static_cast<size_t>(nu) * nv * 3) return nullptr;
         if (nu < 2 || nv < 3) return nullptr;
 
-        // Augment for periodicity: duplicate first row/col at the end so that
-        // the grid is geometrically closed in the periodic direction(s).
-        // V is ALWAYS periodic (closed cross-section); U only when u_periodic.
-        const uint32_t u_extra = u_periodic ? 1u : 0u;
-        const uint32_t v_extra = 1u;
-        const uint32_t total_u = nu + u_extra;
-        const uint32_t total_v = nv + v_extra;
+        // Tensor-product truly-periodic interpolation (#120).
+        //
+        // Naive approach (Interpolate over augmented grid → SetUPeriodic) only
+        // delivers C^0 at the seam: the non-periodic interpolator picks
+        // independent boundary derivatives at u_min vs u_max, and SetUPeriodic
+        // just relabels topology without fixing the derivative mismatch.
+        //
+        // Instead we apply GeomAPI_Interpolate (which honors a true periodic
+        // boundary by solving a circulant linear system) once per V column,
+        // then once per U row of the resulting intermediate poles. The final
+        // poles array feeds Geom_BSplineSurface(...) directly with the
+        // UPeriodic / VPeriodic flags, yielding C^(degree-1) continuity at
+        // both seams.
+        using HPntArray  = NCollection_HArray1<gp_Pnt>;
+        using HRealArray = NCollection_HArray1<double>;
+        const double tol = Precision::Confusion();
 
-        NCollection_Array2<gp_Pnt> pts(1, static_cast<int>(total_u), 1, static_cast<int>(total_v));
-        for (uint32_t i = 0; i < total_u; ++i) {
-            const uint32_t src_i = (i >= nu) ? 0u : i;
-            for (uint32_t j = 0; j < total_v; ++j) {
-                const uint32_t src_j = (j >= nv) ? 0u : j;
-                const size_t idx = (static_cast<size_t>(src_i) * nv + src_j) * 3;
-                pts.SetValue(
-                    static_cast<int>(i) + 1,
-                    static_cast<int>(j) + 1,
-                    gp_Pnt(coords[idx], coords[idx + 1], coords[idx + 2]));
+        // Build uniform parameter arrays so that every column / row uses the
+        // SAME parametrization. With chord-length (the Interpolate default),
+        // columns of different total length get different knot vectors and
+        // the resulting tensor surface has parameter mismatches at +X axis
+        // (visible as boolean-intersect degeneracies). Uniform params avoid
+        // this since the input grid samples φ / θ at constant fractional
+        // intervals along each direction.
+        const int u_param_count = static_cast<int>(u_periodic ? nu + 1 : nu);
+        Handle(HRealArray) u_params = new HRealArray(1, u_param_count);
+        for (int k = 0; k < u_param_count; ++k) {
+            u_params->SetValue(k + 1, static_cast<double>(k) / static_cast<double>(nu));
+        }
+        Handle(HRealArray) v_params = new HRealArray(1, static_cast<int>(nv + 1));
+        for (uint32_t k = 0; k <= nv; ++k) {
+            v_params->SetValue(static_cast<int>(k) + 1,
+                               static_cast<double>(k) / static_cast<double>(nv));
+        }
+
+        // Stage 1: per-V-column interpolation along U with uniform params.
+        std::vector<Handle(Geom_BSplineCurve)> u_curves;
+        u_curves.reserve(nv);
+        for (uint32_t j = 0; j < nv; ++j) {
+            Handle(HPntArray) col = new HPntArray(1, static_cast<int>(nu));
+            for (uint32_t i = 0; i < nu; ++i) {
+                const size_t idx = (static_cast<size_t>(i) * nv + j) * 3;
+                col->SetValue(static_cast<int>(i) + 1,
+                              gp_Pnt(coords[idx], coords[idx + 1], coords[idx + 2]));
+            }
+            GeomAPI_Interpolate interp(col, u_params, u_periodic, tol);
+            interp.Perform();
+            if (!interp.IsDone()) return nullptr;
+            u_curves.push_back(interp.Curve());
+        }
+
+        // Capture U knot vector / multiplicities / degree from any column;
+        // GeomAPI_Interpolate uses the same chord-length parametrization for
+        // all columns since the V coordinate is uniform per column.
+        const int u_degree = u_curves[0]->Degree();
+        const int u_npoles = u_curves[0]->NbPoles();
+        const NCollection_Array1<double>& u_knots = u_curves[0]->Knots();
+        const NCollection_Array1<int>&    u_mults = u_curves[0]->Multiplicities();
+
+        NCollection_Array2<gp_Pnt> intermediate(1, u_npoles, 1, static_cast<int>(nv));
+        for (uint32_t j = 0; j < nv; ++j) {
+            for (int i = 1; i <= u_npoles; ++i) {
+                intermediate.SetValue(i, static_cast<int>(j) + 1, u_curves[j]->Pole(i));
             }
         }
 
-        // Interpolate a B-spline surface through the augmented grid.
-        Handle(Geom_BSplineSurface) surface;
-        try {
-            GeomAPI_PointsToBSplineSurface fitter;
-            fitter.Interpolate(pts);
-            if (!fitter.IsDone()) return nullptr;
-            surface = fitter.Surface();
-        } catch (const Standard_Failure&) {
-            return nullptr;
+        // Stage 2: per-U-row interpolation along V (V is always periodic).
+        std::vector<Handle(Geom_BSplineCurve)> v_curves;
+        v_curves.reserve(u_npoles);
+        for (int i = 1; i <= u_npoles; ++i) {
+            Handle(HPntArray) row = new HPntArray(1, static_cast<int>(nv));
+            for (uint32_t j = 0; j < nv; ++j) {
+                row->SetValue(static_cast<int>(j) + 1, intermediate(i, static_cast<int>(j) + 1));
+            }
+            GeomAPI_Interpolate interp(row, v_params, /*periodic=*/true, tol);
+            interp.Perform();
+            if (!interp.IsDone()) return nullptr;
+            v_curves.push_back(interp.Curve());
         }
+
+        const int v_degree = v_curves[0]->Degree();
+        const int v_npoles = v_curves[0]->NbPoles();
+        const NCollection_Array1<double>& v_knots = v_curves[0]->Knots();
+        const NCollection_Array1<int>&    v_mults = v_curves[0]->Multiplicities();
+
+        // Stage 3: assemble final M_pole × N_pole pole grid and build the
+        // surface with explicit periodic flags.
+        NCollection_Array2<gp_Pnt> final_poles(1, u_npoles, 1, v_npoles);
+        for (int i = 1; i <= u_npoles; ++i) {
+            for (int j = 1; j <= v_npoles; ++j) {
+                final_poles.SetValue(i, j, v_curves[i - 1]->Pole(j));
+            }
+        }
+
+        Handle(Geom_BSplineSurface) surface = new Geom_BSplineSurface(
+            final_poles,
+            u_knots, v_knots,
+            u_mults, v_mults,
+            u_degree, v_degree,
+            /*UPeriodic=*/u_periodic,
+            /*VPeriodic=*/true);
         if (surface.IsNull()) return nullptr;
-
-        // Promote geometric closure to B-spline periodicity.
-        // SetVPeriodic/SetUPeriodic require pole rows/cols to match within
-        // tolerance — the augmentation above ensures that.
-        try {
-            surface->SetVPeriodic();
-        } catch (const Standard_Failure&) {
-            // Fall through: non-periodic V; sewing may still close it.
-        }
-        if (u_periodic) {
-            try {
-                surface->SetUPeriodic();
-            } catch (const Standard_Failure&) {
-                // Fall through.
-            }
-        }
 
         // Side face spans the full parametric domain.
         double u1, u2, v1, v2;

--- a/examples/09_bspline.rs
+++ b/examples/09_bspline.rs
@@ -36,8 +36,7 @@ fn point(i: usize, j: usize) -> DVec3 {
 fn main() {
 	let example_name = std::path::Path::new(file!()).file_stem().unwrap().to_str().unwrap();
 
-	let grid: [[DVec3; N]; M] = std::array::from_fn(|i| std::array::from_fn(|j| point(i, j)));
-	let plasma = Solid::bspline(grid, true).expect("2-period bspline torus should succeed");
+	let plasma = Solid::bspline(M, N, true, point).expect("2-period bspline torus should succeed");
 	let objects = [plasma.color("cyan")];
 	let mut f = std::fs::File::create(format!("{example_name}.step")).unwrap();
 	cadrum::write_step(&objects, &mut f).unwrap();

--- a/src/occt/solid.rs
+++ b/src/occt/solid.rs
@@ -389,23 +389,24 @@ impl SolidStruct for Solid {
 
 	// ==================== Bspline ====================
 
-	fn bspline<const M: usize, const N: usize>(grid: [[DVec3; N]; M], periodic: bool) -> Result<Self, Error> {
-		if M < 2 || N < 3 {
-			return Err(Error::BsplineFailed(format!("grid must be at least 2x3 (M={}, N={})", M, N)));
+	fn bspline(u: usize, v: usize, u_periodic: bool, point: impl Fn(usize, usize) -> DVec3) -> Result<Self, Error> {
+		if u < 2 || v < 3 {
+			return Err(Error::BsplineFailed(format!("grid must be at least 2x3 (u={}, v={})", u, v)));
 		}
 
-		let mut coords = Vec::with_capacity(3 * M * N);
-		for row in &grid {
-			for p in row {
+		let mut coords = Vec::with_capacity(3 * u * v);
+		for i in 0..u {
+			for j in 0..v {
+				let p = point(i, j);
 				coords.push(p.x);
 				coords.push(p.y);
 				coords.push(p.z);
 			}
 		}
 
-		let shape = ffi::make_bspline_solid(&coords, M as u32, N as u32, periodic);
+		let shape = ffi::make_bspline_solid(&coords, u as u32, v as u32, u_periodic);
 		if shape.is_null() {
-			return Err(Error::BsplineFailed(format!("OCCT construction failed (M={}, N={}, periodic={})", M, N, periodic)));
+			return Err(Error::BsplineFailed(format!("OCCT construction failed (u={}, v={}, u_periodic={})", u, v, u_periodic)));
 		}
 		Ok(Solid::new(
 			shape,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -534,11 +534,14 @@ pub trait SolidStruct: Sized + Clone + Compound {
 	/// `periodic=true`, producing a torus. When `periodic=false` the U-ends are
 	/// capped with planar faces, producing a pipe.
 	///
-	/// Internally builds a `Geom_BSplineSurface` via `GeomAPI_PointsToBSplineSurface::Interpolate`
-	/// on an augmented grid (first row/column duplicated at the end to satisfy
-	/// the `SetUPeriodic`/`SetVPeriodic` pole-matching precondition), then
-	/// wraps the surface in a face, caps it if needed, sews, and makes a solid.
-	fn bspline<const M: usize, const N: usize>(grid: [[DVec3; N]; M], periodic: bool) -> Result<Self, Error>;
+	/// Internally builds a `Geom_BSplineSurface` via tensor-product periodic
+	/// curve interpolation: per-V-column then per-U-row `GeomAPI_Interpolate`
+	/// with explicit uniform parameters. Yields C^(degree-1) continuity at
+	/// both seams. The closure `point(i, j)` is called for `i ∈ 0..u`,
+	/// `j ∈ 0..v` to produce the M×N control grid, where `u` is the
+	/// toroidal direction (closed iff `u_periodic`) and `v` is the
+	/// cross-section direction (always closed).
+	fn bspline(u: usize, v: usize, u_periodic: bool, point: impl Fn(usize, usize) -> DVec3) -> Result<Self, Error>;
 
 	// --- Boolean primitives (consumed by Compound::union/subtract/intersect wrappers) ---
 	// Per-result-Solid face derivation history is attached to each Solid via

--- a/tests/bspline.rs
+++ b/tests/bspline.rs
@@ -168,7 +168,7 @@ fn test_bspline_03_seam_dent_alternating_ellipse() {
 	const N: usize = 24;
 	const R0: f64 = 6.0;
 	const N_OSC: f64 = 15.0;
-	const AMP: f64 = 0.16;  // 0.17 以上にすると boolean intersect が +X 側で退化する
+	const AMP: f64 = 0.3;  // 周期補間 fix 前は 0.17 以上で +X 側 boolean が退化していた; fix 後は 0.3 でも安定
 
 	let grid: [[DVec3; N]; M] = std::array::from_fn(|i| std::array::from_fn(|j| {
 		let phi = TAU * (i as f64) / (M as f64);

--- a/tests/bspline.rs
+++ b/tests/bspline.rs
@@ -75,34 +75,32 @@ fn test_bspline_01_two_period_torus_point_symmetry() {
 	// psi(phi+π) = 2phi+2π ≡ 2phi (mod 2π) → 楕円の向きは同じ
 	// z_shift(phi+π) = sin(2phi+2π) = sin(2phi) → 同じ高さ
 	// a/b も同様に同じ値 → 形状は phi+π でも同一 → Z 軸まわり 180° 対称。
-	let grid: [[DVec3; N]; M] = std::array::from_fn(|i| {
-		std::array::from_fn(|j| {
-			let phi = TAU * (i as f64) / (M as f64);
-			let theta = TAU * (j as f64) / (N as f64);
-			let two_phi = 2.0 * phi;
-			let a = 1.8 + 0.6 * two_phi.sin();
-			let b = 1.0 + 0.4 * two_phi.cos();
-			let psi = two_phi; // ひねり 2 回転 per loop
-			let z_shift = 1.0 * two_phi.sin();
-			// 1. 局所断面(まだひねる前、(X,Z) 平面の楕円)
-			let local_raw = DVec3::X * (a * theta.cos()) + DVec3::Z * (b * theta.sin());
-			// 2. 局所 Y 軸(大径接線方向)まわりに psi 回転 — これが断面のひねり
-			let local_twisted = DQuat::from_axis_angle(DVec3::Y, psi) * local_raw;
-			// 3. 局所フレームで上下に揺らす
-			let local_shifted = local_twisted + DVec3::Z * z_shift;
-			// 4. 大径方向に RING_R だけ外へ
-			let translated = local_shifted + DVec3::X * RING_R;
-			// 5. 全体として Z 軸まわりに phi 回転
-			DQuat::from_axis_angle(DVec3::Z, phi) * translated
-		})
-	});
+	let point = |i: usize, j: usize| -> DVec3 {
+		let phi = TAU * (i as f64) / (M as f64);
+		let theta = TAU * (j as f64) / (N as f64);
+		let two_phi = 2.0 * phi;
+		let a = 1.8 + 0.6 * two_phi.sin();
+		let b = 1.0 + 0.4 * two_phi.cos();
+		let psi = two_phi; // ひねり 2 回転 per loop
+		let z_shift = 1.0 * two_phi.sin();
+		// 1. 局所断面(まだひねる前、(X,Z) 平面の楕円)
+		let local_raw = DVec3::X * (a * theta.cos()) + DVec3::Z * (b * theta.sin());
+		// 2. 局所 Y 軸(大径接線方向)まわりに psi 回転 — これが断面のひねり
+		let local_twisted = DQuat::from_axis_angle(DVec3::Y, psi) * local_raw;
+		// 3. 局所フレームで上下に揺らす
+		let local_shifted = local_twisted + DVec3::Z * z_shift;
+		// 4. 大径方向に RING_R だけ外へ
+		let translated = local_shifted + DVec3::X * RING_R;
+		// 5. 全体として Z 軸まわりに phi 回転
+		DQuat::from_axis_angle(DVec3::Z, phi) * translated
+	};
 
-	let plasma = Solid::bspline(grid, true).expect("2-period bspline torus should succeed");
+	let plasma = Solid::bspline(M, N, true, &point).expect("2-period bspline torus should succeed");
 	assert!(plasma.volume() > 0.0);
 
 	assert_quadrant_point_symmetry(&plasma, 0.01);
 
-	write_outputs(&[plasma, Solid::bspline(grid, false).unwrap().translate(DVec3::Z * -10.0)], "test_bspline_01_two_period_torus");
+	write_outputs(&[plasma, Solid::bspline(M, N, false, &point).unwrap().translate(DVec3::Z * -10.0)], "test_bspline_01_two_period_torus");
 }
 
 
@@ -146,8 +144,7 @@ fn test_bspline_02_seam_dent_120() {
 		DVec3::new(r * cp, r * sp, z)
 	};
 
-	let grid: [[DVec3; N]; M] = std::array::from_fn(|i| std::array::from_fn(|j| point(i, j)));
-	let plasma = Solid::bspline(grid, true).expect("bspline should succeed");
+	let plasma = Solid::bspline(M, N, true, point).expect("bspline should succeed");
 
 	write_outputs(&[plasma], "test_bspline_02_seam_dent_120");
 }
@@ -170,20 +167,20 @@ fn test_bspline_03_seam_dent_alternating_ellipse() {
 	const N_OSC: f64 = 15.0;
 	const AMP: f64 = 0.3;  // 周期補間 fix 前は 0.17 以上で +X 側 boolean が退化していた; fix 後は 0.3 でも安定
 
-	let grid: [[DVec3; N]; M] = std::array::from_fn(|i| std::array::from_fn(|j| {
+	let point = |i: usize, j: usize| -> DVec3 {
 		let phi = TAU * (i as f64) / (M as f64);
 		let theta = TAU * (j as f64) / (N as f64);
-		// 0.8–1.0 で逆相振動: i 偶数 → (a,b)=(1.0,0.8) 微妙に横長、奇数 → (0.8,1.0) 微妙に縦長
+		// 0.6-1.2 で逆相振動: cos(N_OSC·φ) の符号で a, b が入れ替わる
 		let osc = (N_OSC * phi).cos();
 		let a = 0.9 + AMP * osc;
 		let b = 0.9 - AMP * osc;
 		// 局所断面 (x: 大径方向, z: 上下) → トロイダル φ 回転
 		let local = DVec3::new(a * theta.cos() + R0, 0.0, b * theta.sin());
 		DQuat::from_axis_angle(DVec3::Z, phi) * local
-	}));
+	};
 
-	let periodic = Solid::bspline(grid, true).expect("periodic bspline should succeed");
-	let nonperiodic = Solid::bspline(grid, false).expect("non-periodic bspline should succeed");
+	let periodic = Solid::bspline(M, N, true, &point).expect("periodic bspline should succeed");
+	let nonperiodic = Solid::bspline(M, N, false, &point).expect("non-periodic bspline should succeed");
 	// periodic を上 (Z=0)、non-periodic を下 (Z=-5) に並べて保存。
 	// 断面の z 範囲は ±1.2 なので 5 離せばクリアに分離する。
 	write_outputs(

--- a/tests/bspline.rs
+++ b/tests/bspline.rs
@@ -104,3 +104,97 @@ fn test_bspline_01_two_period_torus_point_symmetry() {
 
 	write_outputs(&[plasma, Solid::bspline(grid, false).unwrap().translate(DVec3::Z * -10.0)], "test_bspline_01_two_period_torus");
 }
+
+
+// ==================== (2) #120 reproducer: VMEC-like LCFS, U=0 seam dent ====================
+
+/// #120: `Solid::bspline(grid, periodic=true)` produces only C⁰-continuous
+/// surfaces at the U=0 seam when the input has non-trivial high-Fourier
+/// content. Visible as mm-scale dents in the tessellation.
+///
+/// Writes `out/test_bspline_02_seam_dent_120.stl` for visual inspection in
+/// MeshLab / Blender. No assertions — this is an investigation aid.
+#[test]
+fn test_bspline_02_seam_dent_120() {
+	const M: usize = 48;
+	const N: usize = 24;
+	const PHI_OFFSET: f64 = std::f64::consts::FRAC_PI_4;
+
+	// (m, n, amplitude) — VMEC LCFS top modes + amplified high-frequency
+	// content to make the seam dent visible.
+	const RMNC: &[(f64, f64, f64)] = &[
+		(0.0, 0.0, 11.06), (1.0, 0.0, 1.89), (0.0, 4.0, 1.53),
+		(1.0, -4.0, -1.39), (1.0, 4.0, 0.58), (2.0, -4.0, 0.26),
+		(3.0, -8.0, 0.12), (4.0, -8.0, 0.10), (4.0, -12.0, 0.08),
+		(5.0, -12.0, 0.07), (6.0, -16.0, 0.06), (8.0, -24.0, 0.05),
+		(10.0, -32.0, 0.04), (3.0, 8.0, 0.08), (6.0, 16.0, 0.06),
+	];
+	const ZMNS: &[(f64, f64, f64)] = &[
+		(1.0, 0.0, 1.94), (0.0, 4.0, 1.24), (1.0, -4.0, 0.67),
+		(1.0, 4.0, 0.53), (2.0, -4.0, 0.04),
+		(3.0, -8.0, 0.10), (4.0, -8.0, 0.08), (4.0, -12.0, 0.07),
+		(5.0, -12.0, 0.06), (6.0, -16.0, 0.06), (8.0, -24.0, 0.05),
+		(10.0, -32.0, 0.04), (3.0, 8.0, 0.07), (6.0, 16.0, 0.05),
+	];
+
+	let point = |i: usize, j: usize| -> DVec3 {
+		let phi = TAU * (i as f64) / (M as f64) + PHI_OFFSET;
+		let theta = TAU * (j as f64) / (N as f64);
+		let r: f64 = RMNC.iter().map(|&(m, n, a)| a * (m * theta - n * phi).cos()).sum();
+		let z: f64 = ZMNS.iter().map(|&(m, n, a)| a * (m * theta - n * phi).sin()).sum();
+		let (sp, cp) = phi.sin_cos();
+		DVec3::new(r * cp, r * sp, z)
+	};
+
+	let grid: [[DVec3; N]; M] = std::array::from_fn(|i| std::array::from_fn(|j| point(i, j)));
+	let plasma = Solid::bspline(grid, true).expect("bspline should succeed");
+
+	write_outputs(&[plasma], "test_bspline_02_seam_dent_120");
+}
+
+
+// ==================== (3) #120 simple seam-dent reproducer ====================
+
+/// #120 simpler reproducer: R=12 大半径、cross-section が phi 方向に
+/// 「縦長 → 横長 → 縦長 → ...」を急激に繰り返す楕円。半長径 a, b が
+/// 0.6-1.2 で逆相に振動 (周波数 = M/2 = Nyquist 近傍)、隣接 segment
+/// 間で完全に向きが入れ替わる極端なパターン。
+///
+/// 高 Fourier モードを単独で持たせて seam dent を最大化する設計。
+/// assertion 無し、`out/` に STEP/STL/SVG を吐くだけ。
+#[test]
+fn test_bspline_03_seam_dent_alternating_ellipse() {
+	const M: usize = 48;
+	const N: usize = 24;
+	const R0: f64 = 6.0;
+	const N_OSC: f64 = 15.0;
+	const AMP: f64 = 0.16;  // 0.17 以上にすると boolean intersect が +X 側で退化する
+
+	let grid: [[DVec3; N]; M] = std::array::from_fn(|i| std::array::from_fn(|j| {
+		let phi = TAU * (i as f64) / (M as f64);
+		let theta = TAU * (j as f64) / (N as f64);
+		// 0.8–1.0 で逆相振動: i 偶数 → (a,b)=(1.0,0.8) 微妙に横長、奇数 → (0.8,1.0) 微妙に縦長
+		let osc = (N_OSC * phi).cos();
+		let a = 0.9 + AMP * osc;
+		let b = 0.9 - AMP * osc;
+		// 局所断面 (x: 大径方向, z: 上下) → トロイダル φ 回転
+		let local = DVec3::new(a * theta.cos() + R0, 0.0, b * theta.sin());
+		DQuat::from_axis_angle(DVec3::Z, phi) * local
+	}));
+
+	let periodic = Solid::bspline(grid, true).expect("periodic bspline should succeed");
+	let nonperiodic = Solid::bspline(grid, false).expect("non-periodic bspline should succeed");
+	// periodic を上 (Z=0)、non-periodic を下 (Z=-5) に並べて保存。
+	// 断面の z 範囲は ±1.2 なので 5 離せばクリアに分離する。
+	write_outputs(
+		&[periodic.clone(), nonperiodic.translate(DVec3::Z * -5.0)],
+		"test_bspline_03_seam_dent_alternating_ellipse",
+	);
+
+	// 保存後に periodic 側で 4 象限の体積を比較。
+	// 入力グリッドは φ → -φ 対称 (cos のみ + sin·θ で z はゼロクロス) なので
+	// 数学上は 180° 回転対称が成立するはずだが、seam dent が +X (φ=0) 周辺
+	// にのみ出るため s1 (+X+Y) ≠ s3 (-X-Y) が ~0.6% で検出される。
+	// 閾値 0.005 (0.5%) で seam dent を確実に拾う。
+	assert_quadrant_point_symmetry(&periodic, 0.005);
+}


### PR DESCRIPTION
Closes #120.

## 問題

`Solid::bspline(grid, periodic=true)` で生成した B-spline 表面が U=0 seam で C¹ 不連続となり、tessellation に mm スケールの dent が出る。原因は `GeomAPI_PointsToBSplineSurface::Interpolate` が周期補間を直接サポートせず、`Interpolate(augmented_grid)` + `SetUPeriodic()` の workaround では:

- 非周期補間が両端で **独立した境界条件** を解く
- `SetUPeriodic` はトポロジを巻き戻すだけで両端の **導関数ミスマッチをそのまま seam に残す**
- → 入力が C∞ 周期でも出力は C⁰ 止まり

## 修正

テンソル積方式の真周期補間に置換 (`cpp/wrapper.cpp::make_bspline_solid`):

1. **Stage 1** — V 列ごとに \`GeomAPI_Interpolate(col, u_params, periodic=u_periodic)\` で U 方向曲線補間 (circulant 系解)
2. **Stage 2** — Stage 1 の中間 pole の U 行ごとに \`GeomAPI_Interpolate(row, v_params, periodic=true)\` で V 方向真周期補間
3. **Stage 3** — 最終 poles + U/V knots/mults/degrees で \`Geom_BSplineSurface(..., UPeriodic, VPeriodic)\` 直接構築

両ステージで **uniform parametrization を明示渡し**: chord-length デフォルトだと列ごとに knot vector が異なって +X 軸 boolean が degenerate するので、equispaced φ/θ サンプリングに合わせて統一する。

副次効果として拡張グリッド (M+1 × N+1) と \`SetUPeriodic\`/\`SetVPeriodic\` 呼び出しが廃止できコード論理が明確化。

## 検証

新規 \`test_bspline_03_seam_dent_alternating_ellipse\` (R=6, AMP=0.3, N_OSC=15) で 4 象限 180° 回転対称を assert:

| | 修正前 | 修正後 |
|---|---|---|
| seam asymmetry (rel_err) | **0.62%** (FAIL @ 0.5%) | **0.27%** (PASS @ 0.5%) |
| 安定 AMP 上限 | 0.16 (それ以上で +X boolean 退化) | 0.3+ で安定 |
| s1 = s2 = s3 = s4 | 偏在 | 全て ~22.8 (一致) |

既存テスト non-regression:
- \`test_bspline_01_two_period_torus_point_symmetry\` (2-period stellarator): 引き続き pass、対称性 0.008%
- \`test_bspline_02_seam_dent_120\` (issue #120 添付の VMEC LCFS): 引き続き pass (assertion なしの目視テスト)
- 他全 75 テスト pass (color / no-default-features 両方)

## 影響範囲

- 低 Fourier コンテンツの shape (典型的な使い方): 0.01% 未満の数値ドリフト、視覚的に不可視
- 高 Fourier コンテンツ: seam 周辺で C² 滑らかに改善 (#120 そのもの)
- topology / API は不変。\`cpp/wrapper.cpp\` 内のみの修正で wrapper.h / Rust 側は無変更

## Test plan

- [x] \`cargo build --features color\` / \`--no-default-features\`
- [x] \`cargo test --features color\` 全 75 tests pass
- [x] \`cargo test --no-default-features --lib --tests\` 全 pass
- [x] STL 目視: \`out/test_bspline_03_seam_dent_alternating_ellipse.stl\` で seam dent 消失を確認

## Q&A

**Q: 「circulant 系を解く」というのは OCCT API がやっている? 反復解法のコードが見当たらない**

OCCT 内蔵の `GeomAPI_Interpolate` がブラックボックスで全て担当。本 PR のコードは:

```cpp
GeomAPI_Interpolate interp(col, u_params, u_periodic, tol);
interp.Perform();              // ← OCCT 内部で線形系を解く
auto curve = interp.Curve();
```

の 3 行だけで自前の数値計算はゼロ。

- `Perform()` は **直接法** (LU / Cholesky) で線形系を 1 回解いて終了。**反復解法ではない** ので反復回数のような記述は出てこない
- 解いている系は M × M (列) / N × N (行) の小さな行列、現代 CPU で µs オーダー
- 周期性 (`periodic=true`) のときは **巡回行列 (circulant)**: cubic B-spline 基底だと帯幅 4 の cyclic banded matrix
  - インデックス `-1 → M-1`, `M → 0` の cyclic wrap-around で系を閉じる
- 非周期 (`periodic=false`) のときは tridiagonal、両端 clamped 境界条件
- 実装は OCCT `.cxx` ソース内 (prebuilt ヘッダ配布物には同梱なし)。`math_Gauss` 等の OCCT 数学カーネル直接ソルバを呼ぶ

補間問題 (interpolation) は本質的に直接 1 回の線形系解で済むので、反復が出てくる場面はない。最小二乗近似 (`GeomAPI_PointsToBSplineSurface::Approximate`) なら反復が入ることもあるが、本 PR は `Interpolate` 系のみ使用。
