### PR TITLE
refactor(traits): reduce Compound and Wire to iter_elem + map_elem

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,13 +45,6 @@ pub use glam;
 impl Edge{
     ////////// codegen.rs
     pub fn id(&self) -> u64 {<Self as crate::traits::EdgeStruct>::id(self)}
-    pub fn start_point(&self) -> DVec3 {<Self as crate::traits::EdgeStruct>::start_point(self)}
-    pub fn end_point(&self) -> DVec3 {<Self as crate::traits::EdgeStruct>::end_point(self)}
-    pub fn start_tangent(&self) -> DVec3 {<Self as crate::traits::EdgeStruct>::start_tangent(self)}
-    pub fn end_tangent(&self) -> DVec3 {<Self as crate::traits::EdgeStruct>::end_tangent(self)}
-    pub fn is_closed(&self) -> bool {<Self as crate::traits::EdgeStruct>::is_closed(self)}
-    pub fn approximation_segments(&self, tolerance: f64) -> Vec<DVec3> {<Self as crate::traits::EdgeStruct>::approximation_segments(self, tolerance)}
-    pub fn project(&self, p: DVec3) -> (DVec3, DVec3) {<Self as crate::traits::EdgeStruct>::project(self, p)}
     pub fn helix(radius: f64, pitch: f64, height: f64, axis: DVec3, x_ref: DVec3) -> Result<crate::Edge, Error> {<Self as crate::traits::EdgeStruct>::helix(radius, pitch, height, axis, x_ref)}
     pub fn polygon<'a>(points: impl IntoIterator<Item = &'a DVec3>) -> Result<Vec<crate::Edge>, Error> {<Self as crate::traits::EdgeStruct>::polygon(points)}
     pub fn circle(radius: f64, axis: DVec3) -> Result<crate::Edge, Error> {<Self as crate::traits::EdgeStruct>::circle(radius, axis)}
@@ -60,6 +53,13 @@ impl Edge{
     pub fn bspline<'a>(points: impl IntoIterator<Item = &'a DVec3>, end: BSplineEnd) -> Result<crate::Edge, Error> {<Self as crate::traits::EdgeStruct>::bspline(points, end)}
     pub fn iter_elem(&self) -> impl Iterator<Item = &crate::Edge> + '_ {<Self as crate::traits::Wire>::iter_elem(self)}
     pub fn map_elem(self, f: impl FnMut(crate::Edge) -> crate::Edge) -> crate::Edge {<Self as crate::traits::Wire>::map_elem(self, f)}
+    pub fn start_point(&self) -> DVec3 {<Self as crate::traits::Wire>::start_point(self)}
+    pub fn end_point(&self) -> DVec3 {<Self as crate::traits::Wire>::end_point(self)}
+    pub fn start_tangent(&self) -> DVec3 {<Self as crate::traits::Wire>::start_tangent(self)}
+    pub fn end_tangent(&self) -> DVec3 {<Self as crate::traits::Wire>::end_tangent(self)}
+    pub fn is_closed(&self) -> bool {<Self as crate::traits::Wire>::is_closed(self)}
+    pub fn approximation_segments(&self, tolerance: f64) -> Vec<DVec3> {<Self as crate::traits::Wire>::approximation_segments(self, tolerance)}
+    pub fn project(&self, p: DVec3) -> (DVec3, DVec3) {<Self as crate::traits::Wire>::project(self, p)}
     pub fn translate(self, translation: DVec3) -> crate::Edge {<Self as crate::traits::Wire>::translate(self, translation)}
     pub fn rotate(self, axis_origin: DVec3, axis_direction: DVec3, angle: f64) -> crate::Edge {<Self as crate::traits::Wire>::rotate(self, axis_origin, axis_direction, angle)}
     pub fn rotate_x(self, angle: f64) -> crate::Edge {<Self as crate::traits::Wire>::rotate_x(self, angle)}
@@ -90,16 +90,6 @@ impl Solid{
     pub fn iter_face(&self) -> impl Iterator<Item = &Face> + '_ {<Self as crate::traits::SolidStruct>::iter_face(self)}
     pub fn iter_history(&self) -> impl Iterator<Item = [u64; 2]> + '_ {<Self as crate::traits::SolidStruct>::iter_history(self)}
     pub fn clean(&self) -> Result<crate::Solid, Error> {<Self as crate::traits::SolidStruct>::clean(self)}
-    pub fn volume(&self) -> f64 {<Self as crate::traits::SolidStruct>::volume(self)}
-    pub fn area(&self) -> f64 {<Self as crate::traits::SolidStruct>::area(self)}
-    pub fn center(&self) -> DVec3 {<Self as crate::traits::SolidStruct>::center(self)}
-    pub fn inertia(&self) -> DMat3 {<Self as crate::traits::SolidStruct>::inertia(self)}
-    pub fn contains(&self, point: DVec3) -> bool {<Self as crate::traits::SolidStruct>::contains(self, point)}
-    pub fn bounding_box(&self) -> [DVec3; 2] {<Self as crate::traits::SolidStruct>::bounding_box(self)}
-    #[cfg(feature = "color")]
-    pub fn color(self, color: impl Into<Color>) -> crate::Solid {<Self as crate::traits::SolidStruct>::color(self, color)}
-    #[cfg(feature = "color")]
-    pub fn color_clear(self) -> crate::Solid {<Self as crate::traits::SolidStruct>::color_clear(self)}
     pub fn extrude<'a>(profile: impl IntoIterator<Item = &'a Edge>, dir: DVec3) -> Result<crate::Solid, Error> where Edge: 'a {<Self as crate::traits::SolidStruct>::extrude(profile, dir)}
     pub fn shell<'a>(&self, thickness: f64, open_faces: impl IntoIterator<Item = &'a Face>) -> Result<crate::Solid, Error> where Face: 'a {<Self as crate::traits::SolidStruct>::shell(self, thickness, open_faces)}
     pub fn fillet_edges<'a>(&self, radius: f64, edges: impl IntoIterator<Item = &'a Edge>) -> Result<crate::Solid, Error> where Edge: 'a {<Self as crate::traits::SolidStruct>::fillet_edges(self, radius, edges)}
@@ -119,6 +109,16 @@ impl Solid{
     pub fn mesh<'a>(solids: impl IntoIterator<Item = &'a crate::Solid>, tolerance: f64) -> Result<Mesh, Error> where Self: 'a {<Self as crate::traits::SolidStruct>::mesh(solids, tolerance)}
     pub fn iter_elem(&self) -> impl Iterator<Item = &crate::Solid> + '_ {<Self as crate::traits::Compound>::iter_elem(self)}
     pub fn map_elem(self, f: impl FnMut(crate::Solid) -> crate::Solid) -> crate::Solid {<Self as crate::traits::Compound>::map_elem(self, f)}
+    pub fn volume(&self) -> f64 {<Self as crate::traits::Compound>::volume(self)}
+    pub fn area(&self) -> f64 {<Self as crate::traits::Compound>::area(self)}
+    pub fn contains(&self, point: DVec3) -> bool {<Self as crate::traits::Compound>::contains(self, point)}
+    pub fn bounding_box(&self) -> [DVec3; 2] {<Self as crate::traits::Compound>::bounding_box(self)}
+    pub fn center(&self) -> DVec3 {<Self as crate::traits::Compound>::center(self)}
+    pub fn inertia(&self) -> DMat3 {<Self as crate::traits::Compound>::inertia(self)}
+    #[cfg(feature = "color")]
+    pub fn color(self, color: impl Into<Color>) -> crate::Solid {<Self as crate::traits::Compound>::color(self, color)}
+    #[cfg(feature = "color")]
+    pub fn color_clear(self) -> crate::Solid {<Self as crate::traits::Compound>::color_clear(self)}
     pub fn union<'a>(&self, tool: impl IntoIterator<Item = &'a crate::Solid>) -> Result<Vec<crate::Solid>, Error> where crate::Solid: 'a {<Self as crate::traits::Compound>::union(self, tool)}
     pub fn subtract<'a>(&self, tool: impl IntoIterator<Item = &'a crate::Solid>) -> Result<Vec<crate::Solid>, Error> where crate::Solid: 'a {<Self as crate::traits::Compound>::subtract(self, tool)}
     pub fn intersect<'a>(&self, tool: impl IntoIterator<Item = &'a crate::Solid>) -> Result<Vec<crate::Solid>, Error> where crate::Solid: 'a {<Self as crate::traits::Compound>::intersect(self, tool)}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,17 @@ impl Solid{
     pub fn iter_edge(&self) -> impl Iterator<Item = &Edge> + '_ {<Self as crate::traits::SolidStruct>::iter_edge(self)}
     pub fn iter_face(&self) -> impl Iterator<Item = &Face> + '_ {<Self as crate::traits::SolidStruct>::iter_face(self)}
     pub fn iter_history(&self) -> impl Iterator<Item = [u64; 2]> + '_ {<Self as crate::traits::SolidStruct>::iter_history(self)}
+    pub fn clean(&self) -> Result<crate::Solid, Error> {<Self as crate::traits::SolidStruct>::clean(self)}
+    pub fn volume(&self) -> f64 {<Self as crate::traits::SolidStruct>::volume(self)}
+    pub fn area(&self) -> f64 {<Self as crate::traits::SolidStruct>::area(self)}
+    pub fn center(&self) -> DVec3 {<Self as crate::traits::SolidStruct>::center(self)}
+    pub fn inertia(&self) -> DMat3 {<Self as crate::traits::SolidStruct>::inertia(self)}
+    pub fn contains(&self, point: DVec3) -> bool {<Self as crate::traits::SolidStruct>::contains(self, point)}
+    pub fn bounding_box(&self) -> [DVec3; 2] {<Self as crate::traits::SolidStruct>::bounding_box(self)}
+    #[cfg(feature = "color")]
+    pub fn color(self, color: impl Into<Color>) -> crate::Solid {<Self as crate::traits::SolidStruct>::color(self, color)}
+    #[cfg(feature = "color")]
+    pub fn color_clear(self) -> crate::Solid {<Self as crate::traits::SolidStruct>::color_clear(self)}
     pub fn extrude<'a>(profile: impl IntoIterator<Item = &'a Edge>, dir: DVec3) -> Result<crate::Solid, Error> where Edge: 'a {<Self as crate::traits::SolidStruct>::extrude(profile, dir)}
     pub fn shell<'a>(&self, thickness: f64, open_faces: impl IntoIterator<Item = &'a Face>) -> Result<crate::Solid, Error> where Face: 'a {<Self as crate::traits::SolidStruct>::shell(self, thickness, open_faces)}
     pub fn fillet_edges<'a>(&self, radius: f64, edges: impl IntoIterator<Item = &'a Edge>) -> Result<crate::Solid, Error> where Edge: 'a {<Self as crate::traits::SolidStruct>::fillet_edges(self, radius, edges)}
@@ -104,17 +115,8 @@ impl Solid{
     pub fn write_brep_binary<'a, W: std::io::Write>(solids: impl IntoIterator<Item = &'a crate::Solid>, writer: &mut W) -> Result<(), Error> where Self: 'a {<Self as crate::traits::SolidStruct>::write_brep_binary(solids, writer)}
     pub fn write_brep_text<'a, W: std::io::Write>(solids: impl IntoIterator<Item = &'a crate::Solid>, writer: &mut W) -> Result<(), Error> where Self: 'a {<Self as crate::traits::SolidStruct>::write_brep_text(solids, writer)}
     pub fn mesh<'a>(solids: impl IntoIterator<Item = &'a crate::Solid>, tolerance: f64) -> Result<Mesh, Error> where Self: 'a {<Self as crate::traits::SolidStruct>::mesh(solids, tolerance)}
