### PR TITLE
feat(solid): add Solid::project, measure #120 seam residual (#140)

### DIFF
--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -39,9 +39,13 @@
 #include <BRepBuilderAPI_MakeEdge.hxx>
 #include <BRepBuilderAPI_MakeWire.hxx>
 #include <BRepBuilderAPI_MakeSolid.hxx>
+#include <BRepBuilderAPI_MakeVertex.hxx>
 #include <BRepBuilderAPI_Sewing.hxx>
 #include <BRepBuilderAPI_Transform.hxx>
 #include <BRepClass3d_SolidClassifier.hxx>
+#include <BRepExtrema_DistShapeShape.hxx>
+#include <BRepLProp_SLProps.hxx>
+#include <BRepAdaptor_Surface.hxx>
 #include <BRepPrimAPI_MakeBox.hxx>
 #include <BRepPrimAPI_MakeCone.hxx>
 #include <BRepPrimAPI_MakeCylinder.hxx>
@@ -773,6 +777,51 @@ void shape_bounding_box(const TopoDS_Shape& shape,
     Bnd_Box box;
     BRepBndLib::Add(shape, box);
     box.Get(xmin, ymin, zmin, xmax, ymax, zmax);
+}
+
+bool solid_project_point(const TopoDS_Shape& solid,
+    double px, double py, double pz,
+    double& cpx, double& cpy, double& cpz,
+    double& nx, double& ny, double& nz)
+{
+    // Default normal: zero. Used as fallback when the closest hit lands on
+    // an edge / vertex (where the normal is ambiguous between adjacent
+    // faces). The caller can detect this via `normal.length() == 0`.
+    nx = 0.0; ny = 0.0; nz = 0.0;
+
+    try {
+        TopoDS_Vertex vert = BRepBuilderAPI_MakeVertex(gp_Pnt(px, py, pz));
+        BRepExtrema_DistShapeShape ext(vert, solid);
+        if (!ext.IsDone() || ext.NbSolution() < 1) return false;
+
+        gp_Pnt cp = ext.PointOnShape2(1);
+        cpx = cp.X();
+        cpy = cp.Y();
+        cpz = cp.Z();
+
+        // Only IsInFace gives a unique surface (u, v) for normal evaluation.
+        // For IsOnEdge / IsVertex we keep cp but leave normal = 0 vector.
+        if (ext.SupportTypeShape2(1) != BRepExtrema_IsInFace) return true;
+
+        TopoDS_Face face = TopoDS::Face(ext.SupportOnShape2(1));
+        double u, v;
+        ext.ParOnFaceS2(1, u, v);
+
+        BRepAdaptor_Surface surf(face);
+        BRepLProp_SLProps props(surf, u, v, /*derivOrder=*/1, Precision::Confusion());
+        if (!props.IsNormalDefined()) return true;  // cp valid, normal stays 0.
+
+        gp_Dir n = props.Normal();
+        // BRepLProp returns the surface-orientation normal; flip to the
+        // face's outward direction when the face is REVERSED in the shell.
+        if (face.Orientation() == TopAbs_REVERSED) n.Reverse();
+        nx = n.X();
+        ny = n.Y();
+        nz = n.Z();
+        return true;
+    } catch (const Standard_Failure&) {
+        return false;
+    }
 }
 
 // ==================== Meshing ====================

--- a/cpp/wrapper.h
+++ b/cpp/wrapper.h
@@ -219,6 +219,15 @@ void shape_bounding_box(const TopoDS_Shape& shape,
     double& xmin, double& ymin, double& zmin,
     double& xmax, double& ymax, double& zmax);
 
+// Project a 3D point onto the closest face of `solid`. Returns false if the
+// projector fails or the closest hit lands on an edge / vertex (where the
+// surface normal is not defined). On success, `cp*` is the closest point and
+// `n*` is the outward-facing unit normal at that point.
+bool solid_project_point(const TopoDS_Shape& solid,
+    double px, double py, double pz,
+    double& cpx, double& cpy, double& cpz,
+    double& nx, double& ny, double& nz);
+
 // ==================== Compound Decompose/Compose ====================
 
 std::unique_ptr<std::vector<TopoDS_Shape>> decompose_into_solids(const TopoDS_Shape& shape);

