### PR TITLE
Scene2D::write_png via tiny-skia + standardize examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ linkedin.md
 *.step
 *.stl
 *.svg
+*.png
 *.tar.gz
 uv.lock
 *.dockerignore

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "adler32"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,10 +36,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "cadrum"
@@ -48,6 +78,7 @@ dependencies = [
  "minreq",
  "regex",
  "tar",
+ "tiny-skia",
  "walkdir",
 ]
 
@@ -207,6 +238,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +262,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -303,7 +353,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
  "plain",
  "redox_syscall",
@@ -337,6 +387,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "minreq"
 version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,6 +423,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,7 +459,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -444,7 +517,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -535,6 +608,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +654,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,19 +11,25 @@ categories = ["graphics", "science"]
 exclude = ["/figure", "/notes", "/steps", "/sandbox*", "/.github"]
 
 [features]
-default = ["color"]
+default = ["color", "png"]
 # Enable TShapeId, Rgb, and colormap on Shape for face-level color tracking
 color = []
-# Pure Rust CAD backend (no OCCT dependency)
-pure = []
 # Build OCCT from upstream sources when the cache is empty, instead of
 # downloading a prebuilt tarball. Off by default — most users will use the
 # prebuilt binary path.
 source-build = ["dep:cmake"]
+# PNG raster output for Scene2D via tiny-skia.
+png = ["dep:tiny-skia"]
+# Pure Rust CAD backend (no OCCT dependency)
+pure = []
 
 [dependencies]
 cxx = "1"
 glam = { version = ">=0.29", features = ["std"] }