-    pub fn clean(&self) -> Result<crate::Solid, Error> {<Self as crate::traits::Compound>::clean(self)}
-    pub fn volume(&self) -> f64 {<Self as crate::traits::Compound>::volume(self)}
-    pub fn bounding_box(&self) -> [DVec3; 2] {<Self as crate::traits::Compound>::bounding_box(self)}
-    pub fn contains(&self, point: DVec3) -> bool {<Self as crate::traits::Compound>::contains(self, point)}
-    pub fn area(&self) -> f64 {<Self as crate::traits::Compound>::area(self)}
-    pub fn center(&self) -> DVec3 {<Self as crate::traits::Compound>::center(self)}
-    pub fn inertia(&self) -> DMat3 {<Self as crate::traits::Compound>::inertia(self)}
-    #[cfg(feature = "color")]
-    pub fn color(self, color: impl Into<Color>) -> crate::Solid {<Self as crate::traits::Compound>::color(self, color)}
-    #[cfg(feature = "color")]
-    pub fn color_clear(self) -> crate::Solid {<Self as crate::traits::Compound>::color_clear(self)}
+    pub fn iter_elem(&self) -> impl Iterator<Item = &crate::Solid> + '_ {<Self as crate::traits::Compound>::iter_elem(self)}
+    pub fn map_elem(self, f: impl FnMut(crate::Solid) -> crate::Solid) -> crate::Solid {<Self as crate::traits::Compound>::map_elem(self, f)}
     pub fn union<'a>(&self, tool: impl IntoIterator<Item = &'a crate::Solid>) -> Result<Vec<crate::Solid>, Error> where crate::Solid: 'a {<Self as crate::traits::Compound>::union(self, tool)}
     pub fn subtract<'a>(&self, tool: impl IntoIterator<Item = &'a crate::Solid>) -> Result<Vec<crate::Solid>, Error> where crate::Solid: 'a {<Self as crate::traits::Compound>::subtract(self, tool)}
     pub fn intersect<'a>(&self, tool: impl IntoIterator<Item = &'a crate::Solid>) -> Result<Vec<crate::Solid>, Error> where crate::Solid: 'a {<Self as crate::traits::Compound>::intersect(self, tool)}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,19 +45,21 @@ pub use glam;
 impl Edge{
     ////////// codegen.rs
     pub fn id(&self) -> u64 {<Self as crate::traits::EdgeStruct>::id(self)}
+    pub fn start_point(&self) -> DVec3 {<Self as crate::traits::EdgeStruct>::start_point(self)}
+    pub fn end_point(&self) -> DVec3 {<Self as crate::traits::EdgeStruct>::end_point(self)}
+    pub fn start_tangent(&self) -> DVec3 {<Self as crate::traits::EdgeStruct>::start_tangent(self)}
+    pub fn end_tangent(&self) -> DVec3 {<Self as crate::traits::EdgeStruct>::end_tangent(self)}
+    pub fn is_closed(&self) -> bool {<Self as crate::traits::EdgeStruct>::is_closed(self)}
+    pub fn approximation_segments(&self, tolerance: f64) -> Vec<DVec3> {<Self as crate::traits::EdgeStruct>::approximation_segments(self, tolerance)}
+    pub fn project(&self, p: DVec3) -> (DVec3, DVec3) {<Self as crate::traits::EdgeStruct>::project(self, p)}
     pub fn helix(radius: f64, pitch: f64, height: f64, axis: DVec3, x_ref: DVec3) -> Result<crate::Edge, Error> {<Self as crate::traits::EdgeStruct>::helix(radius, pitch, height, axis, x_ref)}
     pub fn polygon<'a>(points: impl IntoIterator<Item = &'a DVec3>) -> Result<Vec<crate::Edge>, Error> {<Self as crate::traits::EdgeStruct>::polygon(points)}
     pub fn circle(radius: f64, axis: DVec3) -> Result<crate::Edge, Error> {<Self as crate::traits::EdgeStruct>::circle(radius, axis)}
     pub fn line(a: DVec3, b: DVec3) -> Result<crate::Edge, Error> {<Self as crate::traits::EdgeStruct>::line(a, b)}
     pub fn arc_3pts(start: DVec3, mid: DVec3, end: DVec3) -> Result<crate::Edge, Error> {<Self as crate::traits::EdgeStruct>::arc_3pts(start, mid, end)}
     pub fn bspline<'a>(points: impl IntoIterator<Item = &'a DVec3>, end: BSplineEnd) -> Result<crate::Edge, Error> {<Self as crate::traits::EdgeStruct>::bspline(points, end)}
-    pub fn start_point(&self) -> DVec3 {<Self as crate::traits::Wire>::start_point(self)}
-    pub fn end_point(&self) -> DVec3 {<Self as crate::traits::Wire>::end_point(self)}
-    pub fn start_tangent(&self) -> DVec3 {<Self as crate::traits::Wire>::start_tangent(self)}
-    pub fn end_tangent(&self) -> DVec3 {<Self as crate::traits::Wire>::end_tangent(self)}
-    pub fn is_closed(&self) -> bool {<Self as crate::traits::Wire>::is_closed(self)}
-    pub fn approximation_segments(&self, tolerance: f64) -> Vec<DVec3> {<Self as crate::traits::Wire>::approximation_segments(self, tolerance)}
-    pub fn project(&self, p: DVec3) -> (DVec3, DVec3) {<Self as crate::traits::Wire>::project(self, p)}
+    pub fn iter_elem(&self) -> impl Iterator<Item = &crate::Edge> + '_ {<Self as crate::traits::Wire>::iter_elem(self)}
+    pub fn map_elem(self, f: impl FnMut(crate::Edge) -> crate::Edge) -> crate::Edge {<Self as crate::traits::Wire>::map_elem(self, f)}
     pub fn translate(self, translation: DVec3) -> crate::Edge {<Self as crate::traits::Wire>::translate(self, translation)}
     pub fn rotate(self, axis_origin: DVec3, axis_direction: DVec3, angle: f64) -> crate::Edge {<Self as crate::traits::Wire>::rotate(self, axis_origin, axis_direction, angle)}
     pub fn rotate_x(self, angle: f64) -> crate::Edge {<Self as crate::traits::Wire>::rotate_x(self, angle)}

--- a/src/occt/edge.rs
+++ b/src/occt/edge.rs
@@ -40,6 +40,62 @@ impl EdgeStruct for Edge {
 		ffi::edge_tshape_id(&self.inner)
 	}
 
+	// ==================== Per-element atomic ops ====================
+	// Wire default が `<Edge as EdgeStruct>::xxx(s)` 形式で呼ぶ。
+
+	fn start_point(&self) -> DVec3 {
+		let (mut sx, mut sy, mut sz) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut ex, mut ey, mut ez) = (0.0_f64, 0.0_f64, 0.0_f64);
+		ffi::edge_endpoints(&self.inner, &mut sx, &mut sy, &mut sz, &mut ex, &mut ey, &mut ez);
+		DVec3::new(sx, sy, sz)
+	}
+
+	fn end_point(&self) -> DVec3 {
+		let (mut sx, mut sy, mut sz) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut ex, mut ey, mut ez) = (0.0_f64, 0.0_f64, 0.0_f64);
+		ffi::edge_endpoints(&self.inner, &mut sx, &mut sy, &mut sz, &mut ex, &mut ey, &mut ez);
+		DVec3::new(ex, ey, ez)
+	}
+
+	fn start_tangent(&self) -> DVec3 {
+		let (mut sx, mut sy, mut sz) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut ex, mut ey, mut ez) = (0.0_f64, 0.0_f64, 0.0_f64);
+		ffi::edge_tangents(&self.inner, &mut sx, &mut sy, &mut sz, &mut ex, &mut ey, &mut ez);
+		DVec3::new(sx, sy, sz)
+	}
+
+	fn end_tangent(&self) -> DVec3 {
+		let (mut sx, mut sy, mut sz) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut ex, mut ey, mut ez) = (0.0_f64, 0.0_f64, 0.0_f64);
+		ffi::edge_tangents(&self.inner, &mut sx, &mut sy, &mut sz, &mut ex, &mut ey, &mut ez);
+		DVec3::new(ex, ey, ez)
+	}
+
+	fn is_closed(&self) -> bool {
+		ffi::edge_is_closed(&self.inner)
+	}
+
+	fn approximation_segments(&self, tolerance: f64) -> Vec<DVec3> {
+		ffi::edge_approximation_segments(&self.inner, tolerance, tolerance)
+			.chunks_exact(3)
+			.map(|c| DVec3::new(c[0], c[1], c[2]))
+			.collect()
+	}
+
+	fn project(&self, p: DVec3) -> (DVec3, DVec3) {
+		let (mut cpx, mut cpy, mut cpz) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut tx, mut ty, mut tz) = (0.0_f64, 0.0_f64, 0.0_f64);
+		// FFI returns false only on truly degenerate edges (no 3D Geom_Curve,
+		// or OCCT internal exception). All cadrum-constructed edges carry a
+		// Geom_Curve, so this is effectively unreachable — treat as a bug and
+		// fail fast rather than returning silent zero.
+		assert!(
+			ffi::edge_project_point(&self.inner, p.x, p.y, p.z, &mut cpx, &mut cpy, &mut cpz, &mut tx, &mut ty, &mut tz),
+			"Edge::project: edge has no 3D curve or OCCT projector threw (this is a bug)"
+		);
+		(DVec3::new(cpx, cpy, cpz), DVec3::new(tx, ty, tz))
+	}
+
 	fn helix(radius: f64, pitch: f64, height: f64, axis: DVec3, x_ref: DVec3) -> Result<Self, Error> {
 		let inner = ffi::make_helix_edge(axis.x, axis.y, axis.z, x_ref.x, x_ref.y, x_ref.z, radius, pitch, height);
 		Edge::try_from_ffi(inner, format!("helix: degenerate params (radius={radius}, pitch={pitch}, height={height}, axis={axis:?}, x_ref={x_ref:?})"))
@@ -136,61 +192,13 @@ impl EdgeStruct for Edge {
 	}
 }
 
