### PR TITLE
chore: bump OCCT to V8_0_0 (GA)

### DIFF
--- a/.github/workflows/prebuilt.yaml
+++ b/.github/workflows/prebuilt.yaml
@@ -80,6 +80,6 @@ jobs:
 
       - uses: softprops/action-gh-release@v2
         with:
-          tag_name: cadrum-occt-v800beta1
-          name: OCCT prebuilt v8.0.0-beta1
+          tag_name: cadrum-occt-v800
+          name: OCCT prebuilt v8.0.0
           files: dist/*.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ This document is written according to the [Keep a Changelog][kac] style.
 `cadrum` is in the `0.x` series. Minor-version bumps may include breaking
 changes until `1.0`.
 
+### Unreleased
+
+#### Changes
+
+- **OCCT bumped to 8.0.0** (final release; was 8.0.0-beta1). No source
+  changes required — APIs deprecated/removed in V8_0_0 (`Standard_Mutex`,
+  OCCT math wrappers like `::Sin` / `::Cos`, `NCollection_BasePointerVector`,
+  `TColGeom`, `PLib_Base`, `BRepMesh_PluginMacro`) are unused by cadrum's
+  `cpp/wrapper.cpp`. The toolkit list (`TKernel`, `TKMath`, ..., `TKDESTEP`)
+  is unchanged.
+
 ### 0.7.6
 
 #### Notes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cadrum"
 version = "0.7.6"
 edition = "2021"
-description = "Rust CAD library powered by statically linked, headless OpenCASCADE (OCCT 8.0.0-beta1)"
+description = "Rust CAD library powered by statically linked, headless OpenCASCADE (OCCT 8.0.0)"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/lzpel/cadrum"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # cadrum
 
-Rust CAD library powered by statically linked, headless [OpenCASCADE][occt] (OCCT 8.0.0-beta1).
+Rust CAD library powered by statically linked, headless [OpenCASCADE][occt] (OCCT 8.0.0).
 
 [![GitHub License][license_img]][license_link]
 [![Crates.io][crate_img]][crate_link]
@@ -87,7 +87,7 @@ Add this to your `Cargo.toml`:
 cadrum = "^0.7"
 ```
 
-`cargo build` automatically downloads a prebuilt OCCT 8.0.0-rc5 binary for the targets below.
+`cargo build` automatically downloads a prebuilt OCCT 8.0.0 binary for the targets below.
 
 | | Target | Prebuilt |
 |--|--------|----------|

--- a/build.rs
+++ b/build.rs
@@ -4,10 +4,10 @@ use std::path::{Path, PathBuf};
 /// OCCT release used by cadrum. Update this tag when bumping OCCT versions.
 /// `cadrum_occt_name()` derives both the GitHub Release tag (no target) and
 /// the prebuilt tarball / cache directory name (with target) from this.
-const OCCT_VERSION: &str = "V8_0_0_beta1";
+const OCCT_VERSION: &str = "V8_0_0";
 
-/// `target` 指定あり: `cadrum-occt-v800beta1-x86_64-pc-windows-gnu` (tarball / cache dir 名)
-/// `target` 指定なし: `cadrum-occt-v800beta1` (`lzpel/cadrum` の GitHub Release タグ)
+/// `target` 指定あり: `cadrum-occt-v800-x86_64-pc-windows-gnu` (tarball / cache dir 名)
+/// `target` 指定なし: `cadrum-occt-v800` (`lzpel/cadrum` の GitHub Release タグ)
 fn cadrum_occt_name(target: Option<&str>) -> String {
 	let slug = OCCT_VERSION.to_ascii_lowercase().replace('_', "");
 	match target {


### PR DESCRIPTION
## Summary

- Bump pinned OCCT from `V8_0_0_beta1` to `V8_0_0` (GA, released 2026-05-07: https://github.com/Open-Cascade-SAS/OCCT/releases/tag/V8_0_0).
- Mechanical version sync only — `cpp/wrapper.cpp` is unchanged because the APIs deprecated/removed in V8_0_0 (`Standard_Mutex`, OCCT math wrappers like `::Sin`/`::Cos`, `NCollection_BasePointerVector`, `TColGeom`, `PLib_Base`, `BRepMesh_PluginMacro`) are not used by cadrum. Toolkit list (`TKernel`, `TKMath`, ..., `TKDESTEP`) is unchanged.
- C++17 baseline / `USE_VTK=OFF` / CMake 3.10+ requirements introduced in V8_0_0 are already satisfied by `build.rs`.

## Files touched

| File | Change |
|---|---|
| `build.rs` | `OCCT_VERSION`: `V8_0_0_beta1` → `V8_0_0` (slug auto-derives `v800`); doc-comment slug examples updated |
| `.github/workflows/prebuilt.yaml` | release `tag_name` / `name` synced to `cadrum-occt-v800` / `OCCT prebuilt v8.0.0` |
| `Cargo.toml` | `description` updated |
| `README.md` | header + Build section updated (also fixes a stale `8.0.0-rc5` mention) |
| `CHANGELOG.md` | new `### Unreleased` entry |

## Post-merge release sequence

`prebuilt.yaml` triggers on push to `prebuilt` branch or manual dispatch — **merging this PR alone does not republish the prebuilt tarballs**. After merge:

1. Fast-forward `prebuilt` branch to the new `main`, or `workflow_dispatch` the `prebuilt` workflow.
2. Matrix builds the 4 targets (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-pc-windows-gnu`, `x86_64-pc-windows-msvc`).
3. `softprops/action-gh-release@v2` creates the `cadrum-occt-v800` release with the 4 tarballs.
4. Until step 3 completes, downstream `cargo build` without `source-build` will fail — keep this PR un-merged or release together with the prebuilts.

Crate version bump (`Cargo.toml::version`) is intentionally **out of scope** for this PR.

## Test plan

- [ ] `cargo build --features source-build` builds OCCT V8_0_0 from source on at least one host (validates `patch_or_none` filenames still exist in V8_0_0 sources)
- [ ] `cargo test` passes under default / `--no-default-features --features pure` / `--features color`
- [ ] After merge: `prebuilt` workflow green for all 4 targets; fresh `cargo build` (prebuilt path) succeeds on at least one target