### PR TITLE
Remove Mesh::normals; compute face normals via cross product

### DIFF
--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -804,9 +804,6 @@ MeshData mesh_shape(const TopoDS_Shape& shape, double tolerance) {
         int nb_nodes = triangulation->NbNodes();
         int nb_triangles = triangulation->NbTriangles();
 
-        // Compute normals for this face
-        // Bug 3 fix: Use Poly_Triangulation::ComputeNormals + correct loop bounds
-
         // Vertices
         for (int i = 1; i <= nb_nodes; i++) {
             gp_Pnt p = triangulation->Node(i);
@@ -840,24 +837,6 @@ MeshData mesh_shape(const TopoDS_Shape& shape, double tolerance) {
             for (int i = 1; i <= nb_nodes; i++) {
                 result.uvs.push_back(0.0);
                 result.uvs.push_back(0.0);
-            }
-        }
-
-        // Normals - Bug 3 fix: iterate exactly nb_nodes times (1..=nb_nodes)
-        // Previous code used normal_array.Length() which was off-by-one.
-        if (!triangulation->HasNormals()) {
-            triangulation->ComputeNormals();
-        }
-        for (int i = 1; i <= nb_nodes; i++) {
-            gp_Dir normal = triangulation->Normal(i);
-            if (face.Orientation() == TopAbs_REVERSED) {
-                result.normals.push_back(-normal.X());
-                result.normals.push_back(-normal.Y());
-                result.normals.push_back(-normal.Z());
-            } else {
-                result.normals.push_back(normal.X());
-                result.normals.push_back(normal.Y());
-                result.normals.push_back(normal.Z());
             }
         }
 

--- a/src/common/mesh.rs
+++ b/src/common/mesh.rs
@@ -3,17 +3,6 @@ use super::color::Color;
 use glam::{DVec2, DVec3};
 use std::collections::HashMap;
 
-/// 3D edge polylines for SVG rendering.
-///
-/// Stores topological edges as 3D polylines. Visibility classification
-/// (visible vs hidden) is computed by [`Mesh::to_svg`] when hidden line
-/// rendering is enabled.
-#[derive(Debug, Clone, Default)]
-pub struct EdgeData {
-	/// 3D polylines representing topological edges.
-	pub polylines: Vec<Vec<DVec3>>,
-}
-
 /// A triangle mesh produced by meshing a solid shape.
 ///
 /// All vectors have the same length: one entry per vertex.
@@ -24,8 +13,6 @@ pub struct Mesh {
 	pub vertices: Vec<DVec3>,
 	/// UV coordinates, normalized to [0, 1] per face.
 	pub uvs: Vec<DVec2>,
-	/// Vertex normals.
-	pub normals: Vec<DVec3>,
 	/// Triangle indices (groups of 3, referencing into `vertices`).
 	pub indices: Vec<usize>,
 	/// Per-triangle face ID. Length equals `indices.len() / 3`.
@@ -34,7 +21,7 @@ pub struct Mesh {
 	#[cfg(feature = "color")]
 	pub colormap: HashMap<u64, Color>,
 	/// Topological edge polylines for SVG rendering.
-	pub edges: EdgeData,
+	pub edges: Vec<Vec<DVec3>>,
 }
 
 // ==================== STL ====================
@@ -131,7 +118,7 @@ impl Mesh {
 		let silhouette_edges = detect_silhouette_edges(self, dir);
 
 		// 3. Combine topological edges + silhouette edges
-		let all_edges: Vec<&Vec<DVec3>> = self.edges.polylines.iter().chain(silhouette_edges.iter()).collect();
+		let all_edges: Vec<&Vec<DVec3>> = self.edges.iter().chain(silhouette_edges.iter()).collect();
 
 		// 4. Classify edges. When hidden lines are disabled we still need to
 		//    drop occluded segments from the visible set, so build occlusion
@@ -147,6 +134,18 @@ impl Mesh {
 }
 
 // ==================== SVG internals ====================
+
+/// Per-triangle face normal from the cross product of its two edges.
+/// Not normalized — callers that need a unit vector should normalize.
+/// Sign convention matches the STL writer at `Mesh::write_stl`: outward-
+/// pointing for face-orientation-consistent winding (which OCCT meshing
+/// produces).
+fn tri_normal(mesh: &Mesh, ti: usize) -> DVec3 {
+	let i0 = mesh.indices[ti * 3];
+	let i1 = mesh.indices[ti * 3 + 1];
+	let i2 = mesh.indices[ti * 3 + 2];
+	(mesh.vertices[i1] - mesh.vertices[i0]).cross(mesh.vertices[i2] - mesh.vertices[i0])
+}
 
 struct SvgTriangle {
 	pts: [(f64, f64); 3],
@@ -195,8 +194,8 @@ fn project_and_sort_triangles(mesh: &Mesh, dir: DVec3, u: DVec3, v: DVec3, shadi
 		let v1 = mesh.vertices[i1];
 		let v2 = mesh.vertices[i2];
 
-		let avg_normal = (mesh.normals[i0] + mesh.normals[i1] + mesh.normals[i2]) / 3.0;
-		if avg_normal.dot(dir) < 0.0 {
+		let face_normal = tri_normal(mesh, ti);
+		if face_normal.dot(dir) < 0.0 {
 			continue;
 		}
 
@@ -208,13 +207,13 @@ fn project_and_sort_triangles(mesh: &Mesh, dir: DVec3, u: DVec3, v: DVec3, shadi
 
 		// Lambertian shading with head-on light (light direction == view direction).
 		// Front-facing triangles get `normal · dir ∈ (0, 1]`; normalize to handle
-		// the averaged normal's non-unit length. Shade maps [0, 1] → [0.5, 1.0]
+		// the face normal's non-unit length. Shade maps [0, 1] → [0.5, 1.0]
 		// so glancing faces darken to half-intensity (not black) — enough to
 		// read the 3D shape without swallowing the silhouette into the stroke.
 		// When `shading` is false, every triangle gets shade=1.0 → flat fill,
 		// matching the pre-shading output (`#ddd` for no-color path).
 		let shade = if shading {
-			let dot = avg_normal.normalize_or_zero().dot(dir).clamp(0.0, 1.0);
+			let dot = face_normal.normalize_or_zero().dot(dir).clamp(0.0, 1.0);
 			0.5 + 0.5 * dot
 		} else {
 			1.0
@@ -265,8 +264,7 @@ fn build_occlusion_data(mesh: &Mesh, dir: DVec3, u: DVec3, v: DVec3) -> Vec<Occl
 		let v1 = mesh.vertices[i1];
 		let v2 = mesh.vertices[i2];
 
-		let avg_normal = (mesh.normals[i0] + mesh.normals[i1] + mesh.normals[i2]) / 3.0;
-		if avg_normal.dot(dir) <= 0.0 {
+		if tri_normal(mesh, ti).dot(dir) <= 0.0 {
 			continue;
 		}
 
@@ -315,11 +313,7 @@ fn detect_silhouette_edges(mesh: &Mesh, dir: DVec3) -> Vec<Vec<DVec3>> {
 
 /// Returns true if triangle `ti` is front-facing relative to `dir`.
 fn tri_facing(mesh: &Mesh, ti: usize, dir: DVec3) -> bool {
-	let i0 = mesh.indices[ti * 3];
-	let i1 = mesh.indices[ti * 3 + 1];
-	let i2 = mesh.indices[ti * 3 + 2];
-	let avg_normal = (mesh.normals[i0] + mesh.normals[i1] + mesh.normals[i2]) / 3.0;
-	avg_normal.dot(dir) > 0.0
+	tri_normal(mesh, ti).dot(dir) > 0.0
 }
 
 /// Classify edge segments as visible or hidden based on triangle occlusion.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub use occt::solid::Solid;
 #[cfg(feature = "color")]
 pub use common::color::Color;
 pub use common::error::Error;
-pub use common::mesh::{EdgeData, Mesh};
+pub use common::mesh::Mesh;
 // Re-export glam types used in cadrum's public API. Users should reach glam
 // through these re-exports (or the `cadrum::glam` module below) instead of
 // adding a direct `glam` dependency — otherwise a mismatched glam minor

--- a/src/occt/ffi.rs
+++ b/src/occt/ffi.rs
@@ -7,7 +7,6 @@ mod ffi_bridge {
 	struct MeshData {
 		vertices: Vec<f64>, // flat xyz
 		uvs: Vec<f64>,      // flat uv
-		normals: Vec<f64>,  // flat xyz
 		indices: Vec<u32>,
 		face_tshape_ids: Vec<u64>, // per-triangle TShape* address
 		success: bool,

--- a/src/occt/io.rs
+++ b/src/occt/io.rs
@@ -199,7 +199,7 @@ fn write_brep_with<'a, W: Write>(solids: impl IntoIterator<Item = &'a Solid>, wr
 }
 
 pub(super) fn mesh<'a>(solids: impl IntoIterator<Item = &'a Solid>, tolerance: f64) -> Result<crate::common::mesh::Mesh, Error> {
-	use crate::common::mesh::{EdgeData, Mesh};
+	use crate::common::mesh::Mesh;
 	use glam::{DVec2, DVec3};
 
 	let compound = CompoundShape::new(solids);
@@ -210,7 +210,6 @@ pub(super) fn mesh<'a>(solids: impl IntoIterator<Item = &'a Solid>, tolerance: f
 	let vertex_count = data.vertices.len() / 3;
 	let vertices: Vec<DVec3> = (0..vertex_count).map(|i| DVec3::new(data.vertices[i * 3], data.vertices[i * 3 + 1], data.vertices[i * 3 + 2])).collect();
 	let uvs: Vec<DVec2> = (0..vertex_count).map(|i| DVec2::new(data.uvs[i * 2], data.uvs[i * 2 + 1])).collect();
-	let normals: Vec<DVec3> = (0..vertex_count).map(|i| DVec3::new(data.normals[i * 3], data.normals[i * 3 + 1], data.normals[i * 3 + 2])).collect();
 	let indices: Vec<usize> = data.indices.iter().map(|&i| i as usize).collect();
 	let face_ids = data.face_tshape_ids;
 
@@ -228,11 +227,10 @@ pub(super) fn mesh<'a>(solids: impl IntoIterator<Item = &'a Solid>, tolerance: f
 	Ok(Mesh {
 		vertices,
 		uvs,
-		normals,
 		indices,
 		face_ids,
 		#[cfg(feature = "color")]
 		colormap,
-		edges: EdgeData::default(),
+		edges: Vec::new(),
 	})
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6,7 +6,7 @@
 //! 各テスト名の `t0N` は合格基準番号に対応:
 //!   T-01: Bug 1 — ブール演算結果の drop 順序で STATUS_HEAP_CORRUPTION が起きない
 //!   T-02: Bug 2 — read_step 複数回呼び出し後にプロセスが正常終了する
-//!   T-03: Bug 3 — mesh.normals.len() == mesh.vertices.len()（法線 off-by-one）
+//!   T-03: 廃止（Mesh::normals フィールド削除に伴い検証対象が消滅）
 //!   T-04: Bug 4 — approximation_segments の tolerance が反映される（ハードコード脱却）
 //!   T-05: Bug 5 — union 後コンパウンドへの平行移動が全頂点に正確に反映される
 //!   T-06: I/O  — BRep バイナリの write→read ラウンドトリップ
@@ -111,17 +111,6 @@ fn test_t02_multiple_reads_no_crash() {
 	for _ in 0..5 {
 		let _shape = cadrum::Solid::read_brep_binary(&mut brep_data.as_slice()).unwrap();
 	}
-}
-
-// ==================== T-03: Mesh normals count ====================
-// Bug 3: 法線ループで normal_array.Length()（キャパシティ=頂点数+1）を上限に
-// 使っていたため normals が vertices より1つ少なかった。
-
-#[test]
-fn test_t03_mesh_normals_count() {
-	let shape = test_box();
-	let mesh = cadrum::Solid::mesh(&[shape], 0.1).unwrap();
-	assert_eq!(mesh.normals.len(), mesh.vertices.len());
 }
 
 // ==================== T-04: Approximation tolerance ====================


### PR DESCRIPTION
## Summary
- Drop `Mesh::normals` field. SVG (backface culling, silhouette detection, Lambertian shading) now computes face normals via cross product, matching what STL already does.
- Remove the OCCT `Poly_Triangulation::Normal()` extraction in `cpp/wrapper.cpp` and the `normals` payload in the FFI `MeshData` struct.
- Retire test T-03 (`mesh.normals.len() == mesh.vertices.len()`); the field no longer exists.

## Rationale
- STL never used `normals` (always recomputed via cross product). SVG used a centroid-averaged smooth normal, but on CAD output OCCT meshes each face independently and shading is per-triangle anyway, so the visual difference vs. a face cross-product normal is negligible.
- Removes 17 lines of C++, the `normals: Vec<f64>` FFI vector, ~24 bytes/vertex of Rust allocation, and a parallel array from the public `Mesh` struct.

## Test plan
- [x] `cargo build`
- [x] `cargo test` (no features)
- [x] `cargo test --features color`
- [x] `cargo run --example 01_primitives` — SVG output well-formed