+// Edge を「単一要素のワイヤ」として扱う trivial impl。endpoint / tangent / project
+// 等の atomic ops は EdgeStruct 側 (上の impl EdgeStruct for Edge 内) に住み、
+// Wire default は `<Edge as EdgeStruct>::xxx(s)` 経由で集約する。
 impl Wire for Edge {
 	type Elem = Edge;
-
-	fn start_point(&self) -> DVec3 {
-		let (mut sx, mut sy, mut sz) = (0.0_f64, 0.0_f64, 0.0_f64);
-		let (mut ex, mut ey, mut ez) = (0.0_f64, 0.0_f64, 0.0_f64);
-		ffi::edge_endpoints(&self.inner, &mut sx, &mut sy, &mut sz, &mut ex, &mut ey, &mut ez);
-		DVec3::new(sx, sy, sz)
-	}
-
-	fn end_point(&self) -> DVec3 {
-		let (mut sx, mut sy, mut sz) = (0.0_f64, 0.0_f64, 0.0_f64);
-		let (mut ex, mut ey, mut ez) = (0.0_f64, 0.0_f64, 0.0_f64);
-		ffi::edge_endpoints(&self.inner, &mut sx, &mut sy, &mut sz, &mut ex, &mut ey, &mut ez);
-		DVec3::new(ex, ey, ez)
-	}
-
-	fn start_tangent(&self) -> DVec3 {
-		let (mut sx, mut sy, mut sz) = (0.0_f64, 0.0_f64, 0.0_f64);
-		let (mut ex, mut ey, mut ez) = (0.0_f64, 0.0_f64, 0.0_f64);
-		ffi::edge_tangents(&self.inner, &mut sx, &mut sy, &mut sz, &mut ex, &mut ey, &mut ez);
-		DVec3::new(sx, sy, sz)
-	}
-
-	fn end_tangent(&self) -> DVec3 {
-		let (mut sx, mut sy, mut sz) = (0.0_f64, 0.0_f64, 0.0_f64);
-		let (mut ex, mut ey, mut ez) = (0.0_f64, 0.0_f64, 0.0_f64);
-		ffi::edge_tangents(&self.inner, &mut sx, &mut sy, &mut sz, &mut ex, &mut ey, &mut ez);
-		DVec3::new(ex, ey, ez)
-	}
-
-	fn is_closed(&self) -> bool {
-		ffi::edge_is_closed(&self.inner)
-	}
-
-	fn approximation_segments(&self, tolerance: f64) -> Vec<DVec3> {
-		ffi::edge_approximation_segments(&self.inner, tolerance, tolerance)
-			.chunks_exact(3)
-			.map(|c| DVec3::new(c[0], c[1], c[2]))
-			.collect()
-	}
-
-	fn project(&self, p: DVec3) -> (DVec3, DVec3) {
-		let (mut cpx, mut cpy, mut cpz) = (0.0_f64, 0.0_f64, 0.0_f64);
-		let (mut tx, mut ty, mut tz) = (0.0_f64, 0.0_f64, 0.0_f64);
-		// FFI returns false only on truly degenerate edges (no 3D Geom_Curve,
-		// or OCCT internal exception). All cadrum-constructed edges carry a
-		// Geom_Curve, so this is effectively unreachable — treat as a bug and
-		// fail fast rather than returning silent zero.
-		assert!(
-			ffi::edge_project_point(&self.inner, p.x, p.y, p.z, &mut cpx, &mut cpy, &mut cpz, &mut tx, &mut ty, &mut tz),
-			"Edge::project: edge has no 3D curve or OCCT projector threw (this is a bug)"
-		);
-		(DVec3::new(cpx, cpy, cpz), DVec3::new(tx, ty, tz))
-	}
+	fn iter_elem(&self) -> impl Iterator<Item = &Edge> + '_ { std::iter::once(self) }
+	fn map_elem(self, mut f: impl FnMut(Edge) -> Edge) -> Self { f(self) }
 }
 
 // Transform は trait 要件で `-> Self` を返すため Result にできない。

--- a/src/occt/edge.rs
+++ b/src/occt/edge.rs
@@ -43,59 +43,6 @@ impl EdgeStruct for Edge {
 	// ==================== Per-element atomic ops ====================
 	// Wire default が `<Edge as EdgeStruct>::xxx(s)` 形式で呼ぶ。
 
-	fn start_point(&self) -> DVec3 {
-		let (mut sx, mut sy, mut sz) = (0.0_f64, 0.0_f64, 0.0_f64);
-		let (mut ex, mut ey, mut ez) = (0.0_f64, 0.0_f64, 0.0_f64);
-		ffi::edge_endpoints(&self.inner, &mut sx, &mut sy, &mut sz, &mut ex, &mut ey, &mut ez);
-		DVec3::new(sx, sy, sz)
-	}
-
-	fn end_point(&self) -> DVec3 {
-		let (mut sx, mut sy, mut sz) = (0.0_f64, 0.0_f64, 0.0_f64);
-		let (mut ex, mut ey, mut ez) = (0.0_f64, 0.0_f64, 0.0_f64);
-		ffi::edge_endpoints(&self.inner, &mut sx, &mut sy, &mut sz, &mut ex, &mut ey, &mut ez);
-		DVec3::new(ex, ey, ez)
-	}
-
-	fn start_tangent(&self) -> DVec3 {
-		let (mut sx, mut sy, mut sz) = (0.0_f64, 0.0_f64, 0.0_f64);
-		let (mut ex, mut ey, mut ez) = (0.0_f64, 0.0_f64, 0.0_f64);
-		ffi::edge_tangents(&self.inner, &mut sx, &mut sy, &mut sz, &mut ex, &mut ey, &mut ez);
-		DVec3::new(sx, sy, sz)
-	}
-
-	fn end_tangent(&self) -> DVec3 {
-		let (mut sx, mut sy, mut sz) = (0.0_f64, 0.0_f64, 0.0_f64);
-		let (mut ex, mut ey, mut ez) = (0.0_f64, 0.0_f64, 0.0_f64);
-		ffi::edge_tangents(&self.inner, &mut sx, &mut sy, &mut sz, &mut ex, &mut ey, &mut ez);
-		DVec3::new(ex, ey, ez)
-	}
-
-	fn is_closed(&self) -> bool {
-		ffi::edge_is_closed(&self.inner)
-	}
-
-	fn approximation_segments(&self, tolerance: f64) -> Vec<DVec3> {
-		ffi::edge_approximation_segments(&self.inner, tolerance, tolerance)
-			.chunks_exact(3)
-			.map(|c| DVec3::new(c[0], c[1], c[2]))
-			.collect()
-	}
-
-	fn project(&self, p: DVec3) -> (DVec3, DVec3) {
-		let (mut cpx, mut cpy, mut cpz) = (0.0_f64, 0.0_f64, 0.0_f64);
-		let (mut tx, mut ty, mut tz) = (0.0_f64, 0.0_f64, 0.0_f64);
-		// FFI returns false only on truly degenerate edges (no 3D Geom_Curve,
-		// or OCCT internal exception). All cadrum-constructed edges carry a
-		// Geom_Curve, so this is effectively unreachable — treat as a bug and
-		// fail fast rather than returning silent zero.
-		assert!(
-			ffi::edge_project_point(&self.inner, p.x, p.y, p.z, &mut cpx, &mut cpy, &mut cpz, &mut tx, &mut ty, &mut tz),
-			"Edge::project: edge has no 3D curve or OCCT projector threw (this is a bug)"
-		);
-		(DVec3::new(cpx, cpy, cpz), DVec3::new(tx, ty, tz))
-	}
-
 	fn helix(radius: f64, pitch: f64, height: f64, axis: DVec3, x_ref: DVec3) -> Result<Self, Error> {
 		let inner = ffi::make_helix_edge(axis.x, axis.y, axis.z, x_ref.x, x_ref.y, x_ref.z, radius, pitch, height);
 		Edge::try_from_ffi(inner, format!("helix: degenerate params (radius={radius}, pitch={pitch}, height={height}, axis={axis:?}, x_ref={x_ref:?})"))
@@ -197,8 +144,65 @@ impl EdgeStruct for Edge {
 // Wire default は `<Edge as EdgeStruct>::xxx(s)` 経由で集約する。
 impl Wire for Edge {
 	type Elem = Edge;
-	fn iter_elem(&self) -> impl Iterator<Item = &Edge> + '_ { std::iter::once(self) }
-	fn map_elem(self, mut f: impl FnMut(Edge) -> Edge) -> Self { f(self) }
+	fn iter_elem(&self) -> impl Iterator<Item = &Edge> + '_ {
+		panic!("Cannot iter_elem on Edge, because Edge is not Wire");
+		#[allow(unreachable_code)] std::iter::empty()
+	}
+	fn map_elem(self, _: impl FnMut(Edge) -> Edge) -> Self {
+		panic!("Cannot map_elem on Edge, because Edge is not Wire");
+	}
+	fn start_point(&self) -> DVec3 {
+		let (mut sx, mut sy, mut sz) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut ex, mut ey, mut ez) = (0.0_f64, 0.0_f64, 0.0_f64);
+		ffi::edge_endpoints(&self.inner, &mut sx, &mut sy, &mut sz, &mut ex, &mut ey, &mut ez);
+		DVec3::new(sx, sy, sz)
+	}
+
+	fn end_point(&self) -> DVec3 {
+		let (mut sx, mut sy, mut sz) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut ex, mut ey, mut ez) = (0.0_f64, 0.0_f64, 0.0_f64);
+		ffi::edge_endpoints(&self.inner, &mut sx, &mut sy, &mut sz, &mut ex, &mut ey, &mut ez);
+		DVec3::new(ex, ey, ez)
+	}
+
+	fn start_tangent(&self) -> DVec3 {
+		let (mut sx, mut sy, mut sz) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut ex, mut ey, mut ez) = (0.0_f64, 0.0_f64, 0.0_f64);
+		ffi::edge_tangents(&self.inner, &mut sx, &mut sy, &mut sz, &mut ex, &mut ey, &mut ez);
+		DVec3::new(sx, sy, sz)
+	}
+
+	fn end_tangent(&self) -> DVec3 {
+		let (mut sx, mut sy, mut sz) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut ex, mut ey, mut ez) = (0.0_f64, 0.0_f64, 0.0_f64);
+		ffi::edge_tangents(&self.inner, &mut sx, &mut sy, &mut sz, &mut ex, &mut ey, &mut ez);
+		DVec3::new(ex, ey, ez)
+	}
+
+	fn is_closed(&self) -> bool {
+		ffi::edge_is_closed(&self.inner)
+	}
+
+	fn approximation_segments(&self, tolerance: f64) -> Vec<DVec3> {
+		ffi::edge_approximation_segments(&self.inner, tolerance, tolerance)
+			.chunks_exact(3)
+			.map(|c| DVec3::new(c[0], c[1], c[2]))
+			.collect()
+	}
+
+	fn project(&self, p: DVec3) -> (DVec3, DVec3) {
+		let (mut cpx, mut cpy, mut cpz) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut tx, mut ty, mut tz) = (0.0_f64, 0.0_f64, 0.0_f64);
+		// FFI returns false only on truly degenerate edges (no 3D Geom_Curve,
+		// or OCCT internal exception). All cadrum-constructed edges carry a
+		// Geom_Curve, so this is effectively unreachable — treat as a bug and
+		// fail fast rather than returning silent zero.
+		assert!(
+			ffi::edge_project_point(&self.inner, p.x, p.y, p.z, &mut cpx, &mut cpy, &mut cpz, &mut tx, &mut ty, &mut tz),
+			"Edge::project: edge has no 3D curve or OCCT projector threw (this is a bug)"
+		);
+		(DVec3::new(cpx, cpy, cpz), DVec3::new(tx, ty, tz))
+	}
 }
 
 // Transform は trait 要件で `-> Self` を返すため Result にできない。

--- a/src/occt/solid.rs
+++ b/src/occt/solid.rs
@@ -237,6 +237,82 @@ impl SolidStruct for Solid {
 		self.history.chunks_exact(2).map(|c| [c[0], c[1]])
 	}
 
