### PR TITLE
ci: use macos-15-intel for x86_64-apple-darwin prebuilt (macos-13 retired)

### DIFF
--- a/.github/workflows/prebuilt.yaml
+++ b/.github/workflows/prebuilt.yaml
@@ -6,7 +6,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Docker 経由 (cross toolchain が Linux 側で成熟している)。
+  # The following prebuilt tarballs are cross-built via Docker:
+  #   - cadrum-occt-x86_64-unknown-linux-gnu
+  #   - cadrum-occt-aarch64-unknown-linux-gnu
+  #   - cadrum-occt-x86_64-pc-windows-gnu
+  # This is because the cross toolchain for these GNU targets is mature on the
+  # Linux side (cross-gcc / mingw-w64), so Docker gives a reproducible build host.
   build:
     strategy:
       fail-fast: false
@@ -30,10 +35,13 @@ jobs:
           name: cadrum-occt-${{ matrix.target }}
           path: out/${{ matrix.target }}/cadrum-occt-*.tar.gz
 
-  # native Windows runner + native cl.exe で作る。
-  # cargo-xwin/clang-cl 経由の prebuild は MSVC STL template の COMDAT 排出判断が
-  # native cl.exe と食い違い、ユーザ側リンク時に `std::_Variant_storage_<...>`
-  # 未解決シンボルを量産する (issue #73)。native ビルドは ABI 境界を踏まない。
+  # The following prebuilt tarball is built on a native Windows runner with
+  # native cl.exe:
+  #   - cadrum-occt-x86_64-pc-windows-msvc
+  # This is because prebuilding via cargo-xwin/clang-cl makes COMDAT emission
+  # decisions for MSVC STL templates that disagree with native cl.exe, producing
+  # `std::_Variant_storage_<...>` unresolved symbols at the user's link step
+  # (issue #73). A native build does not cross that ABI boundary.
   build-windows-msvc:
     runs-on: windows-2022
     steps:
@@ -67,16 +75,20 @@ jobs:
           name: cadrum-occt-x86_64-pc-windows-msvc
           path: out/cadrum-occt-*.tar.gz
 
-  # native macOS runners + Apple clang/libc++ で作る。
-  # OCCT の静的アーカイブはユーザのリンク時 C++ ABI と一致する必要があるため、
-  # Docker cross ではなくホストの clang/libc++ でソースビルドする
-  # (windows-msvc を native runner で作るのと同じ理由)。
-  # macos-14 = Apple Silicon (aarch64), macos-15-intel = Intel (x86_64)。
-  # ※ macos-13 (旧 Intel ラベル) は 2025-12-04 に廃止されたため、後継の
-  #    macos-15-intel を使う。https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/
-  # cmake / make / clang は GitHub macOS runner にプリインストール済み。
-  # make cadrum-occt 内の CADRUM_BUNDLE_GCC_RUNTIME=1 は Darwin では no-op
-  # (build.rs は *-windows-gnu / *-linux-gnu のみ libstdc++/libgcc を同梱)。
+  # The following prebuilt tarballs are built on native macOS runners with Apple
+  # clang/libc++:
+  #   - cadrum-occt-aarch64-apple-darwin
+  #   - cadrum-occt-x86_64-apple-darwin
+  # This is because this repo has no Docker/osxcross apple-darwin toolchain, and
+  # Apple's SDK + clang are simplest (and license-clean) on real Apple hardware,
+  # which GitHub provides as free runners. macOS libc++ has a stable ABI, so this
+  # is NOT the ABI-forced choice that windows-msvc is.
+  # macos-14 = Apple Silicon (aarch64); macos-15-intel = Intel (x86_64).
+  # NOTE: macos-13 (the old Intel label) was retired on 2025-12-04, so we use its
+  #       successor macos-15-intel. https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/
+  # cmake / make / clang are preinstalled on the GitHub macOS runner.
+  # CADRUM_BUNDLE_GCC_RUNTIME=1 inside `make cadrum-occt` is a no-op on Darwin
+  # (build.rs bundles libstdc++/libgcc only for *-windows-gnu / *-linux-gnu).
   build-macos:
     strategy:
       fail-fast: false

--- a/.github/workflows/prebuilt.yaml
+++ b/.github/workflows/prebuilt.yaml
@@ -71,7 +71,9 @@ jobs:
   # OCCT の静的アーカイブはユーザのリンク時 C++ ABI と一致する必要があるため、
   # Docker cross ではなくホストの clang/libc++ でソースビルドする
   # (windows-msvc を native runner で作るのと同じ理由)。
-  # macos-14 = Apple Silicon (aarch64), macos-13 = Intel (x86_64)。
+  # macos-14 = Apple Silicon (aarch64), macos-15-intel = Intel (x86_64)。
+  # ※ macos-13 (旧 Intel ラベル) は 2025-12-04 に廃止されたため、後継の
+  #    macos-15-intel を使う。https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/
   # cmake / make / clang は GitHub macOS runner にプリインストール済み。
   # make cadrum-occt 内の CADRUM_BUNDLE_GCC_RUNTIME=1 は Darwin では no-op
   # (build.rs は *-windows-gnu / *-linux-gnu のみ libstdc++/libgcc を同梱)。
@@ -83,7 +85,7 @@ jobs:
           - target: aarch64-apple-darwin
             runs-on: macos-14
           - target: x86_64-apple-darwin
-            runs-on: macos-13
+            runs-on: macos-15-intel
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Close #173 

## Problem

The `build-macos` matrix added in #172 pins the `x86_64-apple-darwin` leg to **`macos-13`**. GitHub **retired the `macos-13` runner image on 2025-12-04** ([changelog](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/)), so that job can never get an Intel runner — it sits in `Waiting for a runner to pick up this job…` indefinitely (observed: queued 5h+ while the `macos-14` aarch64 sibling finished in ~18 min).

Because `release` has `needs: [build, build-windows-msvc, build-macos]`, a stuck `build-macos` leg **blocks the entire prebuilt release**, not just the macOS part.

## Fix

The job needs the **Intel (x86_64) architecture, not macOS 13 specifically**, and only *builds* the static archive (no macOS-13-specific runtime dependency). Swap to GitHub's recommended Intel replacement label:

```diff
   - target: x86_64-apple-darwin
-    runs-on: macos-13
+    runs-on: macos-15-intel
```

(+ the adjacent comment updated to note the retirement.)

## Note (follow-up, out of scope here)

This is a **time-limited** fix — Apple has dropped Intel and GitHub plans to retire Intel macOS entirely after `macos-15` (~Fall 2027). The durable option is to cross-build `x86_64-apple-darwin` on an arm64 runner (`macos-14`/`15`, same Apple clang/libc++, `--target x86_64-apple-darwin`) and drop Intel runners altogether.

🤖 Generated with [Claude Code](https://claude.com/claude-code)