### PR TITLE
feat(face): Edge::id and Face::iter_edge for face-edge incidence

### DIFF
--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -914,6 +914,19 @@ std::unique_ptr<std::vector<TopoDS_Face>> shape_faces(const TopoDS_Shape& shape)
     return out;
 }
 
+std::unique_ptr<std::vector<TopoDS_Edge>> face_edges(const TopoDS_Face& face) {
+    // A face's outer wire and (optional) inner wires can share edges; collapse
+    // them into unique edges with the same IndexedMap trick used in shape_edges.
+    NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> edgeMap;
+    TopExp::MapShapes(face, TopAbs_EDGE, edgeMap);
+    auto out = std::make_unique<std::vector<TopoDS_Edge>>();
+    out->reserve(edgeMap.Extent());
+    for (int i = 1; i <= edgeMap.Extent(); i++) {
+        out->push_back(TopoDS::Edge(edgeMap(i)));
+    }
+    return out;
+}
+
 std::unique_ptr<TopoDS_Shape> clone_shape_handle(const TopoDS_Shape& shape) {
     return std::make_unique<TopoDS_Shape>(shape);
 }
@@ -934,6 +947,10 @@ uint64_t face_tshape_id(const TopoDS_Face& face) {
 
 uint64_t shape_tshape_id(const TopoDS_Shape& shape) {
     return reinterpret_cast<uint64_t>(shape.TShape().get());
+}
+
+uint64_t edge_tshape_id(const TopoDS_Edge& edge) {
+    return reinterpret_cast<uint64_t>(edge.TShape().get());
 }
 
 bool face_project_point(const TopoDS_Face& face,

--- a/cpp/wrapper.h
+++ b/cpp/wrapper.h
@@ -236,6 +236,10 @@ MeshData mesh_shape(const TopoDS_Shape& shape, double tolerance);
 std::unique_ptr<std::vector<TopoDS_Edge>> shape_edges(const TopoDS_Shape& shape);
 std::unique_ptr<std::vector<TopoDS_Face>> shape_faces(const TopoDS_Shape& shape);
 
+// One-shot enumeration of the boundary edges of a single face. Edges shared
+// between this face's wires are deduplicated so each edge appears once.
+std::unique_ptr<std::vector<TopoDS_Edge>> face_edges(const TopoDS_Face& face);
+
 // Shallow handle clone — C++ copy-ctor shares the underlying TShape via
 // OCCT's ref count. Needed when Rust materializes owned `Shape` / `Edge` /
 // `Face` wrappers from the `&TopoDS_*` references yielded by
@@ -396,9 +400,10 @@ std::unique_ptr<TopoDS_Shape> make_bspline_solid(
 // ==================== Face Methods ====================
 
 // Both helpers return the underlying TopoDS_TShape* address as a u64 — used
-// to track face/solid identity across boolean ops, color maps, and BREP I/O.
+// to track face/solid/edge identity across boolean ops, color maps, and BREP I/O.
 uint64_t face_tshape_id(const TopoDS_Face& face);
 uint64_t shape_tshape_id(const TopoDS_Shape& shape);
+uint64_t edge_tshape_id(const TopoDS_Edge& edge);
 
 // Project a 3D point onto `face`. Sister of `edge_project_point`.
 // Returns the closest point on the (trimmed) face surface and the outward

--- a/src/occt/edge.rs
+++ b/src/occt/edge.rs
@@ -36,6 +36,10 @@ impl Clone for Edge {
 }
 
 impl EdgeStruct for Edge {
+	fn id(&self) -> u64 {
+		ffi::edge_tshape_id(&self.inner)
+	}
+
 	fn helix(radius: f64, pitch: f64, height: f64, axis: DVec3, x_ref: DVec3) -> Result<Self, Error> {
 		let inner = ffi::make_helix_edge(axis.x, axis.y, axis.z, x_ref.x, x_ref.y, x_ref.z, radius, pitch, height);
 		Edge::try_from_ffi(inner, format!("helix: degenerate params (radius={radius}, pitch={pitch}, height={height}, axis={axis:?}, x_ref={x_ref:?})"))

--- a/src/occt/face.rs
+++ b/src/occt/face.rs
@@ -1,20 +1,30 @@
+use super::edge::Edge;
 use super::ffi;
 use crate::traits::FaceStruct;
 use glam::DVec3;
+use std::sync::OnceLock;
 
 /// A face topology shape.
+///
+/// `edges` is a lazy `OnceLock` cache populated on first `iter_edge` call,
+/// matching the pattern used by `Solid`. Faces yielded from `Solid::iter_face`
+/// are constructed fresh each time the parent solid's face cache is built, so
+/// the OnceLock matches the lifetime of the enclosing `Vec<Face>`.
 pub struct Face {
 	pub(crate) inner: cxx::UniquePtr<ffi::TopoDS_Face>,
+	edges: OnceLock<Vec<Edge>>,
 }
 
 impl Face {
 	/// Create a Face wrapping a `TopoDS_Face`.
 	pub(crate) fn new(inner: cxx::UniquePtr<ffi::TopoDS_Face>) -> Self {
-		Face { inner }
+		Face { inner, edges: OnceLock::new() }
 	}
 }
 
 impl FaceStruct for Face {
+	type Edge = Edge;
+
 	fn id(&self) -> u64 {
 		ffi::face_tshape_id(&self.inner)
 	}
@@ -29,5 +39,19 @@ impl FaceStruct for Face {
 			"Face::project: BRepExtrema_ExtPF failed (this is a bug)"
 		);
 		(DVec3::new(cpx, cpy, cpz), DVec3::new(nx, ny, nz))
+	}
+
+	fn iter_edge(&self) -> impl Iterator<Item = &Edge> + '_ {
+		self.edges
+			.get_or_init(|| {
+				ffi::face_edges(&self.inner)
+					.iter()
+					.map(|e_ref| {
+						let owned = ffi::clone_edge_handle(e_ref);
+						Edge::try_from_ffi(owned, "face_edges: null".into()).expect("face_edges: unexpected null (this is a bug)")
+					})
+					.collect()
+			})
+			.iter()
 	}
 }

--- a/src/occt/ffi.rs
+++ b/src/occt/ffi.rs
@@ -121,6 +121,7 @@ mod ffi_bridge {
 
 		fn shape_edges(shape: &TopoDS_Shape) -> UniquePtr<CxxVector<TopoDS_Edge>>;
 		fn shape_faces(shape: &TopoDS_Shape) -> UniquePtr<CxxVector<TopoDS_Face>>;
+		fn face_edges(face: &TopoDS_Face) -> UniquePtr<CxxVector<TopoDS_Edge>>;
 
 		fn clone_shape_handle(shape: &TopoDS_Shape) -> UniquePtr<TopoDS_Shape>;
 		fn clone_edge_handle(edge: &TopoDS_Edge) -> UniquePtr<TopoDS_Edge>;
@@ -130,6 +131,7 @@ mod ffi_bridge {
 
 		fn face_tshape_id(face: &TopoDS_Face) -> u64;
 		fn shape_tshape_id(shape: &TopoDS_Shape) -> u64;
+		fn edge_tshape_id(edge: &TopoDS_Edge) -> u64;
 
 		fn face_project_point(face: &TopoDS_Face, px: f64, py: f64, pz: f64, cpx: &mut f64, cpy: &mut f64, cpz: &mut f64, nx: &mut f64, ny: &mut f64, nz: &mut f64) -> bool;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -7,7 +7,7 @@
 //!             └─  Wire    ──  EdgeStruct   (pub(crate))
 //! ```
 //!
-//! `Face` 型は `FaceStruct` トレイトに `id` / `project` を持つ。
+//! `Face` 型は `FaceStruct` トレイトに `id` / `project` / `iter_edge` を持つ。
 //! `SolidStruct::type Face: FaceStruct` で結合される。
 //!
 //! `Edge` / `Vec<Edge>` の対称関係は `Solid` / `Vec<Solid>` と同じ:
@@ -44,7 +44,8 @@
 //!
 //! ```text
 //!   EdgeStruct       ← 単独。下位を一切知らない
-//!   SolidStruct      ← type Edge: EdgeStruct;  type Face;  (Face は bound 無し)
+//!   FaceStruct       ← type Edge: EdgeStruct;
+//!   SolidStruct      ← type Edge: EdgeStruct;  type Face: FaceStruct;
 //!   IoModule         ← type Solid: SolidStruct;
 //! ```
 //!
@@ -345,6 +346,12 @@ pub trait Wire: Transform {
 /// `Error::InvalidEdge(String)` with a message that identifies the failing
 /// constructor and the offending parameters.
 pub trait EdgeStruct: Sized + Clone + Wire {
+	/// Stable, backend-defined identity for this edge. Two `Edge` values
+	/// returning the same `id()` refer to the same topology element.
+	/// Use to compare edges across `Solid::iter_edge()` / `Face::iter_edge()`
+	/// (e.g. `face.iter_edge().any(|e| e.id() == edge.id())`).
+	fn id(&self) -> u64;
+
 	/// Construct a single helical edge on a cylindrical surface centered at
 	/// the world origin.
 	///
@@ -424,6 +431,8 @@ pub trait EdgeStruct: Sized + Clone + Wire {
 /// build_delegation.rs generates `impl Face { pub fn ... }` from this trait
 /// so callers reach the methods inherently as `face.id()` / `face.project(p)`.
 pub trait FaceStruct: Sized {
+	type Edge: EdgeStruct;
+
 	/// Stable, backend-defined identity for this face. Two `Face` values
 	/// returning the same `id()` refer to the same topology element. Used
 	/// to look up entries in `Solid::colormap` or to match faces against
@@ -446,6 +455,14 @@ pub trait FaceStruct: Sized {
 	/// cannot define a normal at the closest hit (degenerate surface
 	/// point); callers can detect this case via `normal.length() == 0`.
 	fn project(&self, p: DVec3) -> (DVec3, DVec3);
+
+	/// Iterate this face's boundary edges (outer wire and any inner wires).
+	/// Each edge appears once even when shared between wires. Backends may
+	/// cache the result internally; re-calls are expected to be cheap.
+	///
+	/// Use with `Edge::id()` to test face/edge incidence:
+	/// `face.iter_edge().any(|e| e.id() == edge.id())`.
+	fn iter_edge(&self) -> impl Iterator<Item = &Self::Edge> + '_;
 }
 
 /// Backend-independent solid trait (pub(crate) — not exposed to users).

--- a/tests/shape.rs
+++ b/tests/shape.rs
@@ -118,6 +118,24 @@ fn test_preserves_face_ids() {
 	assert_eq!(ids, face_ids([&rotated]), "rotate should preserve face IDs");
 }
 
+// ==================== face-edge incidence (Edge::id + Face::iter_edge) ====================
+
+#[test]
+fn test_face_edge_incidence_via_id() {
+	// 立方体は 12 unique edge を持ち、各 face に 4 edge ずつ。
+	// 各 edge は 2 face で共有されるので Σ face.iter_edge() = 24 = 12*2。
+	let cube = test_box();
+	let total_face_edges: usize = cube.iter_face().map(|f| f.iter_edge().count()).sum();
+	assert_eq!(cube.iter_edge().count(), 12, "cube has 12 unique edges");
+	assert_eq!(total_face_edges, 24, "each edge is shared between 2 faces");
+
+	// ある edge が「どの face に属しているか」を id 比較で正しく判定できる。
+	for edge in cube.iter_edge() {
+		let owners = cube.iter_face().filter(|f| f.iter_edge().any(|e| e.id() == edge.id())).count();
+		assert_eq!(owners, 2, "every cube edge is shared by exactly 2 faces");
+	}
+}
+
 // ==================== iter_history (B fully inside A) ====================
 
 #[test]


### PR DESCRIPTION
## Summary
- `EdgeStruct::id(&self) -> u64` を追加（`SolidStruct::id` / `FaceStruct::id` と対称）
- `FaceStruct` に `type Edge: EdgeStruct;` と `iter_edge(&self) -> impl Iterator<Item = &Self::Edge> + '_` を追加（`SolidStruct::iter_edge` / `iter_face` と対称）
- これで「ある face がある edge を持っているか」をワンライナーで判定できる:
  ```rust
  face.iter_edge().any(|e| e.id() == edge.id())
  ```

## Implementation notes
- C++ 側に `edge_tshape_id` と `face_edges` を追加（`face_edges` は `shape_edges` と同じ `IndexedMap` パターンで wire 共有 edge を dedup）
- `Face` 構造体に `edges: OnceLock<Vec<Edge>>` キャッシュを追加（`Solid` と同パターン）
- 専用の `Face::contains_edge(&Edge) -> bool` は意図的に追加していない: id 比較を内部に隠すより `iter_edge` + `id` の合成で書く方が、history 追跡や複数 face/edge 質問への一般化に素直なため

## Test plan
- [x] `cargo build --features color`
- [x] `cargo test --tests`（全 16 suite パス）
- [x] 新規テスト `test_face_edge_incidence_via_id`: 立方体で「12 unique edges、各 face = 4 edges、各 edge は 2 face で共有」を id 比較で検証