+	// ==================== Per-element atomic ops ====================
+	// Compound default が `<Solid as SolidStruct>::xxx(s)` 形式で呼ぶ。
+
+	fn clean(&self) -> Result<Self, Error> {
+		let mut history: Vec<u64> = Default::default();
+		let inner = ffi::builder_clean(&self.inner, &mut history);
+		if inner.is_null() {
+			return Err(Error::CleanFailed);
+		}
+		#[cfg(feature = "color")]
+		let colormap = {
+			let mut m = std::collections::HashMap::new();
+			for pair in history.chunks_exact(2) {
+				if let Some(&color) = self.colormap.get(&pair[1]) {
+					m.entry(pair[0]).or_insert(color);
+				}
+			}
+			m
+		};
+		Ok(Solid::new(inner, #[cfg(feature = "color")] colormap, history))
+	}
+
+	fn volume(&self) -> f64 {
+		ffi::shape_volume(&self.inner)
+	}
+
+	fn area(&self) -> f64 {
+		ffi::shape_surface_area(&self.inner)
+	}
+
+	fn center(&self) -> DVec3 {
+		let (mut x, mut y, mut z) = (0.0_f64, 0.0_f64, 0.0_f64);
+		ffi::shape_center_of_mass(&self.inner, &mut x, &mut y, &mut z);
+		DVec3::new(x, y, z)
+	}
+
+	fn inertia(&self) -> glam::DMat3 {
+		let (mut m00, mut m01, mut m02) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut m10, mut m11, mut m12) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut m20, mut m21, mut m22) = (0.0_f64, 0.0_f64, 0.0_f64);
+		ffi::shape_inertia_tensor(&self.inner,
+			&mut m00, &mut m01, &mut m02,
+			&mut m10, &mut m11, &mut m12,
+			&mut m20, &mut m21, &mut m22);
+		// OCCT fills row-major; DMat3::from_cols_array is column-major so
+		// transpose when handing the components over.
+		glam::DMat3::from_cols_array(&[
+			m00, m10, m20,
+			m01, m11, m21,
+			m02, m12, m22,
+		])
+	}
+
+	fn contains(&self, point: DVec3) -> bool {
+		ffi::shape_contains_point(&self.inner, point.x, point.y, point.z)
+	}
+
+	fn bounding_box(&self) -> [DVec3; 2] {
+		let (mut xmin, mut ymin, mut zmin) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut xmax, mut ymax, mut zmax) = (0.0_f64, 0.0_f64, 0.0_f64);
+		ffi::shape_bounding_box(&self.inner, &mut xmin, &mut ymin, &mut zmin, &mut xmax, &mut ymax, &mut zmax);
+		[DVec3::new(xmin, ymin, zmin), DVec3::new(xmax, ymax, zmax)]
+	}
+
+	#[cfg(feature = "color")]
+	fn color(self, color: impl Into<crate::common::color::Color>) -> Self {
+		let c = color.into();
+		let colormap = ffi::shape_faces(&self.inner).iter().map(|f| (ffi::face_tshape_id(f), c)).collect();
+		Self::new(self.inner, colormap, self.history)
+	}
+
+	#[cfg(feature = "color")]
+	fn color_clear(self) -> Self {
+		Self::new(self.inner, std::collections::HashMap::new(), self.history)
+	}
+
 	// ==================== Extrude ====================
 
 	fn extrude<'a>(profile: impl IntoIterator<Item = &'a Edge>, dir: DVec3) -> Result<Self, Error> {
@@ -525,101 +601,13 @@ impl Transform for Solid {
 
 // ==================== impl Compound for Solid ====================
 //
-// Solid-specific per-element ops (queries / color / boolean wrappers / clean).
-// `Vec<Solid>` and `[Solid; N]` impls live in src/traits.rs and delegate to this one.
+// Solid を「単一要素のコレクション」として扱う trivial impl。queries / color /
+// clean 等の atomic ops は SolidStruct 側 (上の impl SolidStruct for Solid 内) に
+// 住み、Compound default は `<Solid as SolidStruct>::xxx(s)` 経由で集約する。
 impl Compound for Solid {
 	type Elem = Solid;
-
-	fn clean(&self) -> Result<Self, Error> {
-		let mut history: Vec<u64> = Default::default();
-		let inner = ffi::builder_clean(&self.inner, &mut history);
-		if inner.is_null() {
-			return Err(Error::CleanFailed);
-		}
-		#[cfg(feature = "color")]
-		let colormap = {
-			let mut m = std::collections::HashMap::new();
-			for pair in history.chunks_exact(2) {
-				if let Some(&color) = self.colormap.get(&pair[1]) {
-					m.entry(pair[0]).or_insert(color);
-				}
-			}
-			m
-		};
-		Ok(Solid::new(inner, #[cfg(feature = "color")] colormap, history))
-	}
-
-	// ==================== Queries ====================
-
-	fn volume(&self) -> f64 {
-		ffi::shape_volume(&self.inner)
-	}
-
-	fn area(&self) -> f64 {
-		ffi::shape_surface_area(&self.inner)
-	}
-
-	fn center(&self) -> DVec3 {
-		let (mut x, mut y, mut z) = (0.0_f64, 0.0_f64, 0.0_f64);
-		ffi::shape_center_of_mass(&self.inner, &mut x, &mut y, &mut z);
-		DVec3::new(x, y, z)
-	}
-
-	fn inertia(&self) -> glam::DMat3 {
-		let (mut m00, mut m01, mut m02) = (0.0_f64, 0.0_f64, 0.0_f64);
-		let (mut m10, mut m11, mut m12) = (0.0_f64, 0.0_f64, 0.0_f64);
-		let (mut m20, mut m21, mut m22) = (0.0_f64, 0.0_f64, 0.0_f64);
-		ffi::shape_inertia_tensor(&self.inner,
-			&mut m00, &mut m01, &mut m02,
-			&mut m10, &mut m11, &mut m12,
-			&mut m20, &mut m21, &mut m22);
-		// OCCT fills row-major; DMat3::from_cols_array is column-major so
-		// transpose when handing the components over.
-		glam::DMat3::from_cols_array(&[
-			m00, m10, m20,
-			m01, m11, m21,
-			m02, m12, m22,
-		])
-	}
-
-	fn contains(&self, point: DVec3) -> bool {
-		ffi::shape_contains_point(&self.inner, point.x, point.y, point.z)
-	}
-
-	fn bounding_box(&self) -> [DVec3; 2] {
-		let (mut xmin, mut ymin, mut zmin) = (0.0_f64, 0.0_f64, 0.0_f64);
-		let (mut xmax, mut ymax, mut zmax) = (0.0_f64, 0.0_f64, 0.0_f64);
-		ffi::shape_bounding_box(&self.inner, &mut xmin, &mut ymin, &mut zmin, &mut xmax, &mut ymax, &mut zmax);
-		[DVec3::new(xmin, ymin, zmin), DVec3::new(xmax, ymax, zmax)]
-	}
-
-	// ==================== Color ====================
-
-	#[cfg(feature = "color")]
-	fn color(self, color: impl Into<crate::common::color::Color>) -> Self {
-		let c = color.into();
-		let colormap = ffi::shape_faces(&self.inner).iter().map(|f| (ffi::face_tshape_id(f), c)).collect();
-		Self::new(self.inner, colormap, self.history)
-	}
-
-	#[cfg(feature = "color")]
-	fn color_clear(self) -> Self {
-		Self::new(self.inner, std::collections::HashMap::new(), self.history)
-	}
-
-	// ==================== Boolean ====================
-
-	fn union<'a>(&self, tool: impl IntoIterator<Item = &'a Solid>) -> Result<Vec<Solid>, Error> {
-		<Solid as SolidStruct>::boolean_union([self], tool)
-	}
-
-	fn subtract<'a>(&self, tool: impl IntoIterator<Item = &'a Solid>) -> Result<Vec<Solid>, Error> {
-		<Solid as SolidStruct>::boolean_subtract([self], tool)
-	}
-
-	fn intersect<'a>(&self, tool: impl IntoIterator<Item = &'a Solid>) -> Result<Vec<Solid>, Error> {
-		<Solid as SolidStruct>::boolean_intersect([self], tool)
-	}
+	fn iter_elem(&self) -> impl Iterator<Item = &Solid> + '_ { std::iter::once(self) }
+	fn map_elem(self, mut f: impl FnMut(Solid) -> Solid) -> Self { f(self) }
 }
 
 impl Clone for Solid {

--- a/src/occt/solid.rs
+++ b/src/occt/solid.rs
@@ -237,82 +237,6 @@ impl SolidStruct for Solid {
 		self.history.chunks_exact(2).map(|c| [c[0], c[1]])
 	}
 
-	// ==================== Per-element atomic ops ====================
-	// Compound default が `<Solid as SolidStruct>::xxx(s)` 形式で呼ぶ。
-
-	fn clean(&self) -> Result<Self, Error> {
-		let mut history: Vec<u64> = Default::default();
-		let inner = ffi::builder_clean(&self.inner, &mut history);
-		if inner.is_null() {
-			return Err(Error::CleanFailed);
-		}
-		#[cfg(feature = "color")]
-		let colormap = {
-			let mut m = std::collections::HashMap::new();
-			for pair in history.chunks_exact(2) {
-				if let Some(&color) = self.colormap.get(&pair[1]) {
-					m.entry(pair[0]).or_insert(color);
-				}
-			}
-			m
-		};
-		Ok(Solid::new(inner, #[cfg(feature = "color")] colormap, history))
-	}
-
-	fn volume(&self) -> f64 {
-		ffi::shape_volume(&self.inner)
-	}
-
-	fn area(&self) -> f64 {
-		ffi::shape_surface_area(&self.inner)
-	}
-
-	fn center(&self) -> DVec3 {
-		let (mut x, mut y, mut z) = (0.0_f64, 0.0_f64, 0.0_f64);
-		ffi::shape_center_of_mass(&self.inner, &mut x, &mut y, &mut z);
-		DVec3::new(x, y, z)
-	}
-
-	fn inertia(&self) -> glam::DMat3 {
-		let (mut m00, mut m01, mut m02) = (0.0_f64, 0.0_f64, 0.0_f64);
-		let (mut m10, mut m11, mut m12) = (0.0_f64, 0.0_f64, 0.0_f64);
-		let (mut m20, mut m21, mut m22) = (0.0_f64, 0.0_f64, 0.0_f64);
-		ffi::shape_inertia_tensor(&self.inner,
-			&mut m00, &mut m01, &mut m02,
-			&mut m10, &mut m11, &mut m12,
-			&mut m20, &mut m21, &mut m22);
-		// OCCT fills row-major; DMat3::from_cols_array is column-major so
-		// transpose when handing the components over.
-		glam::DMat3::from_cols_array(&[
-			m00, m10, m20,
-			m01, m11, m21,
-			m02, m12, m22,
-		])
-	}
-
-	fn contains(&self, point: DVec3) -> bool {
-		ffi::shape_contains_point(&self.inner, point.x, point.y, point.z)
-	}
-
-	fn bounding_box(&self) -> [DVec3; 2] {
-		let (mut xmin, mut ymin, mut zmin) = (0.0_f64, 0.0_f64, 0.0_f64);
-		let (mut xmax, mut ymax, mut zmax) = (0.0_f64, 0.0_f64, 0.0_f64);
-		ffi::shape_bounding_box(&self.inner, &mut xmin, &mut ymin, &mut zmin, &mut xmax, &mut ymax, &mut zmax);
-		[DVec3::new(xmin, ymin, zmin), DVec3::new(xmax, ymax, zmax)]
-	}
-
-	#[cfg(feature = "color")]
-	fn color(self, color: impl Into<crate::common::color::Color>) -> Self {
-		let c = color.into();
-		let colormap = ffi::shape_faces(&self.inner).iter().map(|f| (ffi::face_tshape_id(f), c)).collect();
-		Self::new(self.inner, colormap, self.history)
-	}
-
-	#[cfg(feature = "color")]
-	fn color_clear(self) -> Self {
-		Self::new(self.inner, std::collections::HashMap::new(), self.history)
-	}
-
 	// ==================== Extrude ====================
 
 	fn extrude<'a>(profile: impl IntoIterator<Item = &'a Edge>, dir: DVec3) -> Result<Self, Error> {
@@ -489,6 +413,27 @@ impl SolidStruct for Solid {
 		))
 	}
 
+	// ==================== Clean ====================
+
+	fn clean(&self) -> Result<Self, Error> {
+		let mut history: Vec<u64> = Default::default();
+		let inner = ffi::builder_clean(&self.inner, &mut history);
+		if inner.is_null() {
+			return Err(Error::CleanFailed);
+		}
+		#[cfg(feature = "color")]
+		let colormap = {
+			let mut m = std::collections::HashMap::new();
+			for pair in history.chunks_exact(2) {
+				if let Some(&color) = self.colormap.get(&pair[1]) {
+					m.entry(pair[0]).or_insert(color);
+				}
+			}
+			m
+		};
+		Ok(Solid::new(inner, #[cfg(feature = "color")] colormap, history))
+	}
+
 	// ==================== Boolean primitives ====================
 
 	fn boolean_union<'a, 'b>(a: impl IntoIterator<Item = &'a Self>, b: impl IntoIterator<Item = &'b Self>) -> Result<Vec<Self>, Error> where Self: 'a + 'b {
@@ -601,13 +546,91 @@ impl Transform for Solid {
 
 // ==================== impl Compound for Solid ====================
 //
-// Solid を「単一要素のコレクション」として扱う trivial impl。queries / color /
-// clean 等の atomic ops は SolidStruct 側 (上の impl SolidStruct for Solid 内) に
-// 住み、Compound default は `<Solid as SolidStruct>::xxx(s)` 経由で集約する。
+// Solid-specific per-element ops (queries / color / boolean wrappers / clean).
+// `Vec<Solid>` and `[Solid; N]` impls live in src/traits.rs and delegate to this one.
 impl Compound for Solid {
 	type Elem = Solid;
-	fn iter_elem(&self) -> impl Iterator<Item = &Solid> + '_ { std::iter::once(self) }
-	fn map_elem(self, mut f: impl FnMut(Solid) -> Solid) -> Self { f(self) }
+
+	// ==================== Queries ====================
+
+	fn volume(&self) -> f64 {
+		ffi::shape_volume(&self.inner)
+	}
+
+	fn area(&self) -> f64 {
+		ffi::shape_surface_area(&self.inner)
+	}
+
+	fn center(&self) -> DVec3 {
+		let (mut x, mut y, mut z) = (0.0_f64, 0.0_f64, 0.0_f64);
+		ffi::shape_center_of_mass(&self.inner, &mut x, &mut y, &mut z);
+		DVec3::new(x, y, z)
+	}
+
+	fn inertia(&self) -> glam::DMat3 {
+		let (mut m00, mut m01, mut m02) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut m10, mut m11, mut m12) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut m20, mut m21, mut m22) = (0.0_f64, 0.0_f64, 0.0_f64);
+		ffi::shape_inertia_tensor(&self.inner,
+			&mut m00, &mut m01, &mut m02,
+			&mut m10, &mut m11, &mut m12,
+			&mut m20, &mut m21, &mut m22);
+		// OCCT fills row-major; DMat3::from_cols_array is column-major so
+		// transpose when handing the components over.
+		glam::DMat3::from_cols_array(&[
+			m00, m10, m20,
+			m01, m11, m21,
+			m02, m12, m22,
+		])
+	}
+
+	fn contains(&self, point: DVec3) -> bool {
+		ffi::shape_contains_point(&self.inner, point.x, point.y, point.z)
+	}
+
+	fn bounding_box(&self) -> [DVec3; 2] {
+		let (mut xmin, mut ymin, mut zmin) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut xmax, mut ymax, mut zmax) = (0.0_f64, 0.0_f64, 0.0_f64);
+		ffi::shape_bounding_box(&self.inner, &mut xmin, &mut ymin, &mut zmin, &mut xmax, &mut ymax, &mut zmax);
+		[DVec3::new(xmin, ymin, zmin), DVec3::new(xmax, ymax, zmax)]
+	}
+
+	// ==================== Color ====================
+
+	#[cfg(feature = "color")]
+	fn color(self, color: impl Into<crate::common::color::Color>) -> Self {
+		let c = color.into();
+		let colormap = ffi::shape_faces(&self.inner).iter().map(|f| (ffi::face_tshape_id(f), c)).collect();
+		Self::new(self.inner, colormap, self.history)
+	}
+
+	#[cfg(feature = "color")]
+	fn color_clear(self) -> Self {
+		Self::new(self.inner, std::collections::HashMap::new(), self.history)
+	}
+
+	// ==================== Boolean ====================
+
+	fn union<'a>(&self, tool: impl IntoIterator<Item = &'a Solid>) -> Result<Vec<Solid>, Error> {
+		<Solid as SolidStruct>::boolean_union([self], tool)
+	}
+
+	fn subtract<'a>(&self, tool: impl IntoIterator<Item = &'a Solid>) -> Result<Vec<Solid>, Error> {
+		<Solid as SolidStruct>::boolean_subtract([self], tool)
+	}
+
+	fn intersect<'a>(&self, tool: impl IntoIterator<Item = &'a Solid>) -> Result<Vec<Solid>, Error> {
+		<Solid as SolidStruct>::boolean_intersect([self], tool)
+	}
+	
+	fn iter_elem(&self) -> impl Iterator<Item = &Self::Elem> + '_ {
+		panic!("Cannot iter_elem on Solid, because Solid is not Compound");
+		#[allow(unreachable_code)] std::iter::empty()
+	}
+
+	fn map_elem(self, _f: impl FnMut(Self::Elem) -> Self::Elem) -> Self {
+		panic!("Cannot map_elem on Solid, because Solid is not Compound")
+	}
 }
 
 impl Clone for Solid {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -270,25 +270,25 @@ pub enum BSplineEnd {
 
 // ==================== Wire / EdgeStruct ====================
 
-/// Public trait: edge/wire-level operations on `Edge`, `Vec<Edge>` and `[Edge; N]`.
+/// Public trait: container abstraction over `Edge`, `Vec<Edge>` and `[Edge; N]`.
 ///
-/// `Vec<Edge>` plays the role of a wire in this library — there is no
-/// dedicated `Wire` type, mirroring how `Compound` is just `Vec<Solid>`.
-/// Methods on `Wire` therefore have meaningful semantics for both a single
-/// edge and an ordered edge list:
+/// **コレクション最小契約**: 実装者は要素列挙 (`iter_elem`) と要素全置換 (`map_elem`)
+/// の 2 つだけを提供する (`Compound` と同形)。start_point / end_point / start_tangent /
+/// end_tangent / is_closed / approximation_segments / project は default で提供され、
+/// 内部で `<Self::Elem as EdgeStruct>::xxx(s)` を `iter_elem` 結果から取り出して合成する。
 ///
-/// - `start_point` / `end_point` / `start_tangent` / `end_tangent` — the
-///   wire's endpoint positions and tangent directions.
-///   For a single edge, the edge's first/last point and tangent.
-///   For a `Vec<Edge>`, the first edge's start and the last edge's end.
-/// - `is_closed` — does the geometry form a closed loop?
-///   For a single edge, whether start == end (e.g. a circle).
-///   For a `Vec<Edge>`, whether the first edge's start equals the last edge's end.
-/// - `approximation_segments` — polyline approximation. For a wire, all
-///   sub-edges' segments are concatenated in order.
-/// - `project` — closest point on the wire to a given world point, with the
-///   unit tangent at that point. For a `Vec<Edge>`, projects onto every
-///   sub-edge and returns the result with the smallest distance to `p`.
+/// `Vec<Edge>` plays the role of a wire in this library — there is no dedicated
+/// `Wire` type, mirroring how `Compound` is just `Vec<Solid>`. Methods on `Wire`
+/// therefore have meaningful semantics for both a single edge and an ordered edge list:
+///
+/// - `start_point` / `end_tangent` / etc. — for a single `Edge` this is the
+///   edge's own endpoint/tangent (via `EdgeStruct`); for a `Vec<Edge>` this is
+///   the first edge's start / last edge's end aggregated by the default impl.
+/// - `is_closed` — for a single `Edge` defers to the edge's geometry (e.g. a
+///   circle is closed); for a `Vec<Edge>` checks `first.start ≈ last.end`.
+/// - `approximation_segments` — concatenates sub-edge polylines, dropping
+///   duplicate seam points.
+/// - `project` — finds the smallest-distance projection across all elements.
 ///
 /// Spatial transforms live on the (crate-private) supertrait `Transform`.
 /// Since `Transform` is not re-exported from the crate root, users cannot
@@ -302,12 +302,54 @@ pub enum BSplineEnd {
 pub trait Wire: Transform {
 	type Elem: EdgeStruct;
 
-	fn start_point(&self) -> DVec3;
-	fn end_point(&self) -> DVec3;
-	fn start_tangent(&self) -> DVec3;
-	fn end_tangent(&self) -> DVec3;
-	fn is_closed(&self) -> bool;
-	fn approximation_segments(&self, tolerance: f64) -> Vec<DVec3>;
+	/// Borrow each element. For `Edge` itself this yields `std::iter::once(self)`;
+	/// for `Vec<T>` / `[T; N]` it yields `self.iter()`.
+	fn iter_elem(&self) -> impl Iterator<Item = &Self::Elem> + '_;
+	/// Replace every element by mapping through `f`. Length is preserved.
+	/// For `Edge` this is `f(self)`; for collections it consumes self and
+	/// rebuilds in the same shape.
+	fn map_elem(self, f: impl FnMut(Self::Elem) -> Self::Elem) -> Self;
+
+	// --- Endpoints / tangents (default — first / last element) ---
+	fn start_point(&self) -> DVec3 {
+		self.iter_elem().next().map(|e| <Self::Elem as EdgeStruct>::start_point(e)).unwrap_or(DVec3::ZERO)
+	}
+	fn end_point(&self) -> DVec3 {
+		self.iter_elem().last().map(|e| <Self::Elem as EdgeStruct>::end_point(e)).unwrap_or(DVec3::ZERO)
+	}
+	fn start_tangent(&self) -> DVec3 {
+		self.iter_elem().next().map(|e| <Self::Elem as EdgeStruct>::start_tangent(e)).unwrap_or(DVec3::ZERO)
+	}
+	fn end_tangent(&self) -> DVec3 {
+		self.iter_elem().last().map(|e| <Self::Elem as EdgeStruct>::end_tangent(e)).unwrap_or(DVec3::ZERO)
+	}
+	/// Empty wire: false. Single-edge wire: defer to that edge's geometry
+	/// (a circle is closed). Multi-edge wire: first edge's start ≈ last edge's
+	/// end. 1e-6 はモデル単位 (mm) を想定したハードコード — 引数化は API が
+	/// 増えるため後回し。極小/極大スケールのモデルで誤判定したら直す。
+	fn is_closed(&self) -> bool {
+		let mut iter = self.iter_elem();
+		let Some(first) = iter.next() else { return false; };
+		match iter.last() {
+			None => <Self::Elem as EdgeStruct>::is_closed(first),
+			Some(last) => (<Self::Elem as EdgeStruct>::start_point(first) - <Self::Elem as EdgeStruct>::end_point(last)).length() < 1e-6,
+		}
+	}
+	fn approximation_segments(&self, tolerance: f64) -> Vec<DVec3> {
+		let mut out: Vec<DVec3> = Vec::new();
+		for e in self.iter_elem() {
+			let pts = <Self::Elem as EdgeStruct>::approximation_segments(e, tolerance);
+			if let Some((first, rest)) = pts.split_first() {
+				if out.last().map(|p| (*p - *first).length() < 1e-9).unwrap_or(false) {
+					out.extend_from_slice(rest);
+				} else {
+					out.push(*first);
+					out.extend_from_slice(rest);
+				}
+			}
+		}
+		out
+	}
 	/// Project `p` onto the wire and return `(closest_point, unit_tangent)`.
 	/// The tangent follows the curve's native parameter direction.
 	///
@@ -316,7 +358,12 @@ pub trait Wire: Transform {
 	/// `Edge` that lacks a 3D geometric curve (i.e. FFI-level failure,
 	/// which cadrum-built edges never produce) panics — that case
 	/// indicates a bug, not a degenerate user input.
-	fn project(&self, p: DVec3) -> (DVec3, DVec3);
+	fn project(&self, p: DVec3) -> (DVec3, DVec3) {
+		self.iter_elem()
+			.map(|e| <Self::Elem as EdgeStruct>::project(e, p))
+			.min_by(|(a, _), (b, _)| (a - p).length_squared().partial_cmp(&(b - p).length_squared()).unwrap_or(std::cmp::Ordering::Equal))
+			.unwrap_or((DVec3::ZERO, DVec3::ZERO))
+	}
 
 	////////// codegen.rs
 	fn translate(self, translation: DVec3) -> Self { <Self as Transform>::translate(self, translation) }
@@ -346,6 +393,26 @@ pub trait EdgeStruct: Sized + Clone + Wire {
 	/// Use to compare edges across `Solid::iter_edge()` / `Face::iter_edge()`
 	/// (e.g. `face.iter_edge().any(|e| e.id() == edge.id())`).
 	fn id(&self) -> u64;
+
+	// --- Per-element atomic ops ---
+	// `Wire` の default メソッド (start_point / is_closed / project / ...) は
+	// `<Self::Elem as EdgeStruct>::xxx(s)` 形式の UFCS でこれらを呼ぶ。Edge 単体は
+	// ここで FFI を直接叩き、Vec<T> / [T; N] は Wire default 経由で集約される。
+
+	/// 3D position of this edge's start vertex.
+	fn start_point(&self) -> DVec3;
+	/// 3D position of this edge's end vertex.
+	fn end_point(&self) -> DVec3;
+	/// Unit tangent at this edge's start, in the curve's parameter direction.
+	fn start_tangent(&self) -> DVec3;
+	/// Unit tangent at this edge's end, in the curve's parameter direction.
+	fn end_tangent(&self) -> DVec3;
+	/// `true` iff start and end coincide (e.g. a full circle).
+	fn is_closed(&self) -> bool;
+	/// Polyline approximation of this edge with deflection ≤ `tolerance`.
+	fn approximation_segments(&self, tolerance: f64) -> Vec<DVec3>;
+	/// Project `p` onto this edge and return `(closest_point, unit_tangent)`.
+	fn project(&self, p: DVec3) -> (DVec3, DVec3);
 
 	/// Construct a single helical edge on a cylindrical surface centered at
 	/// the world origin.
@@ -788,109 +855,13 @@ impl<T: SolidStruct, const N: usize> Compound for [T; N] {
 
 impl<T: EdgeStruct> Wire for Vec<T> {
 	type Elem = T;
-
-	fn start_point(&self) -> DVec3 {
-		self.first().map(|e| e.start_point()).unwrap_or(DVec3::ZERO)
-	}
-
-	fn end_point(&self) -> DVec3 {
-		self.last().map(|e| e.end_point()).unwrap_or(DVec3::ZERO)
-	}
-
-	fn start_tangent(&self) -> DVec3 {
-		self.first().map(|e| e.start_tangent()).unwrap_or(DVec3::ZERO)
-	}
-
-	fn end_tangent(&self) -> DVec3 {
-		self.last().map(|e| e.end_tangent()).unwrap_or(DVec3::ZERO)
-	}
-
-	fn is_closed(&self) -> bool {
-		// Empty wire: not closed. Single-edge wire: defer to that edge.
-		// Multi-edge wire: the first edge's start equals the last edge's end.
-		// 1e-6 はモデル単位 (mm) を想定したハードコード — 引数化は API が
-		// 増えるため後回し。極小/極大スケールのモデルで誤判定したら直す。
-		match self.len() {
-			0 => false,
-			1 => self[0].is_closed(),
-			_ => (self[0].start_point() - self[self.len() - 1].end_point()).length() < 1e-6,
-		}
-	}
-
-	fn approximation_segments(&self, tolerance: f64) -> Vec<DVec3> {
-		let mut out: Vec<DVec3> = Vec::new();
-		for e in self {
-			let pts = e.approximation_segments(tolerance);
-			if let Some((first, rest)) = pts.split_first() {
-				if out.last().map(|p| (*p - *first).length() < 1e-9).unwrap_or(false) {
-					out.extend_from_slice(rest);
-				} else {
-					out.push(*first);
-					out.extend_from_slice(rest);
-				}
-			}
-		}
-		out
-	}
-
-	fn project(&self, p: DVec3) -> (DVec3, DVec3) {
-		project_over_edges(self.iter(), p)
-	}
+	fn iter_elem(&self) -> impl Iterator<Item = &T> + '_ { self.iter() }
+	fn map_elem(self, f: impl FnMut(T) -> T) -> Self { self.into_iter().map(f).collect() }
 }
 
 impl<T: EdgeStruct, const N: usize> Wire for [T; N] {
 	type Elem = T;
-
-	fn start_point(&self) -> DVec3 {
-		self.first().map(|e| e.start_point()).unwrap_or(DVec3::ZERO)
-	}
-
-	fn end_point(&self) -> DVec3 {
-		self.last().map(|e| e.end_point()).unwrap_or(DVec3::ZERO)
-	}
-
-	fn start_tangent(&self) -> DVec3 {
-		self.first().map(|e| e.start_tangent()).unwrap_or(DVec3::ZERO)
-	}
-
-	fn end_tangent(&self) -> DVec3 {
-		self.last().map(|e| e.end_tangent()).unwrap_or(DVec3::ZERO)
-	}
-
-	fn is_closed(&self) -> bool {
-		match N {
-			0 => false,
-			1 => self[0].is_closed(),
-			_ => (self[0].start_point() - self[N - 1].end_point()).length() < 1e-6,
-		}
-	}
-
-	fn approximation_segments(&self, tolerance: f64) -> Vec<DVec3> {
-		let mut out: Vec<DVec3> = Vec::new();
-		for e in self {
-			let pts = e.approximation_segments(tolerance);
-			if let Some((first, rest)) = pts.split_first() {
-				if out.last().map(|p| (*p - *first).length() < 1e-9).unwrap_or(false) {
-					out.extend_from_slice(rest);
-				} else {
-					out.push(*first);
-					out.extend_from_slice(rest);
-				}
-			}
-		}
-		out
-	}
-
-	fn project(&self, p: DVec3) -> (DVec3, DVec3) {
-		project_over_edges(self.iter(), p)
-	}
-}
-
-fn project_over_edges<'a, T: 'a + EdgeStruct + Wire>(edges: impl IntoIterator<Item = &'a T>, p: DVec3) -> (DVec3, DVec3) {
-	edges
-		.into_iter()
-		.map(|e| e.project(p))
-		.min_by(|(a, _), (b, _)| (a - p).length_squared().partial_cmp(&(b - p).length_squared()).unwrap_or(std::cmp::Ordering::Equal))
-		.unwrap_or((DVec3::ZERO, DVec3::ZERO))
+	fn iter_elem(&self) -> impl Iterator<Item = &T> + '_ { self.iter() }
+	fn map_elem(self, f: impl FnMut(T) -> T) -> Self { self.map(f) }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -505,6 +505,35 @@ pub trait SolidStruct: Sized + Clone + Compound {
 	/// construction, I/O read, scale/mirror, or Clone.
 	fn iter_history(&self) -> impl Iterator<Item = [u64; 2]> + '_;
 
+	// --- Per-element atomic ops ---
+	// `Compound` の default メソッド (volume / area / ... / color) はこれらを
+	// `<Self::Elem as SolidStruct>::volume(s)` 形式の UFCS で呼ぶ。Solid 単体は
+	// ここで FFI を直接叩き、Vec<T> / [T; N] は Compound default 経由で集約される。
+
+	/// Heal/regularize this solid (fuse coplanar faces, drop micro-edges,
+	/// repair small inconsistencies). Wraps `ShapeUpgrade_UnifySameDomain`
+	/// + cleanup. Failure is reported as `Error::CleanFailed`.
+	fn clean(&self) -> Result<Self, Error>;
+	/// Volume of this solid (signed by orientation; OCCT returns absolute value).
+	fn volume(&self) -> f64;
+	/// Total surface area of this solid.
+	fn area(&self) -> f64;
+	/// Center of mass (uniform density) in world coordinates.
+	fn center(&self) -> DVec3;
+	/// Inertia tensor about the **world origin** (uniform density). Translate
+	/// to the center-of-mass frame manually if needed.
+	fn inertia(&self) -> DMat3;
+	/// `true` iff `point` is strictly inside or on the boundary of this solid.
+	fn contains(&self, point: DVec3) -> bool;
+	/// Axis-aligned bounding box `[min, max]` in world coordinates.
+	fn bounding_box(&self) -> [DVec3; 2];
+	/// Paint every face of this solid with `color`.
+	#[cfg(feature = "color")]
+	fn color(self, color: impl Into<Color>) -> Self;
+	/// Drop all per-face color assignments from this solid.
+	#[cfg(feature = "color")]
+	fn color_clear(self) -> Self;
+
 	/// Extrude a closed profile wire along a direction vector to form a solid.
 	///
 	/// Internally builds a face from the wire and uses `BRepPrimAPI_MakePrism`.
@@ -622,47 +651,90 @@ pub trait SolidStruct: Sized + Clone + Compound {
 
 // ==================== Compound ====================
 
-/// Public trait: solid-specific operations on Solid, Vec<Solid>, and [Solid; N].
+/// Public trait: container abstraction over `Solid`, `Vec<Solid>`, and `[Solid; N]`.
+///
+/// **コレクション最小契約**: 実装者は要素列挙 (`iter_elem`) と要素全置換 (`map_elem`)
+/// の 2 つだけを提供する。volume / area / bounding_box / center / inertia / contains /
+/// color / color_clear / union / subtract / intersect は default で提供され、
+/// 内部で `<Self::Elem as SolidStruct>::xxx(s)` を `iter_elem` 結果に対して集約する。
+///
+/// **fallible op の意図的な不在**: `clean` は `SolidStruct` のみに置き、`Compound` には
+/// 載せない。fallible メソッドを default 化すると `try_map_elem` 相当の追加要求が必要
+/// になり container 契約が肥大化するため。コレクションに対して clean したい場合は
+/// `vec.into_iter().map(|s| s.clean()).collect::<Result<Vec<_>, _>>()?` と書く。
 ///
 /// Spatial transforms (translate/rotate/scale/mirror) live on the crate-private
-/// supertrait `Transform`. `Compound` re-exposes them through 1-line
-/// forwarders as default methods, so `use cadrum::Compound;` alone is enough
-/// to call `vec.translate(...)` / `[a,b].rotate_z(...)` on collections — no
-/// separate `Transform` import is needed (and none is possible from outside
-/// the crate).
+/// supertrait `Transform`. `Compound` re-exposes them through 1-line forwarders
+/// as default methods, so `use cadrum::Compound;` alone is enough to call
+/// `vec.translate(...)` / `[a,b].rotate_z(...)` on collections — no separate
+/// `Transform` import is needed (and none is possible from outside the crate).
 pub trait Compound: Transform {
 	type Elem: SolidStruct;
 
-	fn clean(&self) -> Result<Self, Error>;
+	/// Borrow each element. For `Solid` itself this yields `std::iter::once(self)`;
+	/// for `Vec<T>` / `[T; N]` it yields `self.iter()`.
+	fn iter_elem(&self) -> impl Iterator<Item = &Self::Elem> + '_;
+	/// Replace every element by mapping through `f`. Length is preserved.
+	/// For `Solid` this is `f(self)`; for collections it consumes self and
+	/// rebuilds in the same shape.
+	fn map_elem(self, f: impl FnMut(Self::Elem) -> Self::Elem) -> Self;
 
+	// --- Queries (default — aggregate over iter_elem) ---
+	fn volume(&self) -> f64 {
+		self.iter_elem().map(|s| <Self::Elem as SolidStruct>::volume(s)).sum()
+	}
+	fn area(&self) -> f64 {
+		self.iter_elem().map(|s| <Self::Elem as SolidStruct>::area(s)).sum()
+	}
+	fn contains(&self, point: DVec3) -> bool {
+		self.iter_elem().any(|s| <Self::Elem as SolidStruct>::contains(s, point))
+	}
+	fn bounding_box(&self) -> [DVec3; 2] {
+		self.iter_elem()
+			.map(|s| <Self::Elem as SolidStruct>::bounding_box(s))
+			.reduce(|[amin, amax], [bmin, bmax]| [amin.min(bmin), amax.max(bmax)])
+			.unwrap_or([DVec3::ZERO, DVec3::ZERO])
+	}
+	/// Center of mass (uniform density). Volume-weighted average of per-element
+	/// centers: `Σ(vol_i · center_i) / Σ vol_i`. volume=0 ガードは Vec/[T;N]
+	/// 空集合と Solid 単要素 (degenerate) の両方を `DVec3::ZERO` で救済する。
+	fn center(&self) -> DVec3 {
+		let total: f64 = self.iter_elem().map(|s| <Self::Elem as SolidStruct>::volume(s)).sum();
+		if total == 0.0 { return DVec3::ZERO; }
+		self.iter_elem()
+			.map(|s| <Self::Elem as SolidStruct>::center(s) * <Self::Elem as SolidStruct>::volume(s))
+			.sum::<DVec3>() / total
+	}
+	/// Inertia tensor about the **world origin** (uniform density). Aggregates
+	/// as a straight matrix sum across elements (parallel-axis theorem is
+	/// already folded in by world-origin referencing).
+	fn inertia(&self) -> DMat3 {
+		self.iter_elem().map(|s| <Self::Elem as SolidStruct>::inertia(s)).fold(DMat3::ZERO, |a, b| a + b)
+	}
 
-	// --- Queries ---
-	fn volume(&self) -> f64;
-	fn bounding_box(&self) -> [DVec3; 2];
-	fn contains(&self, point: DVec3) -> bool;
-	/// Total surface area. Aggregates as a simple sum across elements.
-	fn area(&self) -> f64;
-	/// Center of mass (uniform density). Aggregates as a volume-weighted
-	/// average of per-element centers: `Σ(vol_i · center_i) / Σ vol_i`.
-	fn center(&self) -> DVec3;
-	/// Inertia tensor about the **world origin** (uniform density).
-	/// World-origin referencing makes aggregation a straight matrix sum
-	/// (parallel-axis theorem is already folded in). Translate to the
-	/// center-of-mass frame manually if needed.
-	fn inertia(&self) -> DMat3;
-
-	// --- Color ---
+	// --- Color (default — map over elements) ---
 	#[cfg(feature = "color")]
-	fn color(self, color: impl Into<Color>) -> Self;
+	fn color(self, color: impl Into<Color>) -> Self {
+		let c: Color = color.into();
+		self.map_elem(|s| <Self::Elem as SolidStruct>::color(s, c))
+	}
 	#[cfg(feature = "color")]
-	fn color_clear(self) -> Self;
+	fn color_clear(self) -> Self {
+		self.map_elem(|s| <Self::Elem as SolidStruct>::color_clear(s))
+	}
 
-	// --- Boolean (-> Vec<Self::Elem>) ---
+	// --- Boolean (default — feed iter_elem to SolidStruct::boolean_*) ---
 	// Each result Solid carries its face-derivation history; access via
 	// `Solid::iter_history()`.
-	fn union<'a>(&self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<Vec<Self::Elem>, Error> where Self::Elem: 'a;
-	fn subtract<'a>(&self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<Vec<Self::Elem>, Error> where Self::Elem: 'a;
-	fn intersect<'a>(&self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<Vec<Self::Elem>, Error> where Self::Elem: 'a;
+	fn union<'a>(&self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<Vec<Self::Elem>, Error> where Self::Elem: 'a {
+		Self::Elem::boolean_union(self.iter_elem(), tool)
+	}
+	fn subtract<'a>(&self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<Vec<Self::Elem>, Error> where Self::Elem: 'a {
+		Self::Elem::boolean_subtract(self.iter_elem(), tool)
+	}
+	fn intersect<'a>(&self, tool: impl IntoIterator<Item = &'a Self::Elem>) -> Result<Vec<Self::Elem>, Error> where Self::Elem: 'a {
+		Self::Elem::boolean_intersect(self.iter_elem(), tool)
+	}
 	////////// codegen.rs
 	fn translate(self, translation: DVec3) -> Self { <Self as Transform>::translate(self, translation) }
 	fn rotate(self, axis_origin: DVec3, axis_direction: DVec3, angle: f64) -> Self { <Self as Transform>::rotate(self, axis_origin, axis_direction, angle) }
@@ -690,39 +762,8 @@ impl<T: Transform> Transform for Vec<T> {
 
 impl<T: SolidStruct> Compound for Vec<T> {
 	type Elem = T;
-	fn clean(&self) -> Result<Self, Error> { self.iter().map(|s| s.clean()).collect() }
-	fn volume(&self) -> f64 { self.iter().map(|s| s.volume()).sum() }
-	fn bounding_box(&self) -> [DVec3; 2] {
-		self.iter().map(|s| s.bounding_box())
-			.reduce(|[amin, amax], [bmin, bmax]| [amin.min(bmin), amax.max(bmax)])
-			.unwrap_or([DVec3::ZERO, DVec3::ZERO])
-	}
-	fn contains(&self, p: DVec3) -> bool { self.iter().any(|s| s.contains(p)) }
-	fn area(&self) -> f64 { self.iter().map(|s| s.area()).sum() }
-	fn center(&self) -> DVec3 {
-		let total_vol: f64 = self.iter().map(|s| s.volume()).sum();
-		if total_vol == 0.0 { return DVec3::ZERO; }
-		self.iter().map(|s| s.center() * s.volume()).sum::<DVec3>() / total_vol
-	}
-	fn inertia(&self) -> DMat3 { self.iter().map(|s| s.inertia()).fold(DMat3::ZERO, |a, b| a + b) }
-	#[cfg(feature = "color")]
-	fn color(self, color: impl Into<Color>) -> Self {
-		let c: Color = color.into();
-		self.into_iter().map(|s| s.color(c)).collect()
-	}
-	#[cfg(feature = "color")]
-	fn color_clear(self) -> Self {
-		self.into_iter().map(|s| s.color_clear()).collect()
-	}
-	fn union<'a>(&self, tool: impl IntoIterator<Item = &'a T>) -> Result<Vec<T>, Error> where T: 'a {
-		T::boolean_union(self.iter(), tool)
-	}
-	fn subtract<'a>(&self, tool: impl IntoIterator<Item = &'a T>) -> Result<Vec<T>, Error> where T: 'a {
-		T::boolean_subtract(self.iter(), tool)
-	}
-	fn intersect<'a>(&self, tool: impl IntoIterator<Item = &'a T>) -> Result<Vec<T>, Error> where T: 'a {
-		T::boolean_intersect(self.iter(), tool)
-	}
+	fn iter_elem(&self) -> impl Iterator<Item = &T> + '_ { self.iter() }
+	fn map_elem(self, f: impl FnMut(T) -> T) -> Self { self.into_iter().map(f).collect() }
 }
 
 // ==================== impl Transform / Compound for [T; N] ====================
@@ -736,42 +777,8 @@ impl<T: Transform, const N: usize> Transform for [T; N] {
 
 impl<T: SolidStruct, const N: usize> Compound for [T; N] {
 	type Elem = T;
-	fn clean(&self) -> Result<Self, Error> {
-		let v: Result<Vec<T>, Error> = self.iter().map(|s| s.clean()).collect();
-		v?.try_into().map_err(|_| unreachable!())
-	}
-	fn volume(&self) -> f64 { self.iter().map(|s| s.volume()).sum() }
-	fn bounding_box(&self) -> [DVec3; 2] {
-		self.iter().map(|s| s.bounding_box())
-			.reduce(|[amin, amax], [bmin, bmax]| [amin.min(bmin), amax.max(bmax)])
-			.unwrap_or([DVec3::ZERO, DVec3::ZERO])
-	}
-	fn contains(&self, p: DVec3) -> bool { self.iter().any(|s| s.contains(p)) }
-	fn area(&self) -> f64 { self.iter().map(|s| s.area()).sum() }
-	fn center(&self) -> DVec3 {
-		let total_vol: f64 = self.iter().map(|s| s.volume()).sum();
-		if total_vol == 0.0 { return DVec3::ZERO; }
-		self.iter().map(|s| s.center() * s.volume()).sum::<DVec3>() / total_vol
-	}
-	fn inertia(&self) -> DMat3 { self.iter().map(|s| s.inertia()).fold(DMat3::ZERO, |a, b| a + b) }
-	#[cfg(feature = "color")]
-	fn color(self, color: impl Into<Color>) -> Self {
-		let c: Color = color.into();
-		self.map(|s| s.color(c))
-	}
-	#[cfg(feature = "color")]
-	fn color_clear(self) -> Self {
-		self.map(|s| s.color_clear())
-	}
-	fn union<'a>(&self, tool: impl IntoIterator<Item = &'a T>) -> Result<Vec<T>, Error> where T: 'a {
-		T::boolean_union(self.iter(), tool)
-	}
-	fn subtract<'a>(&self, tool: impl IntoIterator<Item = &'a T>) -> Result<Vec<T>, Error> where T: 'a {
-		T::boolean_subtract(self.iter(), tool)
-	}
-	fn intersect<'a>(&self, tool: impl IntoIterator<Item = &'a T>) -> Result<Vec<T>, Error> where T: 'a {
-		T::boolean_intersect(self.iter(), tool)
-	}
+	fn iter_elem(&self) -> impl Iterator<Item = &T> + '_ { self.iter() }
+	fn map_elem(self, f: impl FnMut(T) -> T) -> Self { self.map(f) }
 }
 
 // ==================== impl Wire for Vec<T> / [T; N] ====================

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -300,7 +300,7 @@ pub enum BSplineEnd {
 /// methods inherently via `examples/codegen.rs`; the `use` import is only
 /// required when chaining on `Vec<Edge>` / `[Edge; N]`.
 pub trait Wire: Transform {
-	type Elem: EdgeStruct;
+	type Elem: Wire;
 
 	/// Borrow each element. For `Edge` itself this yields `std::iter::once(self)`;
 	/// for `Vec<T>` / `[T; N]` it yields `self.iter()`.
@@ -312,16 +312,16 @@ pub trait Wire: Transform {
 
 	// --- Endpoints / tangents (default — first / last element) ---
 	fn start_point(&self) -> DVec3 {
-		self.iter_elem().next().map(|e| <Self::Elem as EdgeStruct>::start_point(e)).unwrap_or(DVec3::ZERO)
+		self.iter_elem().next().map(|e| <Self::Elem as Wire>::start_point(e)).unwrap_or(DVec3::ZERO)
 	}
 	fn end_point(&self) -> DVec3 {
-		self.iter_elem().last().map(|e| <Self::Elem as EdgeStruct>::end_point(e)).unwrap_or(DVec3::ZERO)
+		self.iter_elem().last().map(|e| <Self::Elem as Wire>::end_point(e)).unwrap_or(DVec3::ZERO)
 	}
 	fn start_tangent(&self) -> DVec3 {
-		self.iter_elem().next().map(|e| <Self::Elem as EdgeStruct>::start_tangent(e)).unwrap_or(DVec3::ZERO)
+		self.iter_elem().next().map(|e| <Self::Elem as Wire>::start_tangent(e)).unwrap_or(DVec3::ZERO)
 	}
 	fn end_tangent(&self) -> DVec3 {
-		self.iter_elem().last().map(|e| <Self::Elem as EdgeStruct>::end_tangent(e)).unwrap_or(DVec3::ZERO)
+		self.iter_elem().last().map(|e| <Self::Elem as Wire>::end_tangent(e)).unwrap_or(DVec3::ZERO)
 	}
 	/// Empty wire: false. Single-edge wire: defer to that edge's geometry
 	/// (a circle is closed). Multi-edge wire: first edge's start ≈ last edge's
@@ -331,14 +331,14 @@ pub trait Wire: Transform {
 		let mut iter = self.iter_elem();
 		let Some(first) = iter.next() else { return false; };
 		match iter.last() {
-			None => <Self::Elem as EdgeStruct>::is_closed(first),
-			Some(last) => (<Self::Elem as EdgeStruct>::start_point(first) - <Self::Elem as EdgeStruct>::end_point(last)).length() < 1e-6,
+			None => <Self::Elem as Wire>::is_closed(first),
+			Some(last) => (<Self::Elem as Wire>::start_point(first) - <Self::Elem as Wire>::end_point(last)).length() < 1e-6,
 		}
 	}
 	fn approximation_segments(&self, tolerance: f64) -> Vec<DVec3> {
 		let mut out: Vec<DVec3> = Vec::new();
 		for e in self.iter_elem() {
-			let pts = <Self::Elem as EdgeStruct>::approximation_segments(e, tolerance);
+			let pts = <Self::Elem as Wire>::approximation_segments(e, tolerance);
 			if let Some((first, rest)) = pts.split_first() {
 				if out.last().map(|p| (*p - *first).length() < 1e-9).unwrap_or(false) {
 					out.extend_from_slice(rest);
@@ -360,7 +360,7 @@ pub trait Wire: Transform {
 	/// indicates a bug, not a degenerate user input.
 	fn project(&self, p: DVec3) -> (DVec3, DVec3) {
 		self.iter_elem()
-			.map(|e| <Self::Elem as EdgeStruct>::project(e, p))
+			.map(|e| <Self::Elem as Wire>::project(e, p))
 			.min_by(|(a, _), (b, _)| (a - p).length_squared().partial_cmp(&(b - p).length_squared()).unwrap_or(std::cmp::Ordering::Equal))
 			.unwrap_or((DVec3::ZERO, DVec3::ZERO))
 	}
@@ -393,26 +393,6 @@ pub trait EdgeStruct: Sized + Clone + Wire {
 	/// Use to compare edges across `Solid::iter_edge()` / `Face::iter_edge()`
 	/// (e.g. `face.iter_edge().any(|e| e.id() == edge.id())`).
 	fn id(&self) -> u64;
-
-	// --- Per-element atomic ops ---
-	// `Wire` の default メソッド (start_point / is_closed / project / ...) は
-	// `<Self::Elem as EdgeStruct>::xxx(s)` 形式の UFCS でこれらを呼ぶ。Edge 単体は
-	// ここで FFI を直接叩き、Vec<T> / [T; N] は Wire default 経由で集約される。
-
-	/// 3D position of this edge's start vertex.
-	fn start_point(&self) -> DVec3;
-	/// 3D position of this edge's end vertex.
-	fn end_point(&self) -> DVec3;
-	/// Unit tangent at this edge's start, in the curve's parameter direction.
-	fn start_tangent(&self) -> DVec3;
-	/// Unit tangent at this edge's end, in the curve's parameter direction.
-	fn end_tangent(&self) -> DVec3;
-	/// `true` iff start and end coincide (e.g. a full circle).
-	fn is_closed(&self) -> bool;
-	/// Polyline approximation of this edge with deflection ≤ `tolerance`.
-	fn approximation_segments(&self, tolerance: f64) -> Vec<DVec3>;
-	/// Project `p` onto this edge and return `(closest_point, unit_tangent)`.
-	fn project(&self, p: DVec3) -> (DVec3, DVec3);
 
 	/// Construct a single helical edge on a cylindrical surface centered at
 	/// the world origin.
@@ -581,26 +561,6 @@ pub trait SolidStruct: Sized + Clone + Compound {
 	/// repair small inconsistencies). Wraps `ShapeUpgrade_UnifySameDomain`
 	/// + cleanup. Failure is reported as `Error::CleanFailed`.
 	fn clean(&self) -> Result<Self, Error>;
-	/// Volume of this solid (signed by orientation; OCCT returns absolute value).
-	fn volume(&self) -> f64;
-	/// Total surface area of this solid.
-	fn area(&self) -> f64;
-	/// Center of mass (uniform density) in world coordinates.
-	fn center(&self) -> DVec3;
-	/// Inertia tensor about the **world origin** (uniform density). Translate
-	/// to the center-of-mass frame manually if needed.
-	fn inertia(&self) -> DMat3;
-	/// `true` iff `point` is strictly inside or on the boundary of this solid.
-	fn contains(&self, point: DVec3) -> bool;
-	/// Axis-aligned bounding box `[min, max]` in world coordinates.
-	fn bounding_box(&self) -> [DVec3; 2];
-	/// Paint every face of this solid with `color`.
-	#[cfg(feature = "color")]
-	fn color(self, color: impl Into<Color>) -> Self;
-	/// Drop all per-face color assignments from this solid.
-	#[cfg(feature = "color")]
-	fn color_clear(self) -> Self;
-
 	/// Extrude a closed profile wire along a direction vector to form a solid.
 	///
 	/// Internally builds a face from the wire and uses `BRepPrimAPI_MakePrism`.
@@ -736,7 +696,7 @@ pub trait SolidStruct: Sized + Clone + Compound {
 /// `vec.translate(...)` / `[a,b].rotate_z(...)` on collections — no separate
 /// `Transform` import is needed (and none is possible from outside the crate).
 pub trait Compound: Transform {
-	type Elem: SolidStruct;
+	type Elem: Compound+SolidStruct;
 
 	/// Borrow each element. For `Solid` itself this yields `std::iter::once(self)`;
 	/// for `Vec<T>` / `[T; N]` it yields `self.iter()`.
@@ -748,17 +708,17 @@ pub trait Compound: Transform {
 
 	// --- Queries (default — aggregate over iter_elem) ---
 	fn volume(&self) -> f64 {
-		self.iter_elem().map(|s| <Self::Elem as SolidStruct>::volume(s)).sum()
+		self.iter_elem().map(|s| <Self::Elem as Compound>::volume(s)).sum()
 	}
 	fn area(&self) -> f64 {
-		self.iter_elem().map(|s| <Self::Elem as SolidStruct>::area(s)).sum()
+		self.iter_elem().map(|s| <Self::Elem as Compound>::area(s)).sum()
 	}
 	fn contains(&self, point: DVec3) -> bool {
-		self.iter_elem().any(|s| <Self::Elem as SolidStruct>::contains(s, point))
+		self.iter_elem().any(|s| <Self::Elem as Compound>::contains(s, point))
 	}
 	fn bounding_box(&self) -> [DVec3; 2] {
 		self.iter_elem()
-			.map(|s| <Self::Elem as SolidStruct>::bounding_box(s))
+			.map(|s| <Self::Elem as Compound>::bounding_box(s))
 			.reduce(|[amin, amax], [bmin, bmax]| [amin.min(bmin), amax.max(bmax)])
 			.unwrap_or([DVec3::ZERO, DVec3::ZERO])
 	}
@@ -766,28 +726,28 @@ pub trait Compound: Transform {
 	/// centers: `Σ(vol_i · center_i) / Σ vol_i`. volume=0 ガードは Vec/[T;N]
 	/// 空集合と Solid 単要素 (degenerate) の両方を `DVec3::ZERO` で救済する。
 	fn center(&self) -> DVec3 {
-		let total: f64 = self.iter_elem().map(|s| <Self::Elem as SolidStruct>::volume(s)).sum();
+		let total: f64 = self.iter_elem().map(|s| <Self::Elem as Compound>::volume(s)).sum();
 		if total == 0.0 { return DVec3::ZERO; }
 		self.iter_elem()
-			.map(|s| <Self::Elem as SolidStruct>::center(s) * <Self::Elem as SolidStruct>::volume(s))
+			.map(|s| <Self::Elem as Compound>::center(s) * <Self::Elem as Compound>::volume(s))
 			.sum::<DVec3>() / total
 	}
 	/// Inertia tensor about the **world origin** (uniform density). Aggregates
 	/// as a straight matrix sum across elements (parallel-axis theorem is
 	/// already folded in by world-origin referencing).
 	fn inertia(&self) -> DMat3 {
-		self.iter_elem().map(|s| <Self::Elem as SolidStruct>::inertia(s)).fold(DMat3::ZERO, |a, b| a + b)
+		self.iter_elem().map(|s| <Self::Elem as Compound>::inertia(s)).fold(DMat3::ZERO, |a, b| a + b)
 	}
 
 	// --- Color (default — map over elements) ---
 	#[cfg(feature = "color")]
 	fn color(self, color: impl Into<Color>) -> Self {
 		let c: Color = color.into();
-		self.map_elem(|s| <Self::Elem as SolidStruct>::color(s, c))
+		self.map_elem(|s| <Self::Elem as Compound>::color(s, c))
 	}
 	#[cfg(feature = "color")]
 	fn color_clear(self) -> Self {
-		self.map_elem(|s| <Self::Elem as SolidStruct>::color_clear(s))
+		self.map_elem(|s| <Self::Elem as Compound>::color_clear(s))
 	}
 
 	// --- Boolean (default — feed iter_elem to SolidStruct::boolean_*) ---


### PR DESCRIPTION
## Summary

`Compound` (Solid 集合) と `Wire` (Edge 集合) の trait surface をどちらも `iter_elem` + `map_elem` の **2 メソッドだけ** に削減。残りのメソッド (volume / area / center / inertia / contains / bounding_box / color / color_clear / union / subtract / intersect / start_point / end_point / start_tangent / end_tangent / is_closed / approximation_segments / project) はすべて `<Self::Elem as SolidStruct/EdgeStruct>::xxx(s)` を `iter_elem` の結果に対して集約する default に置き換えた。

per-element の atomic 計算 (FFI 直呼び) は `SolidStruct` / `EdgeStruct` の required メソッドに昇格。`Solid` / `Edge` 単体は「単一要素のコレクション」として `iter_elem = std::iter::once(self)`、`map_elem = f(self)` の trivial impl を提供する。

これにより:
- 新コレクション (`SmallVec<Solid>` 等) を追加するときの impl ボイラープレートが **12 メソッド → 2 メソッド** に縮小
- `Compound::clean` は削除 (Compound に fallible op を残すと `try_map_elem` が必要となり container 契約が肥大化するため)。`solid.clean()` は `SolidStruct::clean` 経由で codegen が inherent emit、`vec.clean()` は `vec.into_iter().map(|s| s.clean()).collect::<Result<_,_>>()?` に書き換え (リポジトリ内の唯一の clean 利用箇所 `tests/integration_color_step.rs:100` は既にこの形)
- `impl Compound for Solid` ≈ 100 行 → 3 行、`impl Wire for Edge` ≈ 60 行 → 3 行、`impl Compound for Vec/[T;N]` ≈ 36 行 ×2 → 5 行 ×2、`impl Wire for Vec/[T;N]` ≈ 50 行 ×2 → 5 行 ×2

実装上の注意: Compound / Wire の default body 内で同名メソッドを呼ぶには **UFCS 必須** (`<Self::Elem as SolidStruct>::volume(s)`)。Rust の method resolution は supertrait 関係を disambiguation の根拠にせず、`s.volume()` と書くと SolidStruct::volume と Compound::volume の両方が候補となり E0034 になる。

## Test plan

- [x] `cargo build --features color` — 成功
- [x] `cargo test --features color` — 78 passed / 0 failed / 2 ignored (slow opt-in)
- [x] `cargo run --example codegen -- src/traits.rs src/lib.rs` — `lib.rs` の inherent forwarder が `Compound`/`Wire` から `SolidStruct`/`EdgeStruct` 経由に自動切替された (codegen の child-priority dedup 経由)
- [x] `cargo run --example 01_primitives / 03_transform / 04_boolean / 05_extrude` — 全て成功