### PR TITLE
docs: include README as crate-root doc; add CoC and CONTRIBUTING

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,10 @@
+# Code of Conduct
+
+This project is subject to the official [Rust code of conduct][coc].
+
+As there is no dedicated forum for this project, this applies in the
+[repository] (issues, pull requests, discussions) and in any direct
+communication about the project, over any medium.
+
+[coc]: https://www.rust-lang.org/policies/code-of-conduct
+[repository]: https://github.com/lzpel/cadrum

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing Guide
+
+Contributions, feature requests, usage questions, and general contacts of any
+kind are absolutely welcome.
+
+Note that this is a hobby project worked on in spare time. I can only give a
+best-effort promise of availability or responsiveness, but please do reach
+out with anything you need.
+
+## Contact
+
+- GitHub Issues: <https://github.com/lzpel/cadrum/issues> — preferred for
+  bugs, feature requests, and design discussions.
+- GitHub: [@lzpel](https://github.com/lzpel)
+
+## Preconditions
+
+You should be comfortable with `cargo` and the basics of building Rust
+projects. The first build downloads a prebuilt OCCT 8.0.0 tarball for
+supported targets and links it statically; on unsupported targets you will
+need CMake plus a C++17 compiler and `cargo build --features source-build`.
+See the [README](./README.md#build) for the full build matrix.
+
+The project uses **tab indentation** (`U+0009`) throughout. `rustfmt.toml`
+sets `hard_tabs = true`, so running `cargo fmt` keeps formatting consistent.
+
+This project aims to expose OpenCASCADE through an idiomatic Rust API, so
+contributions to documentation, examples, and ergonomic tweaks are equally
+welcome alongside patches to the FFI core.
+
+## Submitting Changes
+
+If you have a patch you think is worth inspecting right away, opening a pull
+request without prelude is fine, although an accompanying explanation of
+what the patch does and why is appreciated.
+
+For larger or design-affecting changes, please open an issue first to
+discuss the approach. The trait surface in `src/traits.rs` and the codegen
+pipeline in `examples/codegen.rs` interact in non-obvious ways, so a quick
+alignment saves rework.
+
+If you have questions, bugs, suggestions, or any other contributions that
+do not immediately touch the codebase, please open an issue or reach out
+informally on GitHub.
+
+## Environment
+
+The project's build, test, and release commands are driven by `make`:
+
+```sh
+make test     # cargo test (unit + integration + doc tests)
+make deploy   # regenerate examples/markdown output and build the mdbook site
+make publish  # publish to crates.io
+```
+
+### Regenerating derived files
+
+When you change `src/traits.rs`, regenerate the inherent-method delegations
+in `src/lib.rs`:
+
+```sh
+cargo run --example codegen -- src/traits.rs src/lib.rs
+```
+
+When you add or modify a numbered example (`examples/NN_*.rs`), regenerate
+the README's `## Examples` section and the mdbook source:
+
+```sh
+cargo run --example markdown -- out/markdown/SUMMARY.md ./README.md
+```
+
+Both regenerators produce deterministic output. Commit the resulting diffs
+together with the source change that motivated them.
+
+### Before opening a PR
+
+1. `cargo fmt` — keep formatting consistent (`hard_tabs = true`).
+2. `cargo test` — runs unit, integration, and doc tests.
+3. If you touched `src/traits.rs` or `examples/NN_*.rs`, run the relevant
+   regenerator above and commit the diff.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,73 @@
+<div align="center">
+
 # cadrum
 
-[![GitHub License](https://img.shields.io/github/license/lzpel/cadrum)](https://github.com/lzpel/cadrum/blob/main/LICENSE)
-[![Crates.io](https://img.shields.io/crates/v/cadrum.svg?logo=rust)](https://crates.io/crates/cadrum)
-[![Docs](https://img.shields.io/badge/docs-lzpel.github.io%2Fcadrum-blue)](https://lzpel.github.io/cadrum)
+Rust CAD library powered by statically linked, headless [OpenCASCADE][occt] (OCCT 8.0.0-beta1).
 
-Rust CAD library powered by statically linked, headless [OpenCASCADE](https://dev.opencascade.org/) (OCCT 8.0.0-beta1).
+[![GitHub License][license_img]][license_link]
+[![Crates.io][crate_img]][crate_link]
+[![docs.rs][docsrs_img]][docsrs_link]
+[![Docs][book_img]][book_link]
 
-<p align="center">
-  <img src="https://raw.githubusercontent.com/lzpel/alphastell/main/figure/image.png" alt="cadrum"/>
-</p>
+<img src="https://raw.githubusercontent.com/lzpel/alphastell/main/figure/image.png" alt="cadrum"/>
+
+</div>
+
+## Summary
+
+Other Rust CAD bindings either require the user to install OCCT ahead of time
+(with all the version skew this entails on Linux distros and Windows) or
+expose OCCT's class hierarchy 1:1, where building a cube ends up touching
+`gp_Pnt`, `gp_Ax2`, `BRepPrimAPI_MakeBox`, and `TopoDS_Shape` before any
+geometry actually appears.
+
+`cadrum` takes a different bet:
+
+- **Static linking with prebuilt binaries.** `cargo build` on a supported
+  target downloads a self-contained OCCT 8.0.0 tarball and links it
+  statically. No system OCCT, no dynamic libraries to ship, no
+  `LD_LIBRARY_PATH` in production.
+- **A minimal type surface.** Three concrete shape types — `Solid`, `Edge`,
+  `Face` — plus a triangle `Mesh` for visual output and `glam` vectors for
+  input. Operations are inherent methods on the shape types, so
+  `Solid::cube(...).rotate_z(0.5).translate(DVec3::X * 10.0)` chains like
+  any value-returning Rust API.
+- **Collections are first-class.** `Vec<Solid>` and `[Solid; N]` carry the
+  same transform, query, and boolean methods as a single `Solid` via the
+  `Compound` trait; the wire / edge-list pair has the parallel `Wire`
+  trait.
+
+## Introduction
+
+OpenCASCADE represents shapes as a *boundary representation* (BRep): a solid
+is a topological assembly of faces, faces are trimmed surfaces bounded by
+edges, edges are 3D curves with a parameter range. Booleans, fillets,
+sweeps, and the like rebuild this assembly under the hood; CAD I/O formats
+like STEP / IGES preserve it exactly across applications.
+
+Working at that level pays off when the application needs to reason about
+geometry — closest-point queries, swept profiles along arbitrary spines,
+history-tracked face derivation through booleans — and not merely render
+triangles. Triangle meshes are a separate, lossy projection that `cadrum`
+exposes through `Solid::mesh` when an STL export or SVG render is required.
+
+## Capabilities
+
+| Area | Methods |
+|---|---|
+| **Primitives** | `Solid::cube`, `Solid::sphere`, `Solid::cylinder`, `Solid::cone`, `Solid::torus`, `Solid::half_space` |
+| **Curves** | `Edge::line`, `Edge::arc_3pts`, `Edge::circle`, `Edge::polygon`, `Edge::helix`, `Edge::bspline` |
+| **Surfacing** | `Solid::extrude`, `Solid::sweep`, `Solid::loft`, `Solid::bspline` |
+| **Editing** | `Solid::shell`, `Solid::fillet_edges`, `Solid::chamfer_edges`, `Solid::clean` |
+| **Booleans** | `Solid::union`, `Solid::subtract`, `Solid::intersect` |
+| **Transforms** *(shared by `Solid` / `Edge` / `Compound` / `Wire`)* | `translate`, `rotate`, `rotate_x` / `_y` / `_z`, `scale`, `mirror`, `align_x` / `_y` / `_z` |
+| **Queries** | `Solid::volume`, `Solid::area`, `Solid::center`, `Solid::inertia`, `Solid::bounding_box`, `Solid::contains` |
+| **Topology** | `Solid::iter_face`, `Solid::iter_edge`, `Face::iter_edge`, `Face::project`, `Edge::project` |
+| **Identity / history** | `Solid::id`, `Face::id`, `Edge::id`, `Solid::iter_history` |
+| **I/O** | `Solid::read_step` / `Solid::write_step`, `Solid::read_brep_binary` / `Solid::write_brep_binary`, `Solid::read_brep_text` / `Solid::write_brep_text` |
+| **Mesh** | `Solid::mesh` → `Mesh`, `Mesh::write_stl`, `Mesh::write_svg` |
+| **Color** *(feature `color`)* | per-face color preserved across STEP / BRep / STL / SVG round-trips |
+
 ## Usage
 
 | [primitives](#primitives) | [write read](#write-read) | [transform](#transform) | [boolean](#boolean) |
@@ -41,7 +100,9 @@ cadrum = "^0.7"
 
 For other targets, build OCCT from source:
 
-    OCCT_ROOT=/path/to/occt cargo build --features source-build
+```sh
+OCCT_ROOT=/path/to/occt cargo build --features source-build
+```
 
 If `OCCT_ROOT` is not set, built binaries are cached under `target/`.
 
@@ -60,7 +121,7 @@ Primitive solids: box, cylinder, sphere, cone, torus — colored and exported as
 cargo run --example 01_primitives
 ```
 
-```rust
+```rust,no_run
 //! Primitive solids: box, cylinder, sphere, cone, torus — colored and exported as STEP + SVG.
 
 use cadrum::{DVec3, Solid};
@@ -107,7 +168,7 @@ Read and write: chain STEP, BRep text, and BRep binary round-trips with progress
 cargo run --example 02_write_read
 ```
 
-```rust
+```rust,no_run
 //! Read and write: chain STEP, BRep text, and BRep binary round-trips with progressive rotation.
 
 use cadrum::{Compound, DVec3, Solid};
@@ -182,7 +243,7 @@ Transform operations: translate, rotate, scale, and mirror applied to a cone.
 cargo run --example 03_transform
 ```
 
-```rust
+```rust,no_run
 //! Transform operations: translate, rotate, scale, and mirror applied to a cone.
 
 use cadrum::{DVec3, Solid};
@@ -240,7 +301,7 @@ Boolean operations: union, subtract, and intersect between a box and a cylinder.
 cargo run --example 04_boolean
 ```
 
-```rust
+```rust,no_run
 //! Boolean operations: union, subtract, and intersect between a box and a cylinder.
 
 use cadrum::{Compound, DVec3, Solid};
@@ -294,7 +355,7 @@ Demo of `Solid::extrude`: push a closed 2D profile along a direction vector.
 cargo run --example 05_extrude
 ```
 
-```rust
+```rust,no_run
 //! Demo of `Solid::extrude`: push a closed 2D profile along a direction vector.
 //!
 //! - **Box**: square polygon extruded along Z
@@ -387,7 +448,7 @@ Demo of `Solid::loft`: skin a smooth solid through cross-section wires.
 cargo run --example 06_loft
 ```
 
-```rust
+```rust,no_run
 //! Demo of `Solid::loft`: skin a smooth solid through cross-section wires.
 //!
 //! - **Frustum**: two circles of different radii → truncated cone (minimal loft)
@@ -462,7 +523,7 @@ Sweep showcase: M2 screw (helix spine) + U-shaped pipe (line+arc+line spine)
 cargo run --example 07_sweep
 ```
 
-```rust
+```rust,no_run
 //! Sweep showcase: M2 screw (helix spine) + U-shaped pipe (line+arc+line spine)
 //! + twisted ribbon (`Auxiliary` aux-spine mode).
 //!
@@ -608,7 +669,7 @@ Demo of `Solid::shell`:
 cargo run --example 08_shell
 ```
 
-```rust
+```rust,no_run
 //! Demo of `Solid::shell`:
 //! - Cube: remove top face, offset inward → open-top container
 //! - Sealed cube: empty open_faces → solid with an internal void (outer skin
@@ -685,7 +746,7 @@ fn main() -> Result<(), Error> {
 cargo run --example 09_bspline
 ```
 
-```rust
+```rust,no_run
 use cadrum::{DQuat, DVec3, Solid};
 use std::f64::consts::TAU;
 
@@ -748,7 +809,7 @@ Demo of `Solid::fillet_edges`:
 cargo run --example 10_fillet
 ```
 
-```rust
+```rust,no_run
 //! Demo of `Solid::fillet_edges`:
 //! - All 12 cube edges filleted uniformly (rounded cube)
 //! - Only top 4 edges filleted (soft top, sharp base)
@@ -816,7 +877,7 @@ Demo of `Solid::chamfer_edges` — mirror of `10_fillet.rs` using bevels:
 cargo run --example 11_chamfer
 ```
 
-```rust
+```rust,no_run
 //! Demo of `Solid::chamfer_edges` — mirror of `10_fillet.rs` using bevels:
 //! - All 12 cube edges chamfered uniformly (beveled cube)
 //! - Only top 4 edges chamfered (soft top, sharp base)
@@ -877,12 +938,196 @@ fn main() -> Result<(), Error> {
 </p>
 
 
+## The Type Map
+
+Three concrete shape types and two trait umbrellas form the whole public
+surface:
+
+```text
+    Edge  ── single 3D curve         ┐
+    Face  ── trimmed 3D surface      │ concrete BRep handles
+    Solid ── connected closed body   ┘
+
+    Wire     ── trait carrying methods on Edge / Vec<Edge> / [Edge; N]
+    Compound ── trait carrying methods on Solid / Vec<Solid> / [Solid; N]
+```
+
+On a single `Solid` or single `Edge`, every method is reachable inherently —
+no trait import needed:
+
+```rust,no_run
+# use cadrum::{DVec3, Solid};
+let s = Solid::cube(1.0, 1.0, 1.0).rotate_z(0.5).translate(DVec3::X);
+let v = s.volume();
+```
+
+On a `Vec<Solid>` or `[Solid; N]`, the same operations live behind the
+`Compound` trait. A single `use cadrum::Compound;` brings them into scope
+on the collection — including the spatial transforms, which on collections
+distribute element-wise:
+
+```rust,no_run
+use cadrum::{Compound, DVec3, Solid};
+
+let parts: Vec<Solid> = vec![
+    Solid::cube(1.0, 1.0, 1.0),
+    Solid::sphere(1.0),
+];
+let shifted = parts.translate(DVec3::X * 5.0);
+let total   = shifted.volume();        // Σ per-element volumes
+let bbox    = shifted.bounding_box();  // union AABB
+```
+
+`Vec<Edge>` plays the equivalent role for wires (open or closed polylines
+made of edges) under `Wire`. There is no separate `Wire` type — an ordered
+`Vec<Edge>` *is* a wire, and sweep / loft / extrude all take any
+`IntoIterator<Item = &Edge>`.
+
+### Spatial transforms across the whole hierarchy
+
+The transform family — `translate`, `rotate`, `rotate_x` / `_y` / `_z`,
+`scale`, `mirror`, `align_x` / `_y` / `_z` — is implemented identically on
+every shape and every collection. The same method name and signature works
+on:
+
+- a single `Solid` — `cube.rotate_z(angle)`
+- a single `Edge` — `circle.translate(offset)`
+- `Vec<Solid>` / `[Solid; N]` via `Compound` — element-wise
+- `Vec<Edge>` / `[Edge; N]` via `Wire` — element-wise
+
+```rust,no_run
+use cadrum::{Compound, DVec3, Edge, Solid, Wire};
+use std::f64::consts::FRAC_PI_4;
+
+let s: Solid          = Solid::sphere(1.0).translate(DVec3::X);
+let e: Edge           = Edge::circle(1.0, DVec3::Z)?.rotate_x(FRAC_PI_4);
+let v_s: Vec<Solid>   = vec![Solid::cube(1.0, 1.0, 1.0)].translate(DVec3::Y);
+let v_e: Vec<Edge>    = Edge::polygon(&[
+    DVec3::ZERO, DVec3::X, DVec3::X + DVec3::Y, DVec3::Y,
+])?.rotate_z(FRAC_PI_4);
+# Ok::<(), cadrum::Error>(())
+```
+
+On `Solid` / `Edge` themselves the methods are inherent (no import
+required); on collections `use cadrum::Compound;` / `use cadrum::Wire;`
+brings them into scope.
+
+## Working with Wires
+
+Wire constructors return either a single `Edge` or `Vec<Edge>` depending on
+what is natural for the curve:
+
+```rust,no_run
+use cadrum::{BSplineEnd, DVec3, Edge};
+
+// Single-edge primitives → Edge
+let line   = Edge::line(DVec3::ZERO, DVec3::X)?;
+let arc    = Edge::arc_3pts(DVec3::ZERO, DVec3::X, DVec3::Y)?;
+let circle = Edge::circle(1.0, DVec3::Z)?;
+let helix  = Edge::helix(1.0, 0.4, 6.0, DVec3::Z, DVec3::X)?;
+
+// Multi-edge primitive → Vec<Edge>
+let square = Edge::polygon(&[
+    DVec3::new(0.0, 0.0, 0.0),
+    DVec3::new(1.0, 0.0, 0.0),
+    DVec3::new(1.0, 1.0, 0.0),
+    DVec3::new(0.0, 1.0, 0.0),
+])?;
+
+// Free-form curve → Edge (single B-spline)
+let curve = Edge::bspline(
+    &[DVec3::ZERO, DVec3::X, DVec3::X + DVec3::Y, DVec3::Y],
+    BSplineEnd::NotAKnot,
+)?;
+# Ok::<(), cadrum::Error>(())
+```
+
+Either shape feeds `Solid::extrude`, `Solid::sweep`, or `Solid::loft`
+uniformly because they take `IntoIterator<Item = &Edge>`:
+
+```rust,no_run
+# use cadrum::{DVec3, Edge, Solid};
+# let circle = Edge::circle(1.0, DVec3::Z)?;
+# let square: Vec<Edge> = vec![];
+let s1 = Solid::extrude(&[circle], DVec3::Z * 5.0)?;
+let s2 = Solid::extrude(&square,   DVec3::Z * 5.0)?;
+# Ok::<(), cadrum::Error>(())
+```
+
+Pass a single edge as `&[edge]` rather than relying on a sugar that lets
+`&edge` adapt — the slice form keeps the "this function consumes a
+collection" intent visible at the call site.
+
+## Booleans and Topology History
+
+Boolean operations return `Vec<Solid>` because a subtraction or
+intersection can split into several disjoint pieces. Each result solid
+carries a `Solid::iter_history` log of `[post_id, src_id]` pairs — every
+face in the result remembers which face of which input it came from. That
+makes face selectors stable across boolean stages:
+
+```rust,no_run
+use cadrum::{Compound, DVec3, Solid};
+
+let block = Solid::cube(20.0, 20.0, 20.0);
+let hole  = Solid::cylinder(8.0, DVec3::Z, 30.0)
+    .translate(DVec3::new(10.0, 10.0, -5.0));
+
+let drilled = block.subtract(&[hole])?;
+let from_block: Vec<u64> = drilled[0]
+    .iter_history()
+    .filter(|[_, src]| *src == block.id())   // faces inherited from `block`
+    .map(|[post, _]| post)
+    .collect();
+# Ok::<(), cadrum::Error>(())
+```
+
+See `examples/08_shell.rs` for a worked end-to-end use of this mechanism
+(shelling a torus through cut faces produced by a half-space subtraction).
+
+## Mesh and Visual Output
+
+`Solid::mesh` flattens any number of solids into a single triangle `Mesh`
+using OCCT's BRep mesher (`BRepMesh_IncrementalMesh`). From a `Mesh`,
+`Mesh::write_stl` emits a standard binary STL and `Mesh::write_svg`
+renders a hidden-line-removed 2D projection — handy for documentation and
+quick visual diffs:
+
+```rust,no_run
+use cadrum::{DVec3, Solid};
+
+let parts = [Solid::cube(10.0, 20.0, 30.0)];
+let mesh  = Solid::mesh(&parts, 0.5)?;
+
+mesh.write_stl(&mut std::fs::File::create("out.stl").unwrap())?;
+mesh.write_svg(
+    DVec3::ONE,   // view direction
+    DVec3::Z,     // up direction
+    true,         // include hidden lines (dashed)
+    false,        // Lambertian shading off
+    &mut std::fs::File::create("out.svg").unwrap(),
+)?;
+# Ok::<(), cadrum::Error>(())
+```
+
+## Errors
+
+Every fallible operation returns `Result<T, Error>` with `Error`
+enumerating the failure modes (`Error::SweepFailed`,
+`Error::FilletFailed`, `Error::InvalidEdge`, etc.). Variants that need
+detail carry a `String` payload identifying which constructor or parameter
+combination tripped OCCT, so panics are reserved for true logic bugs.
+
 ## Features
 
-- `color` (default): Colored STEP I/O via XDE. Enables `write_step_with_colors`,
-  `read_step_with_colors`, and per-face color on `Solid`.
-- `source-build`: Download and build OCCT from upstream sources via CMake.
-  Enable this on triples without a published prebuilt.
+- **`color`** *(default)*: Enables `Solid::color` and per-face colormap
+  propagation through STEP / BRep / STL / SVG I/O via OCCT's XDE document
+  model. Disable for a smaller binary if shape color is irrelevant.
+- **`source-build`**: When the prebuilt-binary cache is empty, fall back
+  to building OCCT from upstream sources via CMake instead of failing.
+  Required on targets without a published prebuilt (anything outside the
+  four-way Linux / Windows × x86_64 / aarch64 table). Pulls `cmake` in as
+  a build-dep.
 
 ## Showcase
 
@@ -953,7 +1198,21 @@ Aggregated changes since 0.6.0 (no separate entries were written for 0.6.1 – 0
 
 This project is licensed under the MIT License.
 
-Compiled binaries include [OpenCASCADE Technology](https://dev.opencascade.org/) (OCCT),
-which is licensed under the [LGPL 2.1](https://dev.opencascade.org/resources/licensing).
+Compiled binaries include [OpenCASCADE Technology][occt] (OCCT),
+which is licensed under the [LGPL 2.1][occt-license].
 Users who distribute applications built with cadrum must comply with the LGPL 2.1 terms.
 Since cadrum builds OCCT from source, end users can rebuild and relink OCCT to satisfy this requirement.
+
+<!-- Badges -->
+[license_img]: https://img.shields.io/github/license/lzpel/cadrum
+[license_link]: https://github.com/lzpel/cadrum/blob/main/LICENSE
+[crate_img]: https://img.shields.io/crates/v/cadrum.svg?logo=rust
+[crate_link]: https://crates.io/crates/cadrum
+[docsrs_img]: https://img.shields.io/docsrs/cadrum?logo=docsdotrs&label=docs.rs
+[docsrs_link]: https://docs.rs/cadrum
+[book_img]: https://img.shields.io/badge/docs-lzpel.github.io%2Fcadrum-blue
+[book_link]: https://lzpel.github.io/cadrum
+
+<!-- External References -->
+[occt]: https://dev.opencascade.org/
+[occt-license]: https://dev.opencascade.org/resources/licensing

--- a/examples/codegen.rs
+++ b/examples/codegen.rs
@@ -277,8 +277,8 @@ fn regenerate(src: &str, traits: &[TraitDef]) -> String {
 			for j in cursor..=i {
 				out.push(lines[j].to_string());
 			}
-			let indent: String = lines[i].chars().take_while(|c| *c == ' ' || *c == '\t').collect();
 			let depth = depths[i];
+			let indent: String = "\t".repeat(depth as usize);
 			let region_end = compute_region_end(&depths, i, depth);
 			let context = determine_context(&lines, i, &depths, depth);
 			out.extend(render(&context, &indent, traits));

--- a/examples/markdown.rs
+++ b/examples/markdown.rs
@@ -152,7 +152,10 @@ fn render_example(entry: &Entry, outputs: &[(PathBuf, Vec<u8>)]) -> String {
 		s.push_str(&format!("\n{}\n", desc));
 	}
 	s.push_str(&format!("\n```sh\ncargo run --example {}\n```\n", stem));
-	s.push_str(&format!("\n```rust\n{}\n```\n", entry.content));
+	// `rust,no_run`: the README is `include_str!`'d into `src/lib.rs`, so each
+	// example program would otherwise become a doctest that `cargo test` tries
+	// to compile and run (slow + writes files). `no_run` keeps the type check.
+	s.push_str(&format!("\n```rust,no_run\n{}\n```\n", entry.content));
 	s.push_str(&render_assets(entry, outputs));
 	s.push('\n');
 	s

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,4 @@
-//! # cadrum
-//!
-//! Rust CAD library powered by OpenCASCADE (OCCT 8.0.0-rc5).
-//!
-//! ## Core Types
-//! - [`Solid`] — a single solid shape (wraps `TopoDS_Shape` / `TopAbs_SOLID`)
-//! - [`Solid`] has all methods directly (no trait import needed)
+#![doc = include_str!("../README.md")]
 
 pub mod common;
 #[cfg(not(feature = "pure"))]
@@ -44,92 +38,92 @@ pub use glam;
 // `cargo run --example codegen` whenever src/traits.rs is modified.
 impl Edge{
     ////////// codegen.rs
-    pub fn id(&self) -> u64 {<Self as crate::traits::EdgeStruct>::id(self)}
-    pub fn helix(radius: f64, pitch: f64, height: f64, axis: DVec3, x_ref: DVec3) -> Result<crate::Edge, Error> {<Self as crate::traits::EdgeStruct>::helix(radius, pitch, height, axis, x_ref)}
-    pub fn polygon<'a>(points: impl IntoIterator<Item = &'a DVec3>) -> Result<Vec<crate::Edge>, Error> {<Self as crate::traits::EdgeStruct>::polygon(points)}
-    pub fn circle(radius: f64, axis: DVec3) -> Result<crate::Edge, Error> {<Self as crate::traits::EdgeStruct>::circle(radius, axis)}
-    pub fn line(a: DVec3, b: DVec3) -> Result<crate::Edge, Error> {<Self as crate::traits::EdgeStruct>::line(a, b)}
-    pub fn arc_3pts(start: DVec3, mid: DVec3, end: DVec3) -> Result<crate::Edge, Error> {<Self as crate::traits::EdgeStruct>::arc_3pts(start, mid, end)}
-    pub fn bspline<'a>(points: impl IntoIterator<Item = &'a DVec3>, end: BSplineEnd) -> Result<crate::Edge, Error> {<Self as crate::traits::EdgeStruct>::bspline(points, end)}
-    pub fn iter_elem(&self) -> impl Iterator<Item = &crate::Edge> + '_ {<Self as crate::traits::Wire>::iter_elem(self)}
-    pub fn map_elem(self, f: impl FnMut(crate::Edge) -> crate::Edge) -> crate::Edge {<Self as crate::traits::Wire>::map_elem(self, f)}
-    pub fn start_point(&self) -> DVec3 {<Self as crate::traits::Wire>::start_point(self)}
-    pub fn end_point(&self) -> DVec3 {<Self as crate::traits::Wire>::end_point(self)}
-    pub fn start_tangent(&self) -> DVec3 {<Self as crate::traits::Wire>::start_tangent(self)}
-    pub fn end_tangent(&self) -> DVec3 {<Self as crate::traits::Wire>::end_tangent(self)}
-    pub fn is_closed(&self) -> bool {<Self as crate::traits::Wire>::is_closed(self)}
-    pub fn approximation_segments(&self, tolerance: f64) -> Vec<DVec3> {<Self as crate::traits::Wire>::approximation_segments(self, tolerance)}
-    pub fn project(&self, p: DVec3) -> (DVec3, DVec3) {<Self as crate::traits::Wire>::project(self, p)}
-    pub fn translate(self, translation: DVec3) -> crate::Edge {<Self as crate::traits::Wire>::translate(self, translation)}
-    pub fn rotate(self, axis_origin: DVec3, axis_direction: DVec3, angle: f64) -> crate::Edge {<Self as crate::traits::Wire>::rotate(self, axis_origin, axis_direction, angle)}
-    pub fn rotate_x(self, angle: f64) -> crate::Edge {<Self as crate::traits::Wire>::rotate_x(self, angle)}
-    pub fn rotate_y(self, angle: f64) -> crate::Edge {<Self as crate::traits::Wire>::rotate_y(self, angle)}
-    pub fn rotate_z(self, angle: f64) -> crate::Edge {<Self as crate::traits::Wire>::rotate_z(self, angle)}
-    pub fn scale(self, center: DVec3, factor: f64) -> crate::Edge {<Self as crate::traits::Wire>::scale(self, center, factor)}
-    pub fn mirror(self, plane_origin: DVec3, plane_normal: DVec3) -> crate::Edge {<Self as crate::traits::Wire>::mirror(self, plane_origin, plane_normal)}
-    pub fn align_x(self, new_x: DVec3, y_hint: DVec3) -> crate::Edge {<Self as crate::traits::Wire>::align_x(self, new_x, y_hint)}
-    pub fn align_y(self, new_y: DVec3, z_hint: DVec3) -> crate::Edge {<Self as crate::traits::Wire>::align_y(self, new_y, z_hint)}
-    pub fn align_z(self, new_z: DVec3, x_hint: DVec3) -> crate::Edge {<Self as crate::traits::Wire>::align_z(self, new_z, x_hint)}
+	pub fn id(&self) -> u64 {<Self as crate::traits::EdgeStruct>::id(self)}
+	pub fn helix(radius: f64, pitch: f64, height: f64, axis: DVec3, x_ref: DVec3) -> Result<crate::Edge, Error> {<Self as crate::traits::EdgeStruct>::helix(radius, pitch, height, axis, x_ref)}
+	pub fn polygon<'a>(points: impl IntoIterator<Item = &'a DVec3>) -> Result<Vec<crate::Edge>, Error> {<Self as crate::traits::EdgeStruct>::polygon(points)}
+	pub fn circle(radius: f64, axis: DVec3) -> Result<crate::Edge, Error> {<Self as crate::traits::EdgeStruct>::circle(radius, axis)}
+	pub fn line(a: DVec3, b: DVec3) -> Result<crate::Edge, Error> {<Self as crate::traits::EdgeStruct>::line(a, b)}
+	pub fn arc_3pts(start: DVec3, mid: DVec3, end: DVec3) -> Result<crate::Edge, Error> {<Self as crate::traits::EdgeStruct>::arc_3pts(start, mid, end)}
+	pub fn bspline<'a>(points: impl IntoIterator<Item = &'a DVec3>, end: BSplineEnd) -> Result<crate::Edge, Error> {<Self as crate::traits::EdgeStruct>::bspline(points, end)}
+	pub fn iter_elem(&self) -> impl Iterator<Item = &crate::Edge> + '_ {<Self as crate::traits::Wire>::iter_elem(self)}
+	pub fn map_elem(self, f: impl FnMut(crate::Edge) -> crate::Edge) -> crate::Edge {<Self as crate::traits::Wire>::map_elem(self, f)}
+	pub fn start_point(&self) -> DVec3 {<Self as crate::traits::Wire>::start_point(self)}
+	pub fn end_point(&self) -> DVec3 {<Self as crate::traits::Wire>::end_point(self)}
+	pub fn start_tangent(&self) -> DVec3 {<Self as crate::traits::Wire>::start_tangent(self)}
+	pub fn end_tangent(&self) -> DVec3 {<Self as crate::traits::Wire>::end_tangent(self)}
+	pub fn is_closed(&self) -> bool {<Self as crate::traits::Wire>::is_closed(self)}
+	pub fn approximation_segments(&self, tolerance: f64) -> Vec<DVec3> {<Self as crate::traits::Wire>::approximation_segments(self, tolerance)}
+	pub fn project(&self, p: DVec3) -> (DVec3, DVec3) {<Self as crate::traits::Wire>::project(self, p)}
+	pub fn translate(self, translation: DVec3) -> crate::Edge {<Self as crate::traits::Wire>::translate(self, translation)}
+	pub fn rotate(self, axis_origin: DVec3, axis_direction: DVec3, angle: f64) -> crate::Edge {<Self as crate::traits::Wire>::rotate(self, axis_origin, axis_direction, angle)}
+	pub fn rotate_x(self, angle: f64) -> crate::Edge {<Self as crate::traits::Wire>::rotate_x(self, angle)}
+	pub fn rotate_y(self, angle: f64) -> crate::Edge {<Self as crate::traits::Wire>::rotate_y(self, angle)}
+	pub fn rotate_z(self, angle: f64) -> crate::Edge {<Self as crate::traits::Wire>::rotate_z(self, angle)}
+	pub fn scale(self, center: DVec3, factor: f64) -> crate::Edge {<Self as crate::traits::Wire>::scale(self, center, factor)}
+	pub fn mirror(self, plane_origin: DVec3, plane_normal: DVec3) -> crate::Edge {<Self as crate::traits::Wire>::mirror(self, plane_origin, plane_normal)}
+	pub fn align_x(self, new_x: DVec3, y_hint: DVec3) -> crate::Edge {<Self as crate::traits::Wire>::align_x(self, new_x, y_hint)}
+	pub fn align_y(self, new_y: DVec3, z_hint: DVec3) -> crate::Edge {<Self as crate::traits::Wire>::align_y(self, new_y, z_hint)}
+	pub fn align_z(self, new_z: DVec3, x_hint: DVec3) -> crate::Edge {<Self as crate::traits::Wire>::align_z(self, new_z, x_hint)}
 }
 impl Face{
     ////////// codegen.rs
-    pub fn id(&self) -> u64 {<Self as crate::traits::FaceStruct>::id(self)}
-    pub fn project(&self, p: DVec3) -> (DVec3, DVec3) {<Self as crate::traits::FaceStruct>::project(self, p)}
-    pub fn iter_edge(&self) -> impl Iterator<Item = &Edge> + '_ {<Self as crate::traits::FaceStruct>::iter_edge(self)}
+	pub fn id(&self) -> u64 {<Self as crate::traits::FaceStruct>::id(self)}
+	pub fn project(&self, p: DVec3) -> (DVec3, DVec3) {<Self as crate::traits::FaceStruct>::project(self, p)}
+	pub fn iter_edge(&self) -> impl Iterator<Item = &Edge> + '_ {<Self as crate::traits::FaceStruct>::iter_edge(self)}
 }
 impl Solid{
     ////////// codegen.rs
-    pub fn id(&self) -> u64 {<Self as crate::traits::SolidStruct>::id(self)}
-    pub fn cube(x: f64, y: f64, z: f64) -> crate::Solid {<Self as crate::traits::SolidStruct>::cube(x, y, z)}
-    pub fn sphere(radius: f64) -> crate::Solid {<Self as crate::traits::SolidStruct>::sphere(radius)}
-    pub fn cylinder(r: f64, axis: DVec3, h: f64) -> crate::Solid {<Self as crate::traits::SolidStruct>::cylinder(r, axis, h)}
-    pub fn cone(r1: f64, r2: f64, axis: DVec3, h: f64) -> crate::Solid {<Self as crate::traits::SolidStruct>::cone(r1, r2, axis, h)}
-    pub fn torus(r1: f64, r2: f64, axis: DVec3) -> crate::Solid {<Self as crate::traits::SolidStruct>::torus(r1, r2, axis)}
-    pub fn half_space(plane_origin: DVec3, plane_normal: DVec3) -> crate::Solid {<Self as crate::traits::SolidStruct>::half_space(plane_origin, plane_normal)}
-    pub fn iter_edge(&self) -> impl Iterator<Item = &Edge> + '_ {<Self as crate::traits::SolidStruct>::iter_edge(self)}
-    pub fn iter_face(&self) -> impl Iterator<Item = &Face> + '_ {<Self as crate::traits::SolidStruct>::iter_face(self)}
-    pub fn iter_history(&self) -> impl Iterator<Item = [u64; 2]> + '_ {<Self as crate::traits::SolidStruct>::iter_history(self)}
-    pub fn clean(&self) -> Result<crate::Solid, Error> {<Self as crate::traits::SolidStruct>::clean(self)}
-    pub fn extrude<'a>(profile: impl IntoIterator<Item = &'a Edge>, dir: DVec3) -> Result<crate::Solid, Error> where Edge: 'a {<Self as crate::traits::SolidStruct>::extrude(profile, dir)}
-    pub fn shell<'a>(&self, thickness: f64, open_faces: impl IntoIterator<Item = &'a Face>) -> Result<crate::Solid, Error> where Face: 'a {<Self as crate::traits::SolidStruct>::shell(self, thickness, open_faces)}
-    pub fn fillet_edges<'a>(&self, radius: f64, edges: impl IntoIterator<Item = &'a Edge>) -> Result<crate::Solid, Error> where Edge: 'a {<Self as crate::traits::SolidStruct>::fillet_edges(self, radius, edges)}
-    pub fn chamfer_edges<'a>(&self, distance: f64, edges: impl IntoIterator<Item = &'a Edge>) -> Result<crate::Solid, Error> where Edge: 'a {<Self as crate::traits::SolidStruct>::chamfer_edges(self, distance, edges)}
-    pub fn sweep<'a, 'b, 'c>(profile: impl IntoIterator<Item = &'a Edge>, spine: impl IntoIterator<Item = &'b Edge>, orient: ProfileOrient<'c>) -> Result<crate::Solid, Error> where Edge: 'a + 'b {<Self as crate::traits::SolidStruct>::sweep(profile, spine, orient)}
-    pub fn loft<'a, S, I>(sections: S) -> Result<crate::Solid, Error> where S: IntoIterator<Item = I>, I: IntoIterator<Item = &'a Edge>, Edge: 'a {<Self as crate::traits::SolidStruct>::loft(sections)}
-    pub fn bspline(u: usize, v: usize, u_periodic: bool, point: impl Fn(usize, usize) -> DVec3) -> Result<crate::Solid, Error> {<Self as crate::traits::SolidStruct>::bspline(u, v, u_periodic, point)}
-    pub fn boolean_union<'a, 'b>(a: impl IntoIterator<Item = &'a crate::Solid>, b: impl IntoIterator<Item = &'b crate::Solid>) -> Result<Vec<crate::Solid>, Error> where Self: 'a + 'b {<Self as crate::traits::SolidStruct>::boolean_union(a, b)}
-    pub fn boolean_subtract<'a, 'b>(a: impl IntoIterator<Item = &'a crate::Solid>, b: impl IntoIterator<Item = &'b crate::Solid>) -> Result<Vec<crate::Solid>, Error> where Self: 'a + 'b {<Self as crate::traits::SolidStruct>::boolean_subtract(a, b)}
-    pub fn boolean_intersect<'a, 'b>(a: impl IntoIterator<Item = &'a crate::Solid>, b: impl IntoIterator<Item = &'b crate::Solid>) -> Result<Vec<crate::Solid>, Error> where Self: 'a + 'b {<Self as crate::traits::SolidStruct>::boolean_intersect(a, b)}
-    pub fn read_step<R: std::io::Read>(reader: &mut R) -> Result<Vec<crate::Solid>, Error> {<Self as crate::traits::SolidStruct>::read_step(reader)}
-    pub fn read_brep_binary<R: std::io::Read>(reader: &mut R) -> Result<Vec<crate::Solid>, Error> {<Self as crate::traits::SolidStruct>::read_brep_binary(reader)}
-    pub fn read_brep_text<R: std::io::Read>(reader: &mut R) -> Result<Vec<crate::Solid>, Error> {<Self as crate::traits::SolidStruct>::read_brep_text(reader)}
-    pub fn write_step<'a, W: std::io::Write>(solids: impl IntoIterator<Item = &'a crate::Solid>, writer: &mut W) -> Result<(), Error> where Self: 'a {<Self as crate::traits::SolidStruct>::write_step(solids, writer)}
-    pub fn write_brep_binary<'a, W: std::io::Write>(solids: impl IntoIterator<Item = &'a crate::Solid>, writer: &mut W) -> Result<(), Error> where Self: 'a {<Self as crate::traits::SolidStruct>::write_brep_binary(solids, writer)}
-    pub fn write_brep_text<'a, W: std::io::Write>(solids: impl IntoIterator<Item = &'a crate::Solid>, writer: &mut W) -> Result<(), Error> where Self: 'a {<Self as crate::traits::SolidStruct>::write_brep_text(solids, writer)}
-    pub fn mesh<'a>(solids: impl IntoIterator<Item = &'a crate::Solid>, tolerance: f64) -> Result<Mesh, Error> where Self: 'a {<Self as crate::traits::SolidStruct>::mesh(solids, tolerance)}
-    pub fn iter_elem(&self) -> impl Iterator<Item = &crate::Solid> + '_ {<Self as crate::traits::Compound>::iter_elem(self)}
-    pub fn map_elem(self, f: impl FnMut(crate::Solid) -> crate::Solid) -> crate::Solid {<Self as crate::traits::Compound>::map_elem(self, f)}
-    pub fn volume(&self) -> f64 {<Self as crate::traits::Compound>::volume(self)}
-    pub fn area(&self) -> f64 {<Self as crate::traits::Compound>::area(self)}
-    pub fn contains(&self, point: DVec3) -> bool {<Self as crate::traits::Compound>::contains(self, point)}
-    pub fn bounding_box(&self) -> [DVec3; 2] {<Self as crate::traits::Compound>::bounding_box(self)}
-    pub fn center(&self) -> DVec3 {<Self as crate::traits::Compound>::center(self)}
-    pub fn inertia(&self) -> DMat3 {<Self as crate::traits::Compound>::inertia(self)}
-    #[cfg(feature = "color")]
-    pub fn color(self, color: impl Into<Color>) -> crate::Solid {<Self as crate::traits::Compound>::color(self, color)}
-    #[cfg(feature = "color")]
-    pub fn color_clear(self) -> crate::Solid {<Self as crate::traits::Compound>::color_clear(self)}
-    pub fn union<'a>(&self, tool: impl IntoIterator<Item = &'a crate::Solid>) -> Result<Vec<crate::Solid>, Error> where crate::Solid: 'a {<Self as crate::traits::Compound>::union(self, tool)}
-    pub fn subtract<'a>(&self, tool: impl IntoIterator<Item = &'a crate::Solid>) -> Result<Vec<crate::Solid>, Error> where crate::Solid: 'a {<Self as crate::traits::Compound>::subtract(self, tool)}
-    pub fn intersect<'a>(&self, tool: impl IntoIterator<Item = &'a crate::Solid>) -> Result<Vec<crate::Solid>, Error> where crate::Solid: 'a {<Self as crate::traits::Compound>::intersect(self, tool)}
-    pub fn translate(self, translation: DVec3) -> crate::Solid {<Self as crate::traits::Compound>::translate(self, translation)}
-    pub fn rotate(self, axis_origin: DVec3, axis_direction: DVec3, angle: f64) -> crate::Solid {<Self as crate::traits::Compound>::rotate(self, axis_origin, axis_direction, angle)}
-    pub fn rotate_x(self, angle: f64) -> crate::Solid {<Self as crate::traits::Compound>::rotate_x(self, angle)}
-    pub fn rotate_y(self, angle: f64) -> crate::Solid {<Self as crate::traits::Compound>::rotate_y(self, angle)}
-    pub fn rotate_z(self, angle: f64) -> crate::Solid {<Self as crate::traits::Compound>::rotate_z(self, angle)}
-    pub fn scale(self, center: DVec3, factor: f64) -> crate::Solid {<Self as crate::traits::Compound>::scale(self, center, factor)}
-    pub fn mirror(self, plane_origin: DVec3, plane_normal: DVec3) -> crate::Solid {<Self as crate::traits::Compound>::mirror(self, plane_origin, plane_normal)}
-    pub fn align_x(self, new_x: DVec3, y_hint: DVec3) -> crate::Solid {<Self as crate::traits::Compound>::align_x(self, new_x, y_hint)}
-    pub fn align_y(self, new_y: DVec3, z_hint: DVec3) -> crate::Solid {<Self as crate::traits::Compound>::align_y(self, new_y, z_hint)}
-    pub fn align_z(self, new_z: DVec3, x_hint: DVec3) -> crate::Solid {<Self as crate::traits::Compound>::align_z(self, new_z, x_hint)}
+	pub fn id(&self) -> u64 {<Self as crate::traits::SolidStruct>::id(self)}
+	pub fn cube(x: f64, y: f64, z: f64) -> crate::Solid {<Self as crate::traits::SolidStruct>::cube(x, y, z)}
+	pub fn sphere(radius: f64) -> crate::Solid {<Self as crate::traits::SolidStruct>::sphere(radius)}
+	pub fn cylinder(r: f64, axis: DVec3, h: f64) -> crate::Solid {<Self as crate::traits::SolidStruct>::cylinder(r, axis, h)}
+	pub fn cone(r1: f64, r2: f64, axis: DVec3, h: f64) -> crate::Solid {<Self as crate::traits::SolidStruct>::cone(r1, r2, axis, h)}
+	pub fn torus(r1: f64, r2: f64, axis: DVec3) -> crate::Solid {<Self as crate::traits::SolidStruct>::torus(r1, r2, axis)}
+	pub fn half_space(plane_origin: DVec3, plane_normal: DVec3) -> crate::Solid {<Self as crate::traits::SolidStruct>::half_space(plane_origin, plane_normal)}
+	pub fn iter_edge(&self) -> impl Iterator<Item = &Edge> + '_ {<Self as crate::traits::SolidStruct>::iter_edge(self)}
+	pub fn iter_face(&self) -> impl Iterator<Item = &Face> + '_ {<Self as crate::traits::SolidStruct>::iter_face(self)}
+	pub fn iter_history(&self) -> impl Iterator<Item = [u64; 2]> + '_ {<Self as crate::traits::SolidStruct>::iter_history(self)}
+	pub fn clean(&self) -> Result<crate::Solid, Error> {<Self as crate::traits::SolidStruct>::clean(self)}
+	pub fn extrude<'a>(profile: impl IntoIterator<Item = &'a Edge>, dir: DVec3) -> Result<crate::Solid, Error> where Edge: 'a {<Self as crate::traits::SolidStruct>::extrude(profile, dir)}
+	pub fn shell<'a>(&self, thickness: f64, open_faces: impl IntoIterator<Item = &'a Face>) -> Result<crate::Solid, Error> where Face: 'a {<Self as crate::traits::SolidStruct>::shell(self, thickness, open_faces)}
+	pub fn fillet_edges<'a>(&self, radius: f64, edges: impl IntoIterator<Item = &'a Edge>) -> Result<crate::Solid, Error> where Edge: 'a {<Self as crate::traits::SolidStruct>::fillet_edges(self, radius, edges)}
+	pub fn chamfer_edges<'a>(&self, distance: f64, edges: impl IntoIterator<Item = &'a Edge>) -> Result<crate::Solid, Error> where Edge: 'a {<Self as crate::traits::SolidStruct>::chamfer_edges(self, distance, edges)}
+	pub fn sweep<'a, 'b, 'c>(profile: impl IntoIterator<Item = &'a Edge>, spine: impl IntoIterator<Item = &'b Edge>, orient: ProfileOrient<'c>) -> Result<crate::Solid, Error> where Edge: 'a + 'b {<Self as crate::traits::SolidStruct>::sweep(profile, spine, orient)}
+	pub fn loft<'a, S, I>(sections: S) -> Result<crate::Solid, Error> where S: IntoIterator<Item = I>, I: IntoIterator<Item = &'a Edge>, Edge: 'a {<Self as crate::traits::SolidStruct>::loft(sections)}
+	pub fn bspline(u: usize, v: usize, u_periodic: bool, point: impl Fn(usize, usize) -> DVec3) -> Result<crate::Solid, Error> {<Self as crate::traits::SolidStruct>::bspline(u, v, u_periodic, point)}
+	pub fn boolean_union<'a, 'b>(a: impl IntoIterator<Item = &'a crate::Solid>, b: impl IntoIterator<Item = &'b crate::Solid>) -> Result<Vec<crate::Solid>, Error> where Self: 'a + 'b {<Self as crate::traits::SolidStruct>::boolean_union(a, b)}
+	pub fn boolean_subtract<'a, 'b>(a: impl IntoIterator<Item = &'a crate::Solid>, b: impl IntoIterator<Item = &'b crate::Solid>) -> Result<Vec<crate::Solid>, Error> where Self: 'a + 'b {<Self as crate::traits::SolidStruct>::boolean_subtract(a, b)}
+	pub fn boolean_intersect<'a, 'b>(a: impl IntoIterator<Item = &'a crate::Solid>, b: impl IntoIterator<Item = &'b crate::Solid>) -> Result<Vec<crate::Solid>, Error> where Self: 'a + 'b {<Self as crate::traits::SolidStruct>::boolean_intersect(a, b)}
+	pub fn read_step<R: std::io::Read>(reader: &mut R) -> Result<Vec<crate::Solid>, Error> {<Self as crate::traits::SolidStruct>::read_step(reader)}
+	pub fn read_brep_binary<R: std::io::Read>(reader: &mut R) -> Result<Vec<crate::Solid>, Error> {<Self as crate::traits::SolidStruct>::read_brep_binary(reader)}
+	pub fn read_brep_text<R: std::io::Read>(reader: &mut R) -> Result<Vec<crate::Solid>, Error> {<Self as crate::traits::SolidStruct>::read_brep_text(reader)}
+	pub fn write_step<'a, W: std::io::Write>(solids: impl IntoIterator<Item = &'a crate::Solid>, writer: &mut W) -> Result<(), Error> where Self: 'a {<Self as crate::traits::SolidStruct>::write_step(solids, writer)}
+	pub fn write_brep_binary<'a, W: std::io::Write>(solids: impl IntoIterator<Item = &'a crate::Solid>, writer: &mut W) -> Result<(), Error> where Self: 'a {<Self as crate::traits::SolidStruct>::write_brep_binary(solids, writer)}
+	pub fn write_brep_text<'a, W: std::io::Write>(solids: impl IntoIterator<Item = &'a crate::Solid>, writer: &mut W) -> Result<(), Error> where Self: 'a {<Self as crate::traits::SolidStruct>::write_brep_text(solids, writer)}
+	pub fn mesh<'a>(solids: impl IntoIterator<Item = &'a crate::Solid>, tolerance: f64) -> Result<Mesh, Error> where Self: 'a {<Self as crate::traits::SolidStruct>::mesh(solids, tolerance)}
+	pub fn iter_elem(&self) -> impl Iterator<Item = &crate::Solid> + '_ {<Self as crate::traits::Compound>::iter_elem(self)}
+	pub fn map_elem(self, f: impl FnMut(crate::Solid) -> crate::Solid) -> crate::Solid {<Self as crate::traits::Compound>::map_elem(self, f)}
+	pub fn volume(&self) -> f64 {<Self as crate::traits::Compound>::volume(self)}
+	pub fn area(&self) -> f64 {<Self as crate::traits::Compound>::area(self)}
+	pub fn contains(&self, point: DVec3) -> bool {<Self as crate::traits::Compound>::contains(self, point)}
+	pub fn bounding_box(&self) -> [DVec3; 2] {<Self as crate::traits::Compound>::bounding_box(self)}
+	pub fn center(&self) -> DVec3 {<Self as crate::traits::Compound>::center(self)}
+	pub fn inertia(&self) -> DMat3 {<Self as crate::traits::Compound>::inertia(self)}
+	#[cfg(feature = "color")]
+	pub fn color(self, color: impl Into<Color>) -> crate::Solid {<Self as crate::traits::Compound>::color(self, color)}
+	#[cfg(feature = "color")]
+	pub fn color_clear(self) -> crate::Solid {<Self as crate::traits::Compound>::color_clear(self)}
+	pub fn union<'a>(&self, tool: impl IntoIterator<Item = &'a crate::Solid>) -> Result<Vec<crate::Solid>, Error> where crate::Solid: 'a {<Self as crate::traits::Compound>::union(self, tool)}
+	pub fn subtract<'a>(&self, tool: impl IntoIterator<Item = &'a crate::Solid>) -> Result<Vec<crate::Solid>, Error> where crate::Solid: 'a {<Self as crate::traits::Compound>::subtract(self, tool)}
+	pub fn intersect<'a>(&self, tool: impl IntoIterator<Item = &'a crate::Solid>) -> Result<Vec<crate::Solid>, Error> where crate::Solid: 'a {<Self as crate::traits::Compound>::intersect(self, tool)}
+	pub fn translate(self, translation: DVec3) -> crate::Solid {<Self as crate::traits::Compound>::translate(self, translation)}
+	pub fn rotate(self, axis_origin: DVec3, axis_direction: DVec3, angle: f64) -> crate::Solid {<Self as crate::traits::Compound>::rotate(self, axis_origin, axis_direction, angle)}
+	pub fn rotate_x(self, angle: f64) -> crate::Solid {<Self as crate::traits::Compound>::rotate_x(self, angle)}
+	pub fn rotate_y(self, angle: f64) -> crate::Solid {<Self as crate::traits::Compound>::rotate_y(self, angle)}
+	pub fn rotate_z(self, angle: f64) -> crate::Solid {<Self as crate::traits::Compound>::rotate_z(self, angle)}
+	pub fn scale(self, center: DVec3, factor: f64) -> crate::Solid {<Self as crate::traits::Compound>::scale(self, center, factor)}
+	pub fn mirror(self, plane_origin: DVec3, plane_normal: DVec3) -> crate::Solid {<Self as crate::traits::Compound>::mirror(self, plane_origin, plane_normal)}
+	pub fn align_x(self, new_x: DVec3, y_hint: DVec3) -> crate::Solid {<Self as crate::traits::Compound>::align_x(self, new_x, y_hint)}
+	pub fn align_y(self, new_y: DVec3, z_hint: DVec3) -> crate::Solid {<Self as crate::traits::Compound>::align_y(self, new_y, z_hint)}
+	pub fn align_z(self, new_z: DVec3, x_hint: DVec3) -> crate::Solid {<Self as crate::traits::Compound>::align_z(self, new_z, x_hint)}
 }


### PR DESCRIPTION
## Summary

Reference: <https://docs.rs/bitvec/latest/bitvec/> — the bitvec crate uses `#![doc = include_str!("../README.md")]` so that `README.md` is the single source of truth for both GitHub and docs.rs. This PR adopts the same pattern for cadrum, plus the related presentation conventions (centered top section, reference-style links, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`).

- Make `README.md` the single source of truth for crate-level documentation: `src/lib.rs` is reduced to `#![doc = include_str!("../README.md")]`.
- Move the bitvec-style prose (Summary / Introduction / Capabilities / Type Map / Working with Wires / Booleans / Mesh / Errors) from `src/lib.rs` into `README.md` so docs.rs and GitHub render the same content.
- Update `examples/markdown.rs` to emit ` ```rust,no_run ` fences for example programs (without this, every example becomes a slow doctest that compiles and runs once `include_str!` is in place).
- Restructure README's top section: centered `<div align="center">`, reference-style badge / link definitions, new `docs.rs` build-status badge.
- Add `CODE_OF_CONDUCT.md` (Rust CoC) and `CONTRIBUTING.md` (Makefile workflow + codegen / markdown regenerators + tab indentation).
- Normalize `examples/codegen.rs` region indent to tabs based on brace depth so regenerated impl blocks honor the project's tab-indent convention.

## Test plan

- [x] `cargo doc --no-deps --lib` — clean (no new warnings; pre-existing 5 warnings in `traits.rs` only).
- [x] `cargo test --doc` — 18/18 doctests compile-check pass in 0.14 s (`,no_run` keeps them from running).
- [ ] `make deploy` regenerates README's Usage / Examples sections without disturbing the new prose / reference defs.
- [ ] docs.rs build picks up the new README (verify after release).