### PR TITLE
feat(occt): bump to OCCT 8.0.0-beta1

### DIFF
--- a/.github/workflows/prebuilt.yaml
+++ b/.github/workflows/prebuilt.yaml
@@ -7,13 +7,6 @@ on:
 
 jobs:
   # Docker 経由 (cross toolchain が Linux 側で成熟している)。
-  #
-  # windows-gnullvm は Dockerfile ファイル名をあえて `Dockerfile_x86_64-pc-windows-gnu`
-  # のまま維持している (llvm-mingw 移行前の名前と互換を保つため)。そのため make target
-  # 名と成果物 target 名が分離している: `make_target` が makefile のパターンルール
-  # `cadrum-occt-%` に渡される文字列 (= Dockerfile 末尾の拡張子)、`target` が最終的に
-  # 配布される triple 名 (= tarball ファイル名の中身、CARGO_BUILD_TARGET と一致)。
-  # Linux 2 target は両者が一致するので make_target は省略可能。
   build:
     strategy:
       fail-fast: false
@@ -24,19 +17,18 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             runs-on: ubuntu-24.04-arm
           - target: x86_64-pc-windows-gnu
-            make_target: x86_64-pc-windows-gnu
             runs-on: ubuntu-latest
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4
 
       - name: build
-        run: make cadrum-occt-${{ matrix.make_target || matrix.target }}
+        run: make cadrum-occt-${{ matrix.target }}
 
       - uses: actions/upload-artifact@v4
         with:
           name: cadrum-occt-${{ matrix.target }}
-          path: out/${{ matrix.make_target || matrix.target }}/cadrum-occt-*.tar.gz
+          path: out/${{ matrix.target }}/cadrum-occt-*.tar.gz
 
   # native Windows runner + native cl.exe で作る。
   # cargo-xwin/clang-cl 経由の prebuild は MSVC STL template の COMDAT 排出判断が
@@ -88,6 +80,6 @@ jobs:
 
       - uses: softprops/action-gh-release@v2
         with:
-          tag_name: occt-v800rc5
-          name: OCCT prebuilt v800rc5
+          tag_name: cadrum-occt-v800beta1
+          name: OCCT prebuilt v8.0.0-beta1
           files: dist/*.tar.gz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 name = "cadrum"
 version = "0.7.4"
 dependencies = [
+ "cc",
  "cmake",
  "cxx",
  "cxx-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cadrum"
 version = "0.7.4"
 edition = "2021"
-description = "Rust CAD library powered by statically linked, headless OpenCASCADE (OCCT 8.0.0-rc5)"
+description = "Rust CAD library powered by statically linked, headless OpenCASCADE (OCCT 8.0.0-beta1)"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/lzpel/cadrum"
@@ -35,6 +35,8 @@ tar = "0.4"
 walkdir = "2"
 # source-build only: build OCCT from upstream sources
 cmake = { version = "0.1", optional = true }
+# source-build + CADRUM_BUNDLE_GCC_RUNTIME: query the target compiler for libstdc++.a path
+cc = "1"
 
 [dev-dependencies]
 # Used by examples/codegen.rs to parse traits.rs and rewrite marker regions.

--- a/build.rs
+++ b/build.rs
@@ -1,18 +1,19 @@
 use std::env;
 use std::path::{Path, PathBuf};
 
-/// OCCT release used by cadrum. Update this tag when bumping OCCT versions;
-/// `slug()` derives the lowercase/underscore-stripped form used in filenames.
+/// OCCT release used by cadrum. Update this tag when bumping OCCT versions.
+/// `cadrum_occt_name()` derives both the GitHub Release tag (no target) and
+/// the prebuilt tarball / cache directory name (with target) from this.
 const OCCT_VERSION: &str = "V8_0_0_rc5";
 
-/// GitHub Release tag under `lzpel/cadrum` that hosts the prebuilt tarballs.
-/// Bump this when rebuilding prebuilts for the same OCCT version.
-#[cfg(not(feature = "source-build"))]
-const OCCT_PREBUILT_TAG: &str = "occt-v800rc5";
-
-/// `V8_0_0_rc5` → `v800rc5`. Shared rule: lowercase and drop underscores.
-fn slug(version: &str) -> String {
-	version.to_ascii_lowercase().replace('_', "")
+/// `target` 指定あり: `cadrum-occt-v800rc5-x86_64-pc-windows-gnu` (tarball / cache dir 名)
+/// `target` 指定なし: `cadrum-occt-v800rc5` (`lzpel/cadrum` の GitHub Release タグ)
+fn cadrum_occt_name(target: Option<&str>) -> String {
+	let slug = OCCT_VERSION.to_ascii_lowercase().replace('_', "");
+	match target {
+		Some(t) => format!("cadrum-occt-{}-{}", slug, t),
+		None => format!("cadrum-occt-{}", slug),
+	}
 }
 
 fn main() {
@@ -23,18 +24,15 @@ fn main() {
 		return;
 	}
 
-	let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-
 	let target = env::var("TARGET").unwrap();
 
-	let target_dir = target_dir_from_out_dir(&out_dir, &target);
-	let default_root = target_dir.join(format!("cadrum-occt-{}-{}", slug(OCCT_VERSION), &target));
+	// Get occt_root directory whether the binary exist or not. If not, download or compile it.
 	let effective_root = env::var("OCCT_ROOT")
 		.map(|r| {
 			let p = PathBuf::from(r);
 			if p.is_relative() { env::current_dir().unwrap().join(p) } else { p }
 		})
-		.unwrap_or(default_root);
+		.unwrap_or(cargo_target_dir(&target).join(cadrum_occt_name(Some(&target))));
 
 	let [occt_include, occt_lib_dir] = resolve_occt(&effective_root, &target);
 
@@ -46,7 +44,8 @@ fn main() {
 /// `OUT_DIR` layout:
 ///   `<target_dir>/<profile>/build/<pkg>-<hash>/out`            (no `--target`)
 ///   `<target_dir>/<triple>/<profile>/build/<pkg>-<hash>/out`   (with `--target`)
-fn target_dir_from_out_dir(out_dir: &Path, target: &str) -> PathBuf {
+fn cargo_target_dir(target: &str) -> PathBuf {
+	let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 	let above_profile = out_dir.ancestors().nth(4).expect("unexpected OUT_DIR layout");
 	if above_profile.file_name().map_or(false, |n| n == target) {
 		above_profile.parent().unwrap().to_path_buf()
@@ -139,7 +138,7 @@ fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path) {
 	let mut build = cxx_build::bridge("src/occt/ffi.rs");
 	build.file("cpp/wrapper.cpp").include(occt_include).std("c++17").define("_USE_MATH_DEFINES", None);
 
-	if std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc") {
+	if target_env == "msvc" {
 		build.flag("/utf-8");
 	}
 
@@ -156,10 +155,9 @@ fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path) {
 /// Download a prebuilt OCCT tarball for `target` into `dest`.
 #[cfg(not(feature = "source-build"))]
 fn download_prebuilt(dest: &Path, target: &str) -> Option<[PathBuf; 2]> {
-	let slug_ver = slug(OCCT_VERSION);
-	let top_name = format!("cadrum-occt-{}-{}", slug_ver, target);
+	let top_name = cadrum_occt_name(Some(target));
 	let tarball_name = format!("{}.tar.gz", top_name);
-	let url = env::var("CADRUM_PREBUILT_URL").unwrap_or_else(|_| format!("https://github.com/lzpel/cadrum/releases/download/{}/{}", OCCT_PREBUILT_TAG, tarball_name));
+	let url = env::var("CADRUM_PREBUILT_URL").unwrap_or_else(|_| format!("https://github.com/lzpel/cadrum/releases/download/{}/{}", cadrum_occt_name(None), tarball_name));
 
 	eprintln!("cargo:warning=Downloading prebuilt OCCT from {}", url);
 

--- a/build.rs
+++ b/build.rs
@@ -4,10 +4,10 @@ use std::path::{Path, PathBuf};
 /// OCCT release used by cadrum. Update this tag when bumping OCCT versions.
 /// `cadrum_occt_name()` derives both the GitHub Release tag (no target) and
 /// the prebuilt tarball / cache directory name (with target) from this.
-const OCCT_VERSION: &str = "V8_0_0_rc5";
+const OCCT_VERSION: &str = "V8_0_0_beta1";
 
-/// `target` 指定あり: `cadrum-occt-v800rc5-x86_64-pc-windows-gnu` (tarball / cache dir 名)
-/// `target` 指定なし: `cadrum-occt-v800rc5` (`lzpel/cadrum` の GitHub Release タグ)
+/// `target` 指定あり: `cadrum-occt-v800beta1-x86_64-pc-windows-gnu` (tarball / cache dir 名)
+/// `target` 指定なし: `cadrum-occt-v800beta1` (`lzpel/cadrum` の GitHub Release タグ)
 fn cadrum_occt_name(target: Option<&str>) -> String {
 	let slug = OCCT_VERSION.to_ascii_lowercase().replace('_', "");
 	match target {

--- a/build.rs
+++ b/build.rs
@@ -19,6 +19,7 @@ fn cadrum_occt_name(target: Option<&str>) -> String {
 fn main() {
 	println!("cargo:rerun-if-env-changed=OCCT_ROOT");
 	println!("cargo:rerun-if-env-changed=CADRUM_PREBUILT_URL");
+	println!("cargo:rerun-if-env-changed=CADRUM_BUNDLE_GCC_RUNTIME");
 
 	if env::var("DOCS_RS").is_ok() {
 		return;
@@ -60,7 +61,6 @@ fn cargo_target_dir(target: &str) -> PathBuf {
 ///   2. Cache miss + `source-build` → build from upstream sources
 ///   3. Cache miss otherwise → download prebuilt tarball
 fn resolve_occt(effective_root: &Path, target: &str) -> [PathBuf; 2] {
-	let _ = target; // used only in #[cfg(not(feature = "source-build"))]
 	println!("cargo:rerun-if-changed={}", effective_root.display());
 
 	match find_occt_dirs(effective_root) {
@@ -69,8 +69,17 @@ fn resolve_occt(effective_root: &Path, target: &str) -> [PathBuf; 2] {
 			#[cfg(feature = "source-build")]
 			{
 				eprintln!("cargo:warning=OCCT cache miss at {} — building from source (this may take 10-30 minutes)", effective_root.display());
-				return source::build_from_source(effective_root)
+				let dirs = source::build_from_source(effective_root)
 					.expect("Failed to build OCCT from source");
+				// Prebuilt tarball 作成時のみ host GCC runtime を OCCT lib dir に同梱 (#89 / #147 対策)。
+				// gate を切らないと source-build user 全員のホスト libstdc++ が静的取り込みされてしまう。
+				// mingw と Linux GNU で必要 (Windows MSVC は MSVC ランタイム、Mac は別系統)
+				if env::var("CADRUM_BUNDLE_GCC_RUNTIME").is_ok()
+					&& (target.ends_with("windows-gnu") || target.contains("linux-gnu"))
+				{
+					bundle_runtime_libs(&dirs[1], &["libstdc++.a", "libgcc.a", "libgcc_eh.a"]);
+				}
+				return dirs;
 			}
 			#[cfg(not(feature = "source-build"))]
 			{
@@ -204,6 +213,29 @@ fn fetch_bytes(url: &str) -> Result<Vec<u8>, String> {
 	} else {
 		let resp = minreq::get(url).send().map_err(|e| e.to_string())?;
 		Ok(resp.into_bytes())
+	}
+}
+
+/// Bundle GCC runtime archives (libstdc++.a / libgcc.a / libgcc_eh.a) into
+/// the OCCT lib dir as `libcadrum_*.a`. Triggered by `CADRUM_BUNDLE_GCC_RUNTIME`
+/// only — used by the prebuilt-tarball makefile recipe so end users running
+/// source-build don't get their host libstdc++ silently bundled.
+#[cfg(feature = "source-build")]
+fn bundle_runtime_libs(occt_lib_dir: &Path, libs: &[&str]) {
+	let compiler = cc::Build::new().get_compiler();
+	for &lib in libs {
+		let out = std::process::Command::new(compiler.path())
+			.arg(format!("-print-file-name={}", lib))
+			.output()
+			.expect("compiler probe failed");
+		let src = PathBuf::from(std::str::from_utf8(&out.stdout).unwrap().trim());
+		// `-print-file-name=` は名前が見つからない時に lib 名そのものを返すので存在チェック必須
+		if src.is_absolute() && src.exists() {
+			let dst_name = lib.replace("lib", "libcadrum_");
+			std::fs::copy(&src, occt_lib_dir.join(&dst_name)).unwrap();
+		} else {
+			eprintln!("cargo:warning=runtime lib not found: {}", lib);
+		}
 	}
 }
 

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -561,7 +561,7 @@ static void emit_from_pairs(
     TopExp::MapShapes(pre_shape, TopAbs_FACE, pre_map);
     TopExp::MapShapes(post_shape, TopAbs_FACE, post_map);
     // pre_map and post_map have the same size because the copy preserves topology.
-    for (int i = 1; i <= pre_map.Size(); ++i) {
+    for (int i = 1; i <= pre_map.Extent(); ++i) {
         uint64_t pre_id = reinterpret_cast<uint64_t>(pre_map(i).TShape().get());
         auto it = relay.find(pre_id);
         if (it == relay.end()) continue;

--- a/makefile
+++ b/makefile
@@ -11,32 +11,10 @@ deploy: generate # generate out/markdown from examples, then build out/html
 	./out/bin/mdbook build
 publish: deploy # publish to crates.io
 	cargo publish
-ifeq ($(CARGO_BUILD_TARGET),x86_64-pc-windows-gnu)
-# mingw gcc のインストール先から lib<name>.a の絶対 path を引く関数。
-# 使用例: $(call mingw_lib,libstdc++.a) → /usr/.../libstdc++.a
-# -print-file-name= はドライバの library search path から名前解決するだけで、C/C++ 区別はしないので
-# gcc 一本で stdc++/gcc/gcc_eh いずれも取れる (g++ でも同じ結果)。コンパイラは parse 時点で
-# 存在するので make 関数で OK (対 `$(shell find ...)` は parse 時評価なので cargo build 前に
-# 走り空を返す — OCCT lib dir の探索は shell substitution 側で行う、下の recipe を参照)。
-mingw_lib = $(shell x86_64-w64-mingw32-gcc -print-file-name=$(1))
-endif
-
 cadrum-occt: generate # build occt from source natively
 	cargo clean
-	cargo build --example 01_primitives --release --features source-build 2>&1 | tee out/log.txt # colorはdefaultの一部なのでfeature指定不要
-ifeq ($(CARGO_BUILD_TARGET),x86_64-pc-windows-gnu)
-	@# mingw コンテナで作った OCCT の lib dir にコンテナ側 gcc の runtime (libstdc++/libgcc/libgcc_eh) を
-	@# libcadrum_* リネームでコピーする。build.rs の scanner が libcadrum_* を自動で -l として拾い、
-	@# ホスト側 mingw との GCC バージョン差による ABI 不整合を回避する (#89 対策)。
-	@# libTKernel.a の位置から dirname で lib dir を得る。shell substitution `$$(...)` を使うのは
-	@# recipe 実行時に評価する必要があるため — make の `$(shell ...)` は recipe 開始時点で
-	@# 一括展開されるので cargo build 前に走って空を返してしまう。
-	@LIBDIR=$$(find target -maxdepth 6 -type f -name libTKernel.a -path '*cadrum-occt*' | head -n 1 | xargs -r dirname); \
-	[ -n "$$LIBDIR" ] || { echo "bundle: OCCT lib dir not found under target/" >&2; exit 1; }; \
-	cp -v "$(call mingw_lib,libstdc++.a)" "$$LIBDIR/libcadrum_stdc++.a"; \
-	cp -v "$(call mingw_lib,libgcc.a)"    "$$LIBDIR/libcadrum_gcc.a"; \
-	cp -v "$(call mingw_lib,libgcc_eh.a)" "$$LIBDIR/libcadrum_gcc_eh.a"
-endif
+	# CADRUM_BUNDLE_GCC_RUNTIME=1 で OCCT lib dir に libstdc++.a / libgcc.a / libgcc_eh.a を libcadrum_* として同梱し、ホスト側 GCC との ABI 不整合を回避する (#89 / #147 対策)。
+	CADRUM_BUNDLE_GCC_RUNTIME=1 cargo build --example 01_primitives --release --features source-build 2>&1 | tee out/log.txt
 	find target -maxdepth 1 -type d -name 'cadrum*' | xargs -IX sh -c 'tar -czf out/$$(basename X).tar.gz -C $$(dirname X) $$(basename X)'
 cadrum-occt-%: # build occt from source in cross ( = native build in container ) cadrum-occt-aarch64-unknown-linux-gnu cadrum-occt-x86_64-pc-windows-gnu cadrum-occt-x86_64-unknown-linux-gnu
 	docker build -f docker/Dockerfile_$(*) -t cadrum-occt-$(*) .

--- a/makefile
+++ b/makefile
@@ -20,5 +20,6 @@ cadrum-occt-%: # build occt from source in cross ( = native build in container )
 	docker build -f docker/Dockerfile_$(*) -t cadrum-occt-$(*) .
 	docker run --rm -v $(PWD)/out/$(*):/src/out cadrum-occt-$(*) make cadrum-occt
 check-cadrum-occt-%: cadrum-occt-% # varidate builded occt to run binary which is linked with host's code and container's static occt libraries
+	mkdir -p target
 	find out -maxdepth 2 -type f -name '*.tar.gz' | xargs -IX tar -xzf X -C target
 	timeout 300 cargo run --example 01_primitives


### PR DESCRIPTION
## Summary

- Bump OCCT to 8.0.0-beta1 ahead of the May 7 final release.
- Consolidate prebuilt naming via `cadrum_occt_name(Option<&str>)` — single source of truth for both the GitHub Release tag (`cadrum-occt-v800beta1`) and the per-target tarball / cache directory.
- Move GCC runtime archive bundling (libstdc++.a / libgcc.a / libgcc_eh.a → libcadrum_*.a) from makefile shell to `build.rs::bundle_runtime_libs`, gated by `CADRUM_BUNDLE_GCC_RUNTIME` so source-build users don't get their host libstdc++ silently statically linked. Extends mingw's #89 workaround coverage to *-linux-gnu (mitigates #147).
- Workflow updates: align release tag with the new naming, drop legacy gnullvm matrix indirection.

## Notable code changes

- `cpp/wrapper.cpp:564`: `pre_map.Size()` → `pre_map.Extent()` to dodge the signed/unsigned warning introduced by `NCollection_IndexedMap::Size()` returning `size_t` in OCCT 8.0.
- `build.rs`: drop `slug()` + `OCCT_PREBUILT_TAG`; rename `target_dir_from_out_dir` → `cargo_target_dir` and internalize the OUT_DIR read; dedup duplicate `CARGO_CFG_TARGET_ENV` reads.
- `makefile`: replace the per-target `mingw_lib` / `cp -v` block with a single `CADRUM_BUNDLE_GCC_RUNTIME=1 cargo build` prefix; add `mkdir -p target` to `check-cadrum-occt-%` so the recipe doesn't fail on a fresh clone.

## Validation

- `cargo test --features source-build` on `x86_64-pc-windows-gnu`: 78 passed / 0 failed / 0 warnings.
- `make check-cadrum-occt-x86_64-pc-windows-gnu`: docker source-build succeeded, tarball generated at `out/x86_64-pc-windows-gnu/cadrum-occt-v800beta1-x86_64-pc-windows-gnu.tar.gz` (62 MB, includes `libcadrum_*.a` from CADRUM_BUNDLE_GCC_RUNTIME).

## Release prerequisites

The Release `cadrum-occt-v800beta1` does not exist yet — the prebuilt fetch path will 404 until the `prebuilt` branch is updated and CI publishes the tarballs. The MSVC tarball is built natively by `.github/workflows/prebuilt.yaml`'s `build-windows-msvc` job; gnullvm is intentionally dropped (the previous "support" was a relabeled gnu artifact).

## Test plan

- [ ] CI workflow on push to `prebuilt` branch produces 4 tarballs (linux x86_64 / linux aarch64 / windows-gnu / windows-msvc).
- [ ] Each tarball includes `libcadrum_*.a` for gnu targets, none for msvc.
- [ ] `cargo build` against the published `cadrum-occt-v800beta1` Release succeeds on each target.
- [ ] After OCCT 8.0.0 final on May 7, follow up with another bump to `V8_0_0`.