--- a/src/occt/ffi.rs
+++ b/src/occt/ffi.rs
@@ -107,6 +107,7 @@ mod ffi_bridge {
 		fn shape_inertia_tensor(shape: &TopoDS_Shape, m00: &mut f64, m01: &mut f64, m02: &mut f64, m10: &mut f64, m11: &mut f64, m12: &mut f64, m20: &mut f64, m21: &mut f64, m22: &mut f64);
 		fn shape_contains_point(shape: &TopoDS_Shape, x: f64, y: f64, z: f64) -> bool;
 		fn shape_bounding_box(shape: &TopoDS_Shape, xmin: &mut f64, ymin: &mut f64, zmin: &mut f64, xmax: &mut f64, ymax: &mut f64, zmax: &mut f64);
+		fn solid_project_point(solid: &TopoDS_Shape, px: f64, py: f64, pz: f64, cpx: &mut f64, cpy: &mut f64, cpz: &mut f64, nx: &mut f64, ny: &mut f64, nz: &mut f64) -> bool;
 
 		// ==================== Compound Decompose/Compose ====================
 

--- a/src/occt/solid.rs
+++ b/src/occt/solid.rs
@@ -240,6 +240,22 @@ impl SolidStruct for Solid {
 		)
 	}
 
+	// ==================== Surface projection ====================
+
+	fn project(&self, p: DVec3) -> (DVec3, DVec3) {
+		let (mut cpx, mut cpy, mut cpz) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut nx, mut ny, mut nz) = (0.0_f64, 0.0_f64, 0.0_f64);
+		// FFI returns false only on truly catastrophic OCCT failure; for a
+		// well-formed solid this is effectively unreachable.
+		// Edge/vertex hits succeed with `normal == (0, 0, 0)` so the caller
+		// can detect ambiguous-normal cases via `normal.length() == 0`.
+		assert!(
+			ffi::solid_project_point(&self.inner, p.x, p.y, p.z, &mut cpx, &mut cpy, &mut cpz, &mut nx, &mut ny, &mut nz),
+			"Solid::project: BRepExtrema failed (this is a bug)"
+		);
+		(DVec3::new(cpx, cpy, cpz), DVec3::new(nx, ny, nz))
+	}
+
 	// ==================== Extrude ====================
 
 	fn extrude<'a>(profile: impl IntoIterator<Item = &'a Edge>, dir: DVec3) -> Result<Self, Error> {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -440,6 +440,17 @@ pub trait SolidStruct: Sized + Clone + Compound {
 	fn torus(r1: f64, r2: f64, axis: DVec3) -> Self;
 	fn half_space(plane_origin: DVec3, plane_normal: DVec3) -> Self;
 
+	// --- Surface projection ---
+	/// Project a 3D point onto the solid's boundary. Returns `(closest_point,
+	/// outward_normal)`. Sister API of `Wire::project` which returns
+	/// `(closest, tangent)` on a 1D edge.
+	///
+	/// When the closest hit lands on an edge or vertex (where the normal is
+	/// ambiguous between adjacent faces) the closest_point is still valid
+	/// but the normal is the zero vector. Callers that need to discriminate
+	/// can check `normal.length() == 0`.
+	fn project(&self, p: DVec3) -> (DVec3, DVec3);
+
 	// --- Topology iteration ---
 	//
 	// `iter_edge` / `iter_face` returning `std::slice::Iter<'_, T>` are exposed as

--- a/tests/bspline.rs
+++ b/tests/bspline.rs
@@ -188,6 +188,33 @@ fn test_bspline_03_seam_dent_alternating_ellipse() {
 		"test_bspline_03_seam_dent_alternating_ellipse",
 	);
 
+	// #140 副タスク: u=0 (= φ=0) における surface normal の Y 成分を測定。
+	// 入力 a(φ), b(φ) は cos の偶関数で a'(0) = b'(0) = 0 → ∂P/∂θ は XZ 平面内、
+	// ∂P/∂φ は Y 軸方向 → 法線 = ∂P/∂θ × ∂P/∂φ ∈ XZ 平面 → N_y ≡ 0 が数学値。
+	// 真の C^1 周期補間が達成できていれば |N_y|/|N| は数値ノイズレベル。残差が
+	// 大きければ補間戦略を再検討する根拠。
+	//
+	// 解析点 (φ=0 の surface 直上) を直接 project すると seam edge ヒットで
+	// 失敗するため、解析的な外向き法線方向に小さくオフセットして project する。
+	// 投影先は元の点に十分近く、法線も近似的に同じ。
+	const N_THETA: usize = 16;
+	const OFFSET: f64 = 0.01;
+	let mut max_y_ratio = 0.0_f64;
+	for j in 0..N_THETA {
+		let theta = TAU * (j as f64) / (N_THETA as f64);
+		// φ=0 における解析的な surface 上の点 (a(0)=1.2, b(0)=0.6)
+		let surface_point = DVec3::new(R0 + 1.2 * theta.cos(), 0.0, 0.6 * theta.sin());
+		// 解析的な外向き法線 (XZ 平面内): N ∝ (-0.6 cosθ, 0, -1.2 sinθ) を
+		// 反転して外向きへ。長さは正規化。
+		let raw_normal = DVec3::new(-0.6 * theta.cos(), 0.0, -1.2 * theta.sin());
+		let outward = -raw_normal.normalize();
+		let target = surface_point + OFFSET * outward;
+		let (_cp, normal) = periodic.project(target);
+		let y_ratio = normal.y.abs() / normal.length();
+		max_y_ratio = max_y_ratio.max(y_ratio);
+	}
+	println!("seam |N_y|/|N| max over {N_THETA} θ samples at u=0: {max_y_ratio:.6}");
+
 	// 保存後に periodic 側で 4 象限の体積を比較。
 	// 入力グリッドは φ → -φ 対称 (cos のみ + sin·θ で z はゼロクロス) なので
 	// 数学上は 180° 回転対称が成立するはずだが、seam dent が +X (φ=0) 周辺


### PR DESCRIPTION
Closes #140.

## 主タスク: \`Solid::project\` 追加

\`Edge::project\` (#126 で導入) の姉妹 API として \`Solid::project\` を追加:

\`\`\`rust
// 既存 (Edge)
Edge::project(point) -> (closest, tangent)
// 追加 (Solid)
Solid::project(point) -> (closest, outward_normal)
\`\`\`

幾何的対称性: 1D 部分多様体には接ベクトル、2D 部分多様体には法線。

### 実装

\`BRepExtrema_DistShapeShape\` で最近点 + 所属 sub-shape → \`BRepLProp_SLProps\` で (u, v) における法線評価。\`face.Orientation()\` が REVERSED の場合は反転して **外向き法線** を保証。

### Edge / Vertex フォールバック

最近点が edge / vertex 上に落ちた場合 (隣接 2 face の法線が不一致 = ambiguous) は、closest_point は valid なまま **normal を zero vector で返す**。caller は \`normal.length() == 0\` で discriminate できる。\`Result\` を毎回開く API 重複を避ける設計。

## 副タスク: #120 seam 残差の経験的検証

\`tests/bspline.rs::test_bspline_03_seam_dent_alternating_ellipse\` に \`|N_y|/|N|\` 計測を追加。

### 数学的期待値

入力 \`a(φ) = 0.9 + 0.3·cos(15·φ)\`, \`b(φ) = 0.9 - 0.3·cos(15·φ)\` は φ の偶関数で a'(0) = b'(0) = 0:
- ∂P/∂θ ∈ XZ 平面 (y 成分 0)
- ∂P/∂φ ∈ Y 軸方向のみ
- 法線 = ∂P/∂θ × ∂P/∂φ ∈ XZ 平面 ⇒ **N_y ≡ 0**

### 実測値

\`\`\`
seam |N_y|/|N| max over 16 θ samples at u=0: 0.621611
\`\`\`

**62%** という大きな残差。PR #139 のテンソル積真周期補間で C² 連続は達成しているはずだが、法線の Y 成分という直接量で見ると seam の幾何的歪みが残っていることが分かる。

### 解釈

体積ベースの 4 象限対称性 (PR #139 で 0.27%) では捉えられなかった局所残差を、\`Solid::project\` の法線 Y 成分という形で定量化できた。これは PR #139 の interpolation 戦略 (uniform parametrization の選択、knot vector の組み立て方等) を再検討する根拠になる。

assertion は付けず println のみ — 現時点の値をベースラインとして、将来の補間改善で値が下がることを期待。

## 影響を受けるファイル

- \`cpp/wrapper.{h,cpp}\` — \`solid_project_point\` FFI 追加 (~40 行)
- \`src/occt/ffi.rs\` — bridge declaration 1 行
- \`src/occt/solid.rs\` — \`Solid::project\` 実装 (~14 行)
- \`src/traits.rs\` — \`SolidStruct::project\` 宣言
- \`tests/bspline.rs\` — \`test_bspline_03\` に seam residual 計測 (~25 行)

## Test plan

- [x] \`cargo build --features color\` / \`--no-default-features\`
- [x] \`cargo test --features color\` 全 pass (\`test_bspline_03\` 含む、新 println 出力で seam |N_y|/|N| = 0.62 観測)
- [x] \`cargo test --no-default-features --lib --tests\` 全 pass