+# Pure-Rust 2D rasterizer used by Scene2D::write_png. Pulled in only with
+# the `png` feature; tiny-skia bundles its own PNG encoder so no separate
+# `png` crate dep is needed.
+tiny-skia = { version = "0.11", optional = true }
 
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -8,18 +8,18 @@ Rust CAD library powered by statically linked, headless [OpenCASCADE][occt] (OCC
 [![Crates.io][crate_img]][crate_link]
 [![docs.rs][docsrs_img]][docsrs_link]
 
-<img src="https://lzpel.github.io/cadrum/00_chijin.svg" alt="cadrum" height="300" width="auto"/>
+<img src="https://lzpel.github.io/cadrum/00_chijin.png" alt="cadrum" height="300" width="auto"/>
 </div>
 
 <!--GALLERY-->
 
 | [primitives](#primitives) | [write read](#write-read) | [transform](#transform) | [boolean](#boolean) |
 |:---:|:---:|:---:|:---:|
-| [<img src="https://lzpel.github.io/cadrum/01_primitives.svg" width="180" alt="primitives"/>](#primitives) | [<img src="https://lzpel.github.io/cadrum/02_write_read.svg" width="180" alt="write read"/>](#write-read) | [<img src="https://lzpel.github.io/cadrum/03_transform.svg" width="180" alt="transform"/>](#transform) | [<img src="https://lzpel.github.io/cadrum/04_boolean.svg" width="180" alt="boolean"/>](#boolean) |
+| [<img src="https://lzpel.github.io/cadrum/01_primitives.png" width="180" alt="primitives"/>](#primitives) | [<img src="https://lzpel.github.io/cadrum/02_write_read.png" width="180" alt="write read"/>](#write-read) | [<img src="https://lzpel.github.io/cadrum/03_transform.png" width="180" alt="transform"/>](#transform) | [<img src="https://lzpel.github.io/cadrum/04_boolean.png" width="180" alt="boolean"/>](#boolean) |
 | [extrude](#extrude) | [loft](#loft) | [sweep](#sweep) | [shell](#shell) |
-| [<img src="https://lzpel.github.io/cadrum/05_extrude.svg" width="180" alt="extrude"/>](#extrude) | [<img src="https://lzpel.github.io/cadrum/06_loft.svg" width="180" alt="loft"/>](#loft) | [<img src="https://lzpel.github.io/cadrum/07_sweep.svg" width="180" alt="sweep"/>](#sweep) | [<img src="https://lzpel.github.io/cadrum/08_shell.svg" width="180" alt="shell"/>](#shell) |
+| [<img src="https://lzpel.github.io/cadrum/05_extrude.png" width="180" alt="extrude"/>](#extrude) | [<img src="https://lzpel.github.io/cadrum/06_loft.png" width="180" alt="loft"/>](#loft) | [<img src="https://lzpel.github.io/cadrum/07_sweep.png" width="180" alt="sweep"/>](#sweep) | [<img src="https://lzpel.github.io/cadrum/08_shell.png" width="180" alt="shell"/>](#shell) |
 | [bspline](#bspline) | [fillet](#fillet) | [chamfer](#chamfer) |  |
-| [<img src="https://lzpel.github.io/cadrum/09_bspline.svg" width="180" alt="bspline"/>](#bspline) | [<img src="https://lzpel.github.io/cadrum/10_fillet.svg" width="180" alt="fillet"/>](#fillet) | [<img src="https://lzpel.github.io/cadrum/11_chamfer.svg" width="180" alt="chamfer"/>](#chamfer) |  |
+| [<img src="https://lzpel.github.io/cadrum/09_bspline.png" width="180" alt="bspline"/>](#bspline) | [<img src="https://lzpel.github.io/cadrum/10_fillet.png" width="180" alt="fillet"/>](#fillet) | [<img src="https://lzpel.github.io/cadrum/11_chamfer.png" width="180" alt="chamfer"/>](#chamfer) |  |
 
 
 ## Summary
@@ -123,7 +123,7 @@ cargo run --example 01_primitives
 
 use cadrum::{DVec3, Solid};
 
-fn main() {
+fn main() -> Result<(), cadrum::Error> {
     let example_name = std::path::Path::new(file!()).file_stem().unwrap().to_str().unwrap();
 
     let solids = [
@@ -143,14 +143,21 @@ fn main() {
             .color("#9b59b6"),
     ];
 
-    let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create file");
-    Solid::write_step(&solids, &mut f).expect("failed to write STEP");
+    Solid::write_step(&solids, &mut std::fs::File::create(format!("{example_name}.step")).unwrap())?;
 
-    let mut svg = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-    Solid::mesh(&solids, 0.5).and_then(|m| m.scene(DVec3::ONE, DVec3::Z, true, false).write_svg(&mut svg)).expect("failed to write SVG");
+    let scene = Solid::mesh(&solids, 0.5)?.scene(DVec3::ONE, DVec3::Z, true, false);
+    scene.write_svg(&mut std::fs::File::create(format!("{example_name}.svg")).unwrap())?;
+    scene.write_png([640, 640], &mut std::fs::File::create(format!("{example_name}.png")).unwrap())?;
+
+    println!("wrote {example_name}.step / {example_name}.svg / {example_name}.png");
+    Ok(())
 }
 
 ```
+
+<p align="center">
+  <img src="https://lzpel.github.io/cadrum/01_primitives.png" alt="01_primitives" width="360"/>
+</p>
 - [01_primitives.step](https://lzpel.github.io/cadrum/01_primitives.step)
 
 <p align="center">
@@ -206,11 +213,11 @@ fn main() -> Result<(), cadrum::Error> {
         .flat_map(|(i, solids)| solids.translate(DVec3::X * spacing * i as f64))
         .collect();
 
-    let mut svg = std::fs::File::create(format!("{example_name}.svg")).expect("create file");
-    Solid::mesh(&all, 0.5).and_then(|m| m.scene(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, false).write_svg(&mut svg))?;
+    let scene = Solid::mesh(&all, 0.5)?.scene(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, false);
+    scene.write_svg(&mut std::fs::File::create(format!("{example_name}.svg")).unwrap())?;
+    scene.write_png([640, 640], &mut std::fs::File::create(format!("{example_name}.png")).unwrap())?;
 
-    let mut stl = std::fs::File::create(format!("{example_name}.stl")).expect("create file");
-    Solid::mesh(&all, 0.1).and_then(|m| m.write_stl(&mut stl))?;
+    Solid::mesh(&all, 0.1)?.write_stl(&mut std::fs::File::create(format!("{example_name}.stl")).unwrap())?;
 
     // 5. Print summary
     let stl_path = format!("{example_name}.stl");
@@ -224,6 +231,10 @@ fn main() -> Result<(), cadrum::Error> {
 
 ```
 - [02_write_read.brep](https://lzpel.github.io/cadrum/02_write_read.brep)
+
+<p align="center">
+  <img src="https://lzpel.github.io/cadrum/02_write_read.png" alt="02_write_read" width="360"/>
+</p>
 - [02_write_read.step](https://lzpel.github.io/cadrum/02_write_read.step)
 - [02_write_read.stl](https://lzpel.github.io/cadrum/02_write_read.stl)
 
@@ -246,7 +257,7 @@ cargo run --example 03_transform
 use cadrum::{DVec3, Solid};
 use std::f64::consts::PI;
 
-fn main() {
+fn main() -> Result<(), cadrum::Error> {
     let example_name = std::path::Path::new(file!()).file_stem().unwrap().to_str().unwrap();
 
     let base = Solid::cone(8.0, 0.0, DVec3::Z, 20.0)
@@ -276,14 +287,21 @@ fn main() {
             .translate(DVec3::X * 160.0),
     ];
 
-    let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create file");
-    Solid::write_step(&solids, &mut f).expect("failed to write STEP");
+    Solid::write_step(&solids, &mut std::fs::File::create(format!("{example_name}.step")).unwrap())?;
 
-    let mut svg = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-    Solid::mesh(&solids, 0.5).and_then(|m| m.scene(DVec3::ONE, DVec3::Z, true, false).write_svg(&mut svg)).expect("failed to write SVG");
+    let scene = Solid::mesh(&solids, 0.5)?.scene(DVec3::ONE, DVec3::Z, true, false);
+    scene.write_svg(&mut std::fs::File::create(format!("{example_name}.svg")).unwrap())?;
+    scene.write_png([640, 640], &mut std::fs::File::create(format!("{example_name}.png")).unwrap())?;
+
+    println!("wrote {example_name}.step / {example_name}.svg / {example_name}.png");
+    Ok(())
 }
 
 ```
+
+<p align="center">
+  <img src="https://lzpel.github.io/cadrum/03_transform.png" alt="03_transform" width="360"/>
+</p>
 - [03_transform.step](https://lzpel.github.io/cadrum/03_transform.step)
 
 <p align="center">
@@ -340,16 +358,21 @@ fn main() -> Result<(), cadrum::Error> {
         product.translate(DVec3::X * 60.0 + DVec3::Y * 40.0)
     ];
 
-    let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create file");
-    Solid::write_step(&shapes, &mut f).expect("failed to write STEP");
+    Solid::write_step(&shapes, &mut std::fs::File::create(format!("{example_name}.step")).unwrap())?;
 
-    let mut svg = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-    Solid::mesh(&shapes, 0.5).and_then(|m| m.scene(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, false).write_svg(&mut svg)).expect("failed to write SVG");
+    let scene = Solid::mesh(&shapes, 0.5)?.scene(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, false);
+    scene.write_svg(&mut std::fs::File::create(format!("{example_name}.svg")).unwrap())?;
+    scene.write_png([640, 640], &mut std::fs::File::create(format!("{example_name}.png")).unwrap())?;
 
+    println!("wrote {example_name}.step / {example_name}.svg / {example_name}.png");
     Ok(())
 }
 
 ```
+
+<p align="center">
+  <img src="https://lzpel.github.io/cadrum/04_boolean.png" alt="04_boolean" width="360"/>
+</p>
 - [04_boolean.step](https://lzpel.github.io/cadrum/04_boolean.step)
 
 <p align="center">
@@ -432,17 +455,21 @@ fn main() -> Result<(), Error> {
 
 	let result = [box_solid, oblique, l_beam, heart];
 
-	let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create STEP file");
-	Solid::write_step(&result, &mut f).expect("failed to write STEP");
+	Solid::write_step(&result, &mut std::fs::File::create(format!("{example_name}.step")).unwrap())?;
 
-	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-	Solid::mesh(&result, 0.5).and_then(|m| m.scene(DVec3::ONE, DVec3::Z, true, false).write_svg(&mut f)).expect("failed to write SVG");
+	let scene = Solid::mesh(&result, 0.5)?.scene(DVec3::ONE, DVec3::Z, true, false);
+	scene.write_svg(&mut std::fs::File::create(format!("{example_name}.svg")).unwrap())?;
+	scene.write_png([640, 640], &mut std::fs::File::create(format!("{example_name}.png")).unwrap())?;
 
-	println!("wrote {example_name}.step / {example_name}.svg");
+	println!("wrote {example_name}.step / {example_name}.svg / {example_name}.png");
 	Ok(())
 }
 
 ```
+
+<p align="center">
+  <img src="https://lzpel.github.io/cadrum/05_extrude.png" alt="05_extrude" width="360"/>
+</p>
 - [05_extrude.step](https://lzpel.github.io/cadrum/05_extrude.step)
 
 <p align="center">
@@ -507,17 +534,21 @@ fn main() -> Result<(), Error> {
 
 	let result = [frustum, morph, tilted];
 
-	let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create STEP file");
-	Solid::write_step(&result, &mut f).expect("failed to write STEP");
+	Solid::write_step(&result, &mut std::fs::File::create(format!("{example_name}.step")).unwrap())?;
 
-	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-	Solid::mesh(&result, 0.5).and_then(|m| m.scene(DVec3::ONE, DVec3::Z, true, false).write_svg(&mut f)).expect("failed to write SVG");
+	let scene = Solid::mesh(&result, 0.5)?.scene(DVec3::ONE, DVec3::Z, true, false);
+	scene.write_svg(&mut std::fs::File::create(format!("{example_name}.svg")).unwrap())?;
+	scene.write_png([640, 640], &mut std::fs::File::create(format!("{example_name}.png")).unwrap())?;
 
-	println!("wrote {example_name}.step / {example_name}.svg");
+	println!("wrote {example_name}.step / {example_name}.svg / {example_name}.png");
 	Ok(())
 }
 
 ```
+
+<p align="center">
+  <img src="https://lzpel.github.io/cadrum/06_loft.png" alt="06_loft" width="360"/>
+</p>
 - [06_loft.step](https://lzpel.github.io/cadrum/06_loft.step)
 
 <p align="center">
@@ -654,16 +685,22 @@ fn main() -> Result<(), Error> {
 	let example_name = std::path::Path::new(file!()).file_stem().unwrap().to_str().unwrap();
 	let all = [build_m2_screw()?, build_u_pipe()?, build_twisted_ribbon()?];
 
-	let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create STEP file");
-	Solid::write_step(&all, &mut f)?;
-	let mut f_svg = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-	// Helical threads have dense hidden lines that clutter the SVG; disable them.
-	Solid::mesh(&all, 0.5)?.scene(DVec3::new(1.0, 1.0, -1.0), DVec3::Z, false, false).write_svg(&mut f_svg)?;
-	println!("wrote {example_name}.step / {example_name}.svg ({} solids)", all.len());
+	Solid::write_step(&all, &mut std::fs::File::create(format!("{example_name}.step")).unwrap())?;
+
+	// Helical threads have dense hidden lines that clutter the output; disable them.
+	let scene = Solid::mesh(&all, 0.5)?.scene(DVec3::new(1.0, 1.0, -1.0), DVec3::Z, false, false);
+	scene.write_svg(&mut std::fs::File::create(format!("{example_name}.svg")).unwrap())?;
+	scene.write_png([640, 640], &mut std::fs::File::create(format!("{example_name}.png")).unwrap())?;
+
+	println!("wrote {example_name}.step / {example_name}.svg / {example_name}.png ({} solids)", all.len());
 	Ok(())
 }
 
 ```
+
+<p align="center">
+  <img src="https://lzpel.github.io/cadrum/07_sweep.png" alt="07_sweep" width="360"/>
+</p>
 - [07_sweep.step](https://lzpel.github.io/cadrum/07_sweep.step)
 
 <p align="center">
@@ -729,19 +766,23 @@ fn main() -> Result<(), Error> {
 		halved_shelled_torus(-1.0)?.color("#0052ff").translate(DVec3::X * 18.0 + DVec3::Y * 10.0),
 	];
 
-	let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create STEP file");
-	Solid::write_step(&result, &mut f).expect("failed to write STEP");
+	Solid::write_step(&result, &mut std::fs::File::create(format!("{example_name}.step")).unwrap())?;
 
 	// Isometric view from (1, 1, 2) with shading so the cavity depth reads
 	// naturally.
-	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-	Solid::mesh(&result, 0.2).and_then(|m| m.scene(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, true).write_svg(&mut f)).expect("failed to write SVG");
+	let scene = Solid::mesh(&result, 0.2)?.scene(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, true);
+	scene.write_svg(&mut std::fs::File::create(format!("{example_name}.svg")).unwrap())?;
+	scene.write_png([640, 640], &mut std::fs::File::create(format!("{example_name}.png")).unwrap())?;
 
-	println!("wrote {example_name}.step / {example_name}.svg");
+	println!("wrote {example_name}.step / {example_name}.svg / {example_name}.png");
 	Ok(())
 }
 
 ```
+
+<p align="center">
+  <img src="https://lzpel.github.io/cadrum/08_shell.png" alt="08_shell" width="360"/>
+</p>
 - [08_shell.step](https://lzpel.github.io/cadrum/08_shell.step)
 
 <p align="center">
@@ -790,19 +831,27 @@ fn point(i: usize, j: usize) -> DVec3 {
 	DQuat::from_axis_angle(DVec3::Z, phi) * translated
 }
 
-fn main() {
+fn main() -> Result<(), cadrum::Error> {
 	let example_name = std::path::Path::new(file!()).file_stem().unwrap().to_str().unwrap();
 
 	let plasma = Solid::bspline(M, N, true, point).expect("2-period bspline torus should succeed");
 	let objects = [plasma.color("cyan")];
-	let mut f = std::fs::File::create(format!("{example_name}.step")).unwrap();
-	Solid::write_step(&objects, &mut f).unwrap();
-	let mut f_svg = std::fs::File::create(format!("{example_name}.svg")).unwrap();
-	Solid::mesh(&objects, 0.1).and_then(|m| m.scene(DVec3::new(0.05, 0.05, 1.0), DVec3::Y, false, true).write_svg(&mut f_svg)).unwrap();
-	println!("wrote {example_name}.step / {example_name}.svg");
+
+	Solid::write_step(&objects, &mut std::fs::File::create(format!("{example_name}.step")).unwrap())?;
+
+	let scene = Solid::mesh(&objects, 0.05)?.scene(DVec3::new(0.05, 0.05, 1.0), DVec3::Y, false, true);
+	scene.write_svg(&mut std::fs::File::create(format!("{example_name}.svg")).unwrap())?;
+	scene.write_png([640, 640], &mut std::fs::File::create(format!("{example_name}.png")).unwrap())?;
+
+	println!("wrote {example_name}.step / {example_name}.svg / {example_name}.png");
+	Ok(())
 }
 
 ```
+
+<p align="center">
+  <img src="https://lzpel.github.io/cadrum/09_bspline.png" alt="09_bspline" width="360"/>
+</p>
 - [09_bspline.step](https://lzpel.github.io/cadrum/09_bspline.step)
 
 <p align="center">
@@ -860,17 +909,21 @@ fn main() -> Result<(), Error> {
 		coin(4.0, 2.0)?.color("#0052ff").translate(DVec3::X * 24.0),
 	];
 
-	let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create STEP file");
-	Solid::write_step(&result, &mut f).expect("failed to write STEP");
+	Solid::write_step(&result, &mut std::fs::File::create(format!("{example_name}.step")).unwrap())?;
 
-	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-	Solid::mesh(&result, 0.2).and_then(|m| m.scene(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, true).write_svg(&mut f)).expect("failed to write SVG");
+	let scene = Solid::mesh(&result, 0.2)?.scene(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, true);
+	scene.write_svg(&mut std::fs::File::create(format!("{example_name}.svg")).unwrap())?;
+	scene.write_png([640, 640], &mut std::fs::File::create(format!("{example_name}.png")).unwrap())?;
 
-	println!("wrote {example_name}.step / {example_name}.svg");
+	println!("wrote {example_name}.step / {example_name}.svg / {example_name}.png");
 	Ok(())
 }
 
 ```
+
+<p align="center">
+  <img src="https://lzpel.github.io/cadrum/10_fillet.png" alt="10_fillet" width="360"/>
+</p>
 - [10_fillet.step](https://lzpel.github.io/cadrum/10_fillet.step)
 
 <p align="center">
@@ -928,17 +981,21 @@ fn main() -> Result<(), Error> {
 		beveled_coin(4.0, 2.0)?.color("#0052ff").translate(DVec3::X * 24.0),
 	];
 
-	let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create STEP file");
-	Solid::write_step(&result, &mut f).expect("failed to write STEP");
+	Solid::write_step(&result, &mut std::fs::File::create(format!("{example_name}.step")).unwrap())?;
 
-	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-	Solid::mesh(&result, 0.2).and_then(|m| m.scene(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, true).write_svg(&mut f)).expect("failed to write SVG");
+	let scene = Solid::mesh(&result, 0.2)?.scene(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, true);
+	scene.write_svg(&mut std::fs::File::create(format!("{example_name}.svg")).unwrap())?;
+	scene.write_png([640, 640], &mut std::fs::File::create(format!("{example_name}.png")).unwrap())?;
 
-	println!("wrote {example_name}.step / {example_name}.svg");
+	println!("wrote {example_name}.step / {example_name}.svg / {example_name}.png");
 	Ok(())
 }
 
 ```
+
+<p align="center">
+  <img src="https://lzpel.github.io/cadrum/11_chamfer.png" alt="11_chamfer" width="360"/>
+</p>
 - [11_chamfer.step](https://lzpel.github.io/cadrum/11_chamfer.step)
 
 <p align="center">

--- a/examples/00_chijin.rs
+++ b/examples/00_chijin.rs
@@ -3,7 +3,7 @@
 use cadrum::{Color, DVec3, Edge, ProfileOrient, Solid};
 use std::f64::consts::PI;
 
-pub fn chijin() -> Result<Solid, cadrum::Error> {
+fn chijin() -> Result<Solid, cadrum::Error> {
 	// ── Body (cylinder): r=15, h=8, centered at origin (z=-4..+4) ────────
 	let cylinder = Solid::cylinder(15.0, DVec3::Z, 8.0)
 		.translate(DVec3::Z * -4.0)
@@ -56,12 +56,14 @@ fn main() -> Result<(), cadrum::Error> {
 	let example_name = std::path::Path::new(file!()).file_stem().unwrap().to_str().unwrap();
 	let result = [chijin()?];
 
-	let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create STEP file");
-	Solid::write_step(&result, &mut f).expect("failed to write STEP");
+	Solid::write_step(&result, &mut std::fs::File::create(format!("{example_name}.step")).unwrap())?;
 
-	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-	Solid::mesh(&result, 0.5).and_then(|m| m.scene(DVec3::ONE, DVec3::Y, true, false).write_svg(&mut f)).expect("failed to write SVG");
+	let scene = Solid::mesh(&result, 0.5)?.scene(DVec3::ONE, DVec3::Y, true, false);
+	scene.write_svg(&mut std::fs::File::create(format!("{example_name}.svg")).unwrap())?;
+	scene.write_png([1280 , 640], &mut std::fs::File::create(format!("{example_name}.png")).unwrap())?;
+	// This size 1280 x 640 is special because 00_chijin.png is used for github repository social media preview image.
+	// > we recommend a size of at least 640 by 320 pixels (1280 by 640 pixels for best display).　See https://docs.github.com/ja/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/customizing-your-repositorys-social-media-preview
 
-	println!("wrote {example_name}.step / {example_name}.svg");
+	println!("wrote {example_name}.step / {example_name}.svg / {example_name}.png");
 	Ok(())
 }

--- a/examples/01_primitives.rs
+++ b/examples/01_primitives.rs
@@ -2,7 +2,7 @@
 
 use cadrum::{DVec3, Solid};
 
-fn main() {
+fn main() -> Result<(), cadrum::Error> {
     let example_name = std::path::Path::new(file!()).file_stem().unwrap().to_str().unwrap();
 
     let solids = [
@@ -22,9 +22,12 @@ fn main() {
             .color("#9b59b6"),
     ];
 
-    let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create file");
-    Solid::write_step(&solids, &mut f).expect("failed to write STEP");
+    Solid::write_step(&solids, &mut std::fs::File::create(format!("{example_name}.step")).unwrap())?;
 
-    let mut svg = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-    Solid::mesh(&solids, 0.5).and_then(|m| m.scene(DVec3::ONE, DVec3::Z, true, false).write_svg(&mut svg)).expect("failed to write SVG");
+    let scene = Solid::mesh(&solids, 0.5)?.scene(DVec3::ONE, DVec3::Z, true, false);
+    scene.write_svg(&mut std::fs::File::create(format!("{example_name}.svg")).unwrap())?;
+    scene.write_png([640, 640], &mut std::fs::File::create(format!("{example_name}.png")).unwrap())?;
+
+    println!("wrote {example_name}.step / {example_name}.svg / {example_name}.png");
+    Ok(())
 }

--- a/examples/02_write_read.rs
+++ b/examples/02_write_read.rs
@@ -38,11 +38,11 @@ fn main() -> Result<(), cadrum::Error> {
         .flat_map(|(i, solids)| solids.translate(DVec3::X * spacing * i as f64))
         .collect();
 
-    let mut svg = std::fs::File::create(format!("{example_name}.svg")).expect("create file");
-    Solid::mesh(&all, 0.5).and_then(|m| m.scene(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, false).write_svg(&mut svg))?;
+    let scene = Solid::mesh(&all, 0.5)?.scene(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, false);
+    scene.write_svg(&mut std::fs::File::create(format!("{example_name}.svg")).unwrap())?;
+    scene.write_png([640, 640], &mut std::fs::File::create(format!("{example_name}.png")).unwrap())?;
 
-    let mut stl = std::fs::File::create(format!("{example_name}.stl")).expect("create file");
-    Solid::mesh(&all, 0.1).and_then(|m| m.write_stl(&mut stl))?;
+    Solid::mesh(&all, 0.1)?.write_stl(&mut std::fs::File::create(format!("{example_name}.stl")).unwrap())?;
 
     // 5. Print summary
     let stl_path = format!("{example_name}.stl");

--- a/examples/03_transform.rs
+++ b/examples/03_transform.rs
@@ -3,7 +3,7 @@
 use cadrum::{DVec3, Solid};
 use std::f64::consts::PI;
 
-fn main() {
+fn main() -> Result<(), cadrum::Error> {
     let example_name = std::path::Path::new(file!()).file_stem().unwrap().to_str().unwrap();
 
     let base = Solid::cone(8.0, 0.0, DVec3::Z, 20.0)
@@ -33,9 +33,12 @@ fn main() {
             .translate(DVec3::X * 160.0),
     ];
 
-    let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create file");
-    Solid::write_step(&solids, &mut f).expect("failed to write STEP");
+    Solid::write_step(&solids, &mut std::fs::File::create(format!("{example_name}.step")).unwrap())?;
 
-    let mut svg = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-    Solid::mesh(&solids, 0.5).and_then(|m| m.scene(DVec3::ONE, DVec3::Z, true, false).write_svg(&mut svg)).expect("failed to write SVG");
+    let scene = Solid::mesh(&solids, 0.5)?.scene(DVec3::ONE, DVec3::Z, true, false);
+    scene.write_svg(&mut std::fs::File::create(format!("{example_name}.svg")).unwrap())?;
+    scene.write_png([640, 640], &mut std::fs::File::create(format!("{example_name}.png")).unwrap())?;
+
+    println!("wrote {example_name}.step / {example_name}.svg / {example_name}.png");
+    Ok(())
 }

--- a/examples/04_boolean.rs
+++ b/examples/04_boolean.rs
@@ -39,11 +39,12 @@ fn main() -> Result<(), cadrum::Error> {
         product.translate(DVec3::X * 60.0 + DVec3::Y * 40.0)
     ];
 
-    let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create file");
-    Solid::write_step(&shapes, &mut f).expect("failed to write STEP");
+    Solid::write_step(&shapes, &mut std::fs::File::create(format!("{example_name}.step")).unwrap())?;
 
-    let mut svg = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-    Solid::mesh(&shapes, 0.5).and_then(|m| m.scene(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, false).write_svg(&mut svg)).expect("failed to write SVG");
+    let scene = Solid::mesh(&shapes, 0.5)?.scene(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, false);
+    scene.write_svg(&mut std::fs::File::create(format!("{example_name}.svg")).unwrap())?;
+    scene.write_png([640, 640], &mut std::fs::File::create(format!("{example_name}.png")).unwrap())?;
 
+    println!("wrote {example_name}.step / {example_name}.svg / {example_name}.png");
     Ok(())
 }

--- a/examples/05_extrude.rs
+++ b/examples/05_extrude.rs
@@ -65,12 +65,12 @@ fn main() -> Result<(), Error> {
 
 	let result = [box_solid, oblique, l_beam, heart];
 
-	let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create STEP file");
-	Solid::write_step(&result, &mut f).expect("failed to write STEP");
+	Solid::write_step(&result, &mut std::fs::File::create(format!("{example_name}.step")).unwrap())?;
 
-	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-	Solid::mesh(&result, 0.5).and_then(|m| m.scene(DVec3::ONE, DVec3::Z, true, false).write_svg(&mut f)).expect("failed to write SVG");
+	let scene = Solid::mesh(&result, 0.5)?.scene(DVec3::ONE, DVec3::Z, true, false);
+	scene.write_svg(&mut std::fs::File::create(format!("{example_name}.svg")).unwrap())?;
+	scene.write_png([640, 640], &mut std::fs::File::create(format!("{example_name}.png")).unwrap())?;
 
-	println!("wrote {example_name}.step / {example_name}.svg");
+	println!("wrote {example_name}.step / {example_name}.svg / {example_name}.png");
 	Ok(())
 }

--- a/examples/06_loft.rs
+++ b/examples/06_loft.rs
@@ -47,12 +47,12 @@ fn main() -> Result<(), Error> {
 
 	let result = [frustum, morph, tilted];
 
-	let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create STEP file");
-	Solid::write_step(&result, &mut f).expect("failed to write STEP");
+	Solid::write_step(&result, &mut std::fs::File::create(format!("{example_name}.step")).unwrap())?;
 
-	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-	Solid::mesh(&result, 0.5).and_then(|m| m.scene(DVec3::ONE, DVec3::Z, true, false).write_svg(&mut f)).expect("failed to write SVG");
+	let scene = Solid::mesh(&result, 0.5)?.scene(DVec3::ONE, DVec3::Z, true, false);
+	scene.write_svg(&mut std::fs::File::create(format!("{example_name}.svg")).unwrap())?;
+	scene.write_png([640, 640], &mut std::fs::File::create(format!("{example_name}.png")).unwrap())?;
 
-	println!("wrote {example_name}.step / {example_name}.svg");
+	println!("wrote {example_name}.step / {example_name}.svg / {example_name}.png");
 	Ok(())
 }

--- a/examples/07_sweep.rs
+++ b/examples/07_sweep.rs
@@ -119,11 +119,13 @@ fn main() -> Result<(), Error> {
 	let example_name = std::path::Path::new(file!()).file_stem().unwrap().to_str().unwrap();
 	let all = [build_m2_screw()?, build_u_pipe()?, build_twisted_ribbon()?];
 
-	let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create STEP file");
-	Solid::write_step(&all, &mut f)?;
-	let mut f_svg = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-	// Helical threads have dense hidden lines that clutter the SVG; disable them.
-	Solid::mesh(&all, 0.5)?.scene(DVec3::new(1.0, 1.0, -1.0), DVec3::Z, false, false).write_svg(&mut f_svg)?;
-	println!("wrote {example_name}.step / {example_name}.svg ({} solids)", all.len());
+	Solid::write_step(&all, &mut std::fs::File::create(format!("{example_name}.step")).unwrap())?;
+
+	// Helical threads have dense hidden lines that clutter the output; disable them.
+	let scene = Solid::mesh(&all, 0.5)?.scene(DVec3::new(1.0, 1.0, -1.0), DVec3::Z, false, false);
+	scene.write_svg(&mut std::fs::File::create(format!("{example_name}.svg")).unwrap())?;
+	scene.write_png([640, 640], &mut std::fs::File::create(format!("{example_name}.png")).unwrap())?;
+
+	println!("wrote {example_name}.step / {example_name}.svg / {example_name}.png ({} solids)", all.len());
 	Ok(())
 }

--- a/examples/08_shell.rs
+++ b/examples/08_shell.rs
@@ -48,14 +48,14 @@ fn main() -> Result<(), Error> {
 		halved_shelled_torus(-1.0)?.color("#0052ff").translate(DVec3::X * 18.0 + DVec3::Y * 10.0),
 	];
 
-	let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create STEP file");
-	Solid::write_step(&result, &mut f).expect("failed to write STEP");
+	Solid::write_step(&result, &mut std::fs::File::create(format!("{example_name}.step")).unwrap())?;
 
 	// Isometric view from (1, 1, 2) with shading so the cavity depth reads
 	// naturally.
-	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-	Solid::mesh(&result, 0.2).and_then(|m| m.scene(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, true).write_svg(&mut f)).expect("failed to write SVG");
+	let scene = Solid::mesh(&result, 0.2)?.scene(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, true);
+	scene.write_svg(&mut std::fs::File::create(format!("{example_name}.svg")).unwrap())?;
+	scene.write_png([640, 640], &mut std::fs::File::create(format!("{example_name}.png")).unwrap())?;
 
-	println!("wrote {example_name}.step / {example_name}.svg");
+	println!("wrote {example_name}.step / {example_name}.svg / {example_name}.png");
 	Ok(())
 }

--- a/examples/09_bspline.rs
+++ b/examples/09_bspline.rs
@@ -33,14 +33,18 @@ fn point(i: usize, j: usize) -> DVec3 {
 	DQuat::from_axis_angle(DVec3::Z, phi) * translated
 }
 
-fn main() {
+fn main() -> Result<(), cadrum::Error> {
 	let example_name = std::path::Path::new(file!()).file_stem().unwrap().to_str().unwrap();
 
 	let plasma = Solid::bspline(M, N, true, point).expect("2-period bspline torus should succeed");
 	let objects = [plasma.color("cyan")];
-	let mut f = std::fs::File::create(format!("{example_name}.step")).unwrap();
-	Solid::write_step(&objects, &mut f).unwrap();
-	let mut f_svg = std::fs::File::create(format!("{example_name}.svg")).unwrap();
-	Solid::mesh(&objects, 0.1).and_then(|m| m.scene(DVec3::new(0.05, 0.05, 1.0), DVec3::Y, false, true).write_svg(&mut f_svg)).unwrap();
-	println!("wrote {example_name}.step / {example_name}.svg");
+
+	Solid::write_step(&objects, &mut std::fs::File::create(format!("{example_name}.step")).unwrap())?;
+
+	let scene = Solid::mesh(&objects, 0.05)?.scene(DVec3::new(0.05, 0.05, 1.0), DVec3::Y, false, true);
+	scene.write_svg(&mut std::fs::File::create(format!("{example_name}.svg")).unwrap())?;
+	scene.write_png([640, 640], &mut std::fs::File::create(format!("{example_name}.png")).unwrap())?;
+
+	println!("wrote {example_name}.step / {example_name}.svg / {example_name}.png");
+	Ok(())
 }

--- a/examples/101_joint.rs
+++ b/examples/101_joint.rs
@@ -8,6 +8,7 @@ fn part(inner: f64, outer: f64, height: f64) -> Result<[Solid; 3], Error> {
 	Ok([outer_solid, between_solid, inner_solid])
 }
 fn main() -> Result<(), Error> {
+	let example_name = std::path::Path::new(file!()).file_stem().unwrap().to_str().unwrap();
 	let (inner, outer, height) = (8.1, 20., 60.0);
 	let base = part(inner, outer, height)?;
 	let parts = [base.clone(), base.clone().rotate(DVec3::ZERO, DVec3::ONE, std::f64::consts::TAU / 3.0), base.clone().rotate(DVec3::ZERO, DVec3::ONE, std::f64::consts::TAU * 2.0 / 3.0)];
@@ -15,11 +16,17 @@ fn main() -> Result<(), Error> {
 	let positive: Solid = parts.iter().flat_map(|p| [&p[0], &p[1]]).sum::<Result<Solid, _>>()?;
 	// negative = 各 part の inner cylinder (= p[2]) を全部 union
 	let negative: Solid = parts.iter().map(|p| &p[2]).sum::<Result<Solid, _>>()?;
-	let result = (&positive - &negative)?;
-	let mut w = std::fs::File::create("joints.step").unwrap();
-	Solid::write_step([&result], &mut w).unwrap();
-	let mut w = std::fs::File::create("joints.stl").unwrap();
-	Solid::mesh([&result], 0.1).unwrap().write_stl(&mut w).unwrap();
+	let result = [(&positive - &negative)?];
+
+	Solid::write_step(&result, &mut std::fs::File::create(format!("{example_name}.step")).unwrap())?;
+
+	let scene = Solid::mesh(&result, 0.5)?.scene(DVec3::ONE, DVec3::Z, true, true);
+	scene.write_svg(&mut std::fs::File::create(format!("{example_name}.svg")).unwrap())?;
+	scene.write_png([640, 640], &mut std::fs::File::create(format!("{example_name}.png")).unwrap())?;
+
+	Solid::mesh(&result, 0.1)?.write_stl(&mut std::fs::File::create(format!("{example_name}.stl")).unwrap())?;
+
+	println!("wrote {example_name}.step / {example_name}.svg / {example_name}.png / {example_name}.stl");
 	Ok(())
 }
 

--- a/examples/10_fillet.rs
+++ b/examples/10_fillet.rs
@@ -40,12 +40,12 @@ fn main() -> Result<(), Error> {
 		coin(4.0, 2.0)?.color("#0052ff").translate(DVec3::X * 24.0),
 	];
 
-	let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create STEP file");
-	Solid::write_step(&result, &mut f).expect("failed to write STEP");
+	Solid::write_step(&result, &mut std::fs::File::create(format!("{example_name}.step")).unwrap())?;
 
-	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-	Solid::mesh(&result, 0.2).and_then(|m| m.scene(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, true).write_svg(&mut f)).expect("failed to write SVG");
+	let scene = Solid::mesh(&result, 0.2)?.scene(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, true);
+	scene.write_svg(&mut std::fs::File::create(format!("{example_name}.svg")).unwrap())?;
+	scene.write_png([640, 640], &mut std::fs::File::create(format!("{example_name}.png")).unwrap())?;
 
-	println!("wrote {example_name}.step / {example_name}.svg");
+	println!("wrote {example_name}.step / {example_name}.svg / {example_name}.png");
 	Ok(())
 }

--- a/examples/11_chamfer.rs
+++ b/examples/11_chamfer.rs
@@ -40,12 +40,12 @@ fn main() -> Result<(), Error> {
 		beveled_coin(4.0, 2.0)?.color("#0052ff").translate(DVec3::X * 24.0),
 	];
 
-	let mut f = std::fs::File::create(format!("{example_name}.step")).expect("failed to create STEP file");
-	Solid::write_step(&result, &mut f).expect("failed to write STEP");
+	Solid::write_step(&result, &mut std::fs::File::create(format!("{example_name}.step")).unwrap())?;
 
-	let mut f = std::fs::File::create(format!("{example_name}.svg")).expect("failed to create SVG file");
-	Solid::mesh(&result, 0.2).and_then(|m| m.scene(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, true).write_svg(&mut f)).expect("failed to write SVG");
+	let scene = Solid::mesh(&result, 0.2)?.scene(DVec3::new(1.0, 1.0, 2.0), DVec3::Z, true, true);
+	scene.write_svg(&mut std::fs::File::create(format!("{example_name}.svg")).unwrap())?;
+	scene.write_png([640, 640], &mut std::fs::File::create(format!("{example_name}.png")).unwrap())?;
 
-	println!("wrote {example_name}.step / {example_name}.svg");
+	println!("wrote {example_name}.step / {example_name}.svg / {example_name}.png");
 	Ok(())
 }

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -72,6 +72,9 @@ pub enum Error {
 	/// SVG export (HLR projection) failed.
 	SvgExportFailed,
 
+	/// PNG export failed (rasterizer / encoder / writer).
+	PngExportFailed,
+
 	/// STL write failed.
 	StlWriteFailed,
 
@@ -103,6 +106,7 @@ impl std::fmt::Display for Error {
 			Error::BsplineFailed(msg) => write!(f, "Bspline failed: {}", msg),
 			Error::InvalidEdge(msg) => write!(f, "Invalid edge: {}", msg),
 			Error::SvgExportFailed => write!(f, "SVG export failed"),
+			Error::PngExportFailed => write!(f, "PNG export failed"),
 			Error::StlWriteFailed => write!(f, "STL write failed"),
 			Error::InvalidColor(s) => write!(f, "Invalid color: \"{}\"", s),
 			Error::Unknown(msg) => write!(f, "Unknown error: {}", msg),

--- a/src/common/mesh.rs
+++ b/src/common/mesh.rs
@@ -420,33 +420,56 @@ fn compute_viewbox(triangles: &[[DVec2; 3]], visible: &[DVec2], hidden: &[DVec2]
 	[min, max]
 }
 
-// ==================== Scene2D → SVG backend ====================
+// ==================== Scene2D layout (shared by backends) ====================
+
+/// Viewport + stroke parameters derived from `Scene2D::viewbox`. Shared by
+/// SVG and PNG backends so both honor the same margin / stroke / dash ratios.
+/// All units are scene units; per-backend code converts to its target space
+/// (SVG keeps scene units; PNG multiplies by pixels-per-scene-unit).
+struct Layout {
+	/// Output rect in scene-style coordinates with Y already flipped (origin
+	/// at top-left, matching SVG `viewBox` and pixel image conventions).
+	vx: f64,
+	vy: f64,
+	vw: f64,
+	vh: f64,
+	stroke_width: f64,
+	hidden_stroke_width: f64,
+	dash_len: f64,
+	dash_gap: f64,
+}
 
 impl Scene2D {
-	/// Write this scene as an SVG to a writer.
-	pub fn write_svg<W: std::io::Write>(&self, writer: &mut W) -> Result<(), super::error::Error> {
-		writer.write_all(self.to_svg().as_bytes()).map_err(|_| super::error::Error::SvgExportFailed)
-	}
-
-	/// Render this scene as an SVG string.
-	pub fn to_svg(&self) -> String {
+	fn layout(&self) -> Layout {
 		let [min, max] = self.viewbox;
 		let margin_frac = 0.05;
 		let w = max.x - min.x;
 		let h = max.y - min.y;
 		let span = w.max(h);
 		let margin = span * margin_frac;
-		let vx = min.x - margin;
-		// SVG Y axis points down, so flip Y for output.
-		let vy = -(max.y + margin);
-		let vw = w + margin * 2.0;
-		let vh = h + margin * 2.0;
-		let sw = span * 0.003;
-		// Hidden lines: thinner stroke and longer dashes to reduce visual clutter
-		// on dense models (e.g. helical sweeps).
-		let hidden_sw = sw * 0.6;
-		let dash_len = sw * 5.0;
-		let dash_gap = sw * 4.0;
+		let stroke_width = span * 0.003;
+		Layout {
+			vx: min.x - margin,
+			// SVG / image Y axis points down, so flip Y for the output rect.
+			vy: -(max.y + margin),
+			vw: w + margin * 2.0,
+			vh: h + margin * 2.0,
+			stroke_width,
+			// Hidden lines: thinner stroke and longer dashes to reduce
+			// visual clutter on dense models (e.g. helical sweeps).
+			hidden_stroke_width: stroke_width * 0.6,
+			dash_len: stroke_width * 5.0,
+			dash_gap: stroke_width * 4.0,
+		}
+	}
+}
+
+// ==================== Scene2D → SVG backend ====================
+
+impl Scene2D {
+	/// Write this scene as an SVG to a writer.
+	pub fn write_svg<W: std::io::Write>(&self, writer: &mut W) -> Result<(), super::error::Error> {
+		let Layout { vx, vy, vw, vh, stroke_width: sw, hidden_stroke_width: hidden_sw, dash_len, dash_gap } = self.layout();
 
 		let mut svg = String::with_capacity(4096 + self.triangles.len() * 120);
 		svg.push_str(&format!(
@@ -468,7 +491,7 @@ impl Scene2D {
 		polylines_to_svg(&mut svg, &self.edges_hidden, "#bbb", &format!("{dash_len:.4},{dash_gap:.4}"), Some(hidden_sw));
 
 		svg.push_str("</svg>\n");
-		svg
+		writer.write_all(svg.as_bytes()).map_err(|_| super::error::Error::SvgExportFailed)
 	}
 }
 
@@ -508,4 +531,115 @@ fn emit_polyline(svg: &mut String, line: &[DVec2], stroke: &str, dash: &str, wid
 		svg.push('"');
 	}
 	svg.push_str("/>\n");
+}
+
+// ==================== Scene2D → PNG backend ====================
+
+impl Scene2D {
+	/// Rasterize this scene as a PNG and write to a writer.
+	///
+	/// `dimensions` is `[width, height]` in pixels. The scene aspect ratio
+	/// (from `viewbox`) is preserved by scaling to fit and centering — when
+	/// the requested aspect doesn't match the scene's, white letterbox bars
+	/// fill the remainder. Anti-aliased via `tiny-skia`. Background is white
+	/// (CAD documentation convention; transparent backgrounds are not
+	/// supported here).
+	#[cfg(feature = "png")]
+	pub fn write_png<W: std::io::Write>(&self, dimensions: [usize; 2], writer: &mut W) -> Result<(), super::error::Error> {
+		use tiny_skia::{FillRule, Paint, PathBuilder, Pixmap, Stroke, StrokeDash, Transform};
+
+		let [width, height] = dimensions;
+		let layout = self.layout();
+
+		// Preserve aspect: pick the smaller per-axis scale so the whole
+		// viewbox fits, then center the content within the pixmap.
+		let pps = ((width as f64) / layout.vw).min((height as f64) / layout.vh);
+		let off_x = (width as f64 - layout.vw * pps) / 2.0;
+		let off_y = (height as f64 - layout.vh * pps) / 2.0;
+
+		// Scene→pixel transform. SVG y was already flipped in `layout.vy`,
+		// so the same `(vx, vy)` origin maps to pixel `(off_x, off_y)` once
+		// we scale scene-y by `-pps`.
+		let s = pps as f32;
+		let tx = -(layout.vx as f32) * s + off_x as f32;
+		let ty = -(layout.vy as f32) * s + off_y as f32;
+		let transform = Transform::from_row(s, 0.0, 0.0, -s, tx, ty);
+
+		// `tiny-skia` applies stroke width in path coordinate space (= scene
+		// units here), THEN the transform scales the resulting stroke outline
+		// to pixels. So pass the layout values in scene units directly; the
+		// transform turns them into the desired `sw * pps` pixel widths.
+		let sw = layout.stroke_width as f32;
+		let hidden_sw = layout.hidden_stroke_width as f32;
+		let dash_len = layout.dash_len as f32;
+		let dash_gap = layout.dash_gap as f32;
+
+		let mut pixmap = Pixmap::new(width as u32, height as u32).ok_or(super::error::Error::PngExportFailed)?;
+		pixmap.fill(tiny_skia::Color::WHITE);
+
+		// Triangles (back-to-front, already sorted by Scene2D construction).
+		for (tri, color) in self.triangles.iter().zip(self.color.iter()) {
+			let mut pb = PathBuilder::new();
+			pb.move_to(tri[0].x as f32, tri[0].y as f32);
+			pb.line_to(tri[1].x as f32, tri[1].y as f32);
+			pb.line_to(tri[2].x as f32, tri[2].y as f32);
+			pb.close();
+			if let Some(path) = pb.finish() {
+				let mut paint = Paint::default();
+				paint.set_color_rgba8(color[0], color[1], color[2], 255);
+				paint.anti_alias = true;
+				pixmap.fill_path(&path, &paint, FillRule::Winding, transform, None);
+			}
+		}
+
+		// Visible edges — solid black.
+		let mut visible_paint = Paint::default();
+		visible_paint.set_color_rgba8(0, 0, 0, 255);
+		visible_paint.anti_alias = true;
+		let visible_stroke = Stroke { width: sw, ..Stroke::default() };
+		Self::stroke_polylines(&mut pixmap, &self.edges_visible, &visible_paint, &visible_stroke, transform);
+
+		// Hidden edges — gray dashed.
+		let mut hidden_paint = Paint::default();
+		hidden_paint.set_color_rgba8(0xbb, 0xbb, 0xbb, 255);
+		hidden_paint.anti_alias = true;
+		let hidden_stroke = Stroke {
+			width: hidden_sw,
+			dash: StrokeDash::new(vec![dash_len, dash_gap], 0.0),
+			..Stroke::default()
+		};
+		Self::stroke_polylines(&mut pixmap, &self.edges_hidden, &hidden_paint, &hidden_stroke, transform);
+
+		let png_bytes = pixmap.encode_png().map_err(|_| super::error::Error::PngExportFailed)?;
+		writer.write_all(&png_bytes).map_err(|_| super::error::Error::PngExportFailed)
+	}
+
+	#[cfg(feature = "png")]
+	fn stroke_polylines(
+		pixmap: &mut tiny_skia::Pixmap,
+		polylines: &[DVec2],
+		paint: &tiny_skia::Paint,
+		stroke: &tiny_skia::Stroke,
+		transform: tiny_skia::Transform,
+	) {
+		let mut start = 0;
+		for i in 0..=polylines.len() {
+			let is_sep = i == polylines.len() || polylines[i].is_nan();
+			if is_sep {
+				let line = &polylines[start..i];
+				if line.len() >= 2 {
+					let mut pb = tiny_skia::PathBuilder::new();
+					pb.move_to(line[0].x as f32, line[0].y as f32);
+					for p in &line[1..] {
+						pb.line_to(p.x as f32, p.y as f32);
+					}
+					if let Some(path) = pb.finish() {
+						pixmap.stroke_path(&path, paint, stroke, transform, None);
+					}
+				}
+				start = i + 1;
+			}
+		}
+	}
+
 }

--- a/tests/png.rs
+++ b/tests/png.rs
@@ -1,0 +1,68 @@
+//! PNG output tests (Scene2D::write_png via tiny-skia).
+//!
+//! Run with `cargo test --features png`.
+
+#![cfg(feature = "png")]
+
+use cadrum::{DVec3, Solid};
+
+fn dvec3(x: f64, y: f64, z: f64) -> DVec3 {
+	DVec3::new(x, y, z)
+}
+
+/// PNG signature: 89 50 4E 47 0D 0A 1A 0A
+const PNG_MAGIC: &[u8; 8] = &[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+
+/// Read width/height from the IHDR chunk (bytes 16..24 of a PNG file).
+fn png_dimensions(buf: &[u8]) -> (u32, u32) {
+	let w = u32::from_be_bytes(buf[16..20].try_into().unwrap());
+	let h = u32::from_be_bytes(buf[20..24].try_into().unwrap());
+	(w, h)
+}
+
+#[test]
+fn test_png_box_isometric() {
+	let shape = [Solid::cube(10.0, 10.0, 10.0)];
+	let mesh = Solid::mesh(&shape, 0.1).unwrap();
+	let scene = mesh.scene(dvec3(1.0, 1.0, 1.0).normalize(), DVec3::Z, true, false);
+
+	let mut buf = Vec::new();
+	scene.write_png([400, 400], &mut buf).unwrap();
+
+	assert_eq!(&buf[0..8], PNG_MAGIC, "PNG signature missing");
+	assert_eq!(png_dimensions(&buf), (400, 400));
+
+	std::fs::create_dir_all("out").unwrap();
+	std::fs::write("out/box_isometric.png", &buf).unwrap();
+}
+
+#[test]
+fn test_png_cylinder_shaded() {
+	let shape = [Solid::cylinder(5.0, DVec3::Z, 10.0)];
+	let mesh = Solid::mesh(&shape, 0.1).unwrap();
+	let scene = mesh.scene(dvec3(1.0, 0.5, 0.3).normalize(), DVec3::Z, true, true);
+
+	let mut buf = Vec::new();
+	scene.write_png([400, 600], &mut buf).unwrap();
+
+	assert_eq!(&buf[0..8], PNG_MAGIC);
+	assert_eq!(png_dimensions(&buf), (400, 600));
+
+	std::fs::create_dir_all("out").unwrap();
+	std::fs::write("out/cylinder.png", &buf).unwrap();
+}
+
+#[test]
+fn test_png_dimensions_are_exact() {
+	// User-specified [width, height] must appear verbatim in the IHDR,
+	// regardless of viewbox aspect (letterboxed when aspects differ).
+	let shape = [Solid::cube(50.0, 10.0, 10.0)];
+	let mesh = Solid::mesh(&shape, 0.5).unwrap();
+	let scene = mesh.scene(DVec3::Z, DVec3::Y, false, false);
+
+	for dims in [[500, 500], [800, 200], [200, 800]] {
+		let mut buf = Vec::new();
+		scene.write_png(dims, &mut buf).unwrap();
+		assert_eq!(png_dimensions(&buf), (dims[0] as u32, dims[1] as u32));
+	}
+}


### PR DESCRIPTION
Re-opening as a direct PR to `main`. The previous PR #163 was based on `refactor/scene2d` and got marked MERGED by GitHub when that branch was merged into main — but #163's own commits never landed.

## Summary

Adds a PNG backend that consumes the `Scene2D` introduced in #162, plus standardizes every example to emit STEP + SVG + PNG from a single shared `Scene2D`.

```rust
let scene = mesh.scene(view, up, hidden_lines, shading);
scene.write_svg(&mut svg_file)?;
scene.write_png([width, height], &mut png_file)?;
```

## Changes

### PNG backend
- **`Scene2D::write_png(dimensions: [usize; 2], &mut W)`** — pure-Rust raster via `tiny-skia` (AA, dashed strokes). Aspect-preserving with white letterbox bars when requested dims don't match scene viewbox.
- **`png` feature** in default features. Pulls in `tiny-skia` (~150KB pure Rust, no native deps). Motivation: LLM-assisted CAD workflows where image output should be frictionless — `cargo add cadrum` should be enough to produce PNGs for image-input LLMs.
- **`Layout` helper extracted** — margin / stroke widths / dash sizes computed once, shared by SVG and PNG backends.
- **`Scene2D::to_svg()` removed from public API** — body inlined into `write_svg`. No `to_png` counterpart added (writer-only API; in-memory variants are sugar).
- **`Error::PngExportFailed`** variant.

### Example standardization
Every numbered example now follows one shape:

```rust
fn main() -> Result<(), cadrum::Error> {
    let example_name = ...;
    // build `result`
    Solid::write_step(&result, &mut File::create(...).unwrap())?;
    let scene = Solid::mesh(&result, TOL)?.scene(VIEW, UP, HIDDEN, SHADING);
    scene.write_svg(&mut File::create(...).unwrap())?;
    scene.write_png([1024, 1024], &mut File::create(...).unwrap())?;
    println!("wrote ...");
    Ok(())
}
```

Per-example tolerance / view / up / hidden / shading values are preserved. A single shared `Scene2D` halves the meshing + projection cost.

`02_write_read` keeps its STL output (different tolerance, can't share scene). `101_joint` gains SVG + PNG (had only STEP + STL before).

## Test plan
- [x] `cargo build --features color,png`
- [x] `cargo test --features color,png` — 3 new PNG tests (signature, dimensions, aspect)
- [x] All examples build and run; smoke-tested 01_primitives produces correct color-shaded PNG
- [x] README regenerated from updated example sources

## Gotcha worth recording

`tiny-skia` applies `Stroke::width` in path coordinate space, *before* the transform. Pre-multiplying by pixels-per-scene-unit produces a squared-scale blowup (~40px silhouettes). Fix: keep stroke/dash values in scene units.