### PR TITLE
Consolidate primitive constructor arguments into vectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,15 +126,15 @@ fn main() -> Result<(), cadrum::Error> {
     let example_name = std::path::Path::new(file!()).file_stem().unwrap().to_str().unwrap();
 
     let solids = [
-        Solid::cube(10.0, 20.0, 30.0)
+        Solid::cube(DVec3::ZERO, DVec3::new(10.0, 20.0, 30.0))
             .color("#4a90d9"),
-        Solid::cylinder(8.0, DVec3::Z, 30.0)
+        Solid::cylinder(8.0, DVec3::Z * 30.0)
             .translate(DVec3::X * 30.0)
             .color("#e67e22"),
         Solid::sphere(8.0)
             .translate(DVec3::X * 60.0 + DVec3::Z * 15.0)
             .color("#2ecc71"),
-        Solid::cone(8.0, 0.0, DVec3::Z, 30.0)
+        Solid::cone(8.0, 1.0, DVec3::Z * 30.0)
             .translate(DVec3::X * 90.0)
             .color("#e74c3c"),
         Solid::torus(12.0, 4.0, DVec3::Z)
@@ -253,7 +253,7 @@ use std::f64::consts::PI;
 fn main() -> Result<(), cadrum::Error> {
     let example_name = std::path::Path::new(file!()).file_stem().unwrap().to_str().unwrap();
 
-    let base = Solid::cone(8.0, 0.0, DVec3::Z, 20.0)
+    let base = Solid::cone(8.0, 0.0, DVec3::Z * 20.0)
         .color("#888888");
 
     let solids = [
@@ -314,10 +314,10 @@ use cadrum::{Boolean, DVec3, Solid};
 fn main() -> Result<(), cadrum::Error> {
     let example_name = std::path::Path::new(file!()).file_stem().unwrap().to_str().unwrap();
 
-    let make_box = Solid::cube(20.0, 20.0, 20.0)
+    let make_box = Solid::cube(DVec3::ZERO, DVec3::splat(20.0))
         .translate(DVec3::X * -10.+ DVec3:: Y*-10.)
         .color("#4a90d9");
-    let make_cyl = Solid::cylinder(8.0, DVec3::Z, 30.0)
+    let make_cyl = Solid::cylinder(8.0, DVec3::Z * 30.0)
         .translate(DVec3::Z*-5.)
         .color("#e67e22");
 
@@ -330,7 +330,7 @@ fn main() -> Result<(), cadrum::Error> {
     // intersect: only the overlapping volume — offset X=80
     let intersect: Solid = (&make_box * &make_cyl).build()?;
 
-    let cylinder = Solid::cylinder(8.0, DVec3::Z, 30.0)
+    let cylinder = Solid::cylinder(8.0, DVec3::Z * 30.0)
         .translate(DVec3::X*4.);
     let [cylinder0, cylinder1, cylinder2] = [cylinder.clone(), cylinder.clone().rotate_z(std::f64::consts::TAU/3.), cylinder.clone().rotate_z(-std::f64::consts::TAU/3.)];
 
@@ -596,12 +596,12 @@ fn build_m2_screw() -> Result<Solid, Error> {
 	// Reconstruct the ISO 68-1 basic profile (trapezoid) from the sharp triangle:
 	//   union(shaft) fills the bottom H/4 → P/4-wide flat at the root
 	//   intersect(crest) trims the top H/8 → P/8-wide flat at the crest
-	let shaft = Solid::cylinder(r - r_delta * 6.0 / 8.0, DVec3::Z, h_thread);
-	let crest = Solid::cylinder(r - r_delta / 8.0, DVec3::Z, h_thread);
+	let shaft = Solid::cylinder(r - r_delta * 6.0 / 8.0, DVec3::Z * h_thread);
+	let crest = Solid::cylinder(r - r_delta / 8.0, DVec3::Z * h_thread);
 	let thread_shaft: Solid = ((&thread + &shaft) * &crest).build()?;
 
 	// Stack the flat head on top. Screw ends up centered on the origin.
-	let head = Solid::cylinder(r_head, DVec3::Z, h_head).translate(DVec3::Z * h_thread);
+	let head = Solid::cylinder(r_head, DVec3::Z * h_head).translate(DVec3::Z * h_thread);
 	let res: Solid = (&thread_shaft + &head).build()?;
 	Ok(res.color("red"))
 }
@@ -708,14 +708,14 @@ cargo run --example 08_shell
 use cadrum::{DVec3, Error, Solid};
 
 fn hollow_cube() -> Result<Solid, Error> {
-	let cube = Solid::cube(8.0, 8.0, 8.0);
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(8.0));
 	// TopExp_Explorer order on a box is stable; +Z face ends up last.
 	let top = cube.iter_face().last().expect("cube has faces");
 	cube.shell(-1.0, [top])
 }
 
 fn sealed_cube() -> Result<Solid, Error> {
-	let cube = Solid::cube(8.0, 8.0, 8.0);
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(8.0));
 	cube.shell(-1.0, std::iter::empty::<&cadrum::Face>())
 }
 
@@ -850,13 +850,13 @@ cargo run --example 10_fillet
 use cadrum::{DVec3, Error, Solid};
 
 fn rounded_cube(size: f64) -> Result<Solid, Error> {
-	let cube = Solid::cube(size, size, size).translate(-DVec3::ONE * (size / 2.0));
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(size)).translate(-DVec3::ONE * (size / 2.0));
 	let radius = size * 0.2;
 	cube.fillet_edges(radius, cube.iter_edge())
 }
 
 fn soft_top_cube(size: f64) -> Result<Solid, Error> {
-	let cube = Solid::cube(size, size, size).translate(-DVec3::ONE * (size / 2.0));
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(size)).translate(-DVec3::ONE * (size / 2.0));
 	let radius = size * 0.2;
 	// Top cap boundary: a closed circular edge whose start == end lives at z = h.
 	let top_edges = cube
@@ -866,7 +866,7 @@ fn soft_top_cube(size: f64) -> Result<Solid, Error> {
 }
 
 fn coin(radius: f64, height: f64) -> Result<Solid, Error> {
-	let cyl = Solid::cylinder(radius, DVec3::Z, height);
+	let cyl = Solid::cylinder(radius, DVec3::Z * height);
 	let radius = height * 0.3;
 	// Top cap boundary: a closed circular edge whose start == end lives at z = h.
 	let top_circle = cyl
@@ -919,13 +919,13 @@ cargo run --example 11_chamfer
 use cadrum::{DVec3, Error, Solid};
 
 fn beveled_cube(size: f64) -> Result<Solid, Error> {
-	let cube = Solid::cube(size, size, size).translate(-DVec3::ONE * (size / 2.0));
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(size)).translate(-DVec3::ONE * (size / 2.0));
 	let distance = size * 0.2;
 	cube.chamfer_edges(distance, cube.iter_edge())
 }
 
 fn beveled_top_cube(size: f64) -> Result<Solid, Error> {
-	let cube = Solid::cube(size, size, size).translate(-DVec3::ONE * (size / 2.0));
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(size)).translate(-DVec3::ONE * (size / 2.0));
 	let distance = size * 0.2;
 	// Top cap boundary: a closed circular edge whose start == end lives at z = h.
 	let top_edges = cube
@@ -935,7 +935,7 @@ fn beveled_top_cube(size: f64) -> Result<Solid, Error> {
 }
 
 fn beveled_coin(radius: f64, height: f64) -> Result<Solid, Error> {
-	let cyl = Solid::cylinder(radius, DVec3::Z, height);
+	let cyl = Solid::cylinder(radius, DVec3::Z * height);
 	let distance = height * 0.3;
 	// Top cap boundary: a closed circular edge whose start == end lives at z = h.
 	let top_circle = cyl
@@ -992,9 +992,9 @@ use cadrum::{DVec3, Solid};
 fn main() -> Result<(), cadrum::Error> {
 	let example_name = std::path::Path::new(file!()).file_stem().unwrap().to_str().unwrap();
 
-	let block = Solid::cube(40.0, 30.0, 20.0)
+	let block = Solid::cube(DVec3::ZERO, DVec3::new(40.0, 30.0, 20.0))
 		.translate(-DVec3::new(20.0, 15.0, 10.0));
-	let hole = Solid::cylinder(5.0, DVec3::Z, 30.0)
+	let hole = Solid::cylinder(5.0, DVec3::Z * 30.0)
 		.translate(-DVec3::Z * 15.0);
 	// Axis-orientation check: carve only the +X+Y+Z corner with a sphere.
 	// Which corner the notch appears in on each panel uniquely confirms the gnomon's direction.
@@ -1028,7 +1028,7 @@ needed:
 
 ```rust,no_run
 # use cadrum::{DVec3, Solid};
-let s = Solid::cube(1.0, 1.0, 1.0).rotate_z(0.5).translate(DVec3::X);
+let s = Solid::cube(DVec3::ZERO, DVec3::ONE).rotate_z(0.5).translate(DVec3::X);
 let v = s.volume();
 ```
 
@@ -1040,7 +1040,7 @@ transform and aggregate them with ordinary iterator idioms:
 use cadrum::{DVec3, Solid};
 
 let parts: Vec<Solid> = vec![
-    Solid::cube(1.0, 1.0, 1.0),
+    Solid::cube(DVec3::ZERO, DVec3::ONE),
     Solid::sphere(1.0),
 ];
 // element-wise transform

--- a/examples/00_chijin.rs
+++ b/examples/00_chijin.rs
@@ -5,7 +5,7 @@ use std::f64::consts::PI;
 
 fn chijin() -> Result<Solid, cadrum::Error> {
 	// ── Body (cylinder): r=15, h=8, centered at origin (z=-4..+4) ────────
-	let cylinder = Solid::cylinder(15.0, DVec3::Z, 8.0)
+	let cylinder = Solid::cylinder(15.0, DVec3::Z * 8.0)
 		.translate(DVec3::Z * -4.0)
 		.color("#999");
 
@@ -28,13 +28,13 @@ fn chijin() -> Result<Solid, cadrum::Error> {
 	let sheets = [sheet.clone().mirror(DVec3::ZERO, DVec3::Z), sheet];
 
 	// ── Lacing blocks: 2x8x1, rotated 60° around Z, placed at y=15 ──────
-	let block_proto = Solid::cube(2.0, 8.0, 1.0)
+	let block_proto = Solid::cube(DVec3::ZERO, DVec3::new(2.0, 8.0, 1.0))
 		.translate(DVec3::new(-1.0, -4.0, -0.5))
 		.rotate_z(60.0_f64.to_radians())
 		.translate(DVec3::Y * 15.0);
 
 	// ── Lacing holes: thin cylinders through each block ──────────────────
-	let hole_proto = Solid::cylinder(0.7, DVec3::X * 10.0 + DVec3::Z * 30.0, 30.0)
+	let hole_proto = Solid::cylinder(0.7, (DVec3::X * 10.0 + DVec3::Z * 30.0).normalize() * 30.0)
 		.translate(DVec3::new(-5.0, 16.0, -15.0));
 
 	// Distribute N blocks and holes evenly around Z, each block in a rainbow color

--- a/examples/01_primitives.rs
+++ b/examples/01_primitives.rs
@@ -6,15 +6,15 @@ fn main() -> Result<(), cadrum::Error> {
     let example_name = std::path::Path::new(file!()).file_stem().unwrap().to_str().unwrap();
 
     let solids = [
-        Solid::cube(10.0, 20.0, 30.0)
+        Solid::cube(DVec3::ZERO, DVec3::new(10.0, 20.0, 30.0))
             .color("#4a90d9"),
-        Solid::cylinder(8.0, DVec3::Z, 30.0)
+        Solid::cylinder(8.0, DVec3::Z * 30.0)
             .translate(DVec3::X * 30.0)
             .color("#e67e22"),
         Solid::sphere(8.0)
             .translate(DVec3::X * 60.0 + DVec3::Z * 15.0)
             .color("#2ecc71"),
-        Solid::cone(8.0, 0.0, DVec3::Z, 30.0)
+        Solid::cone(8.0, 1.0, DVec3::Z * 30.0)
             .translate(DVec3::X * 90.0)
             .color("#e74c3c"),
         Solid::torus(12.0, 4.0, DVec3::Z)

--- a/examples/03_transform.rs
+++ b/examples/03_transform.rs
@@ -6,7 +6,7 @@ use std::f64::consts::PI;
 fn main() -> Result<(), cadrum::Error> {
     let example_name = std::path::Path::new(file!()).file_stem().unwrap().to_str().unwrap();
 
-    let base = Solid::cone(8.0, 0.0, DVec3::Z, 20.0)
+    let base = Solid::cone(8.0, 0.0, DVec3::Z * 20.0)
         .color("#888888");
 
     let solids = [

--- a/examples/04_boolean.rs
+++ b/examples/04_boolean.rs
@@ -5,10 +5,10 @@ use cadrum::{Boolean, DVec3, Solid};
 fn main() -> Result<(), cadrum::Error> {
     let example_name = std::path::Path::new(file!()).file_stem().unwrap().to_str().unwrap();
 
-    let make_box = Solid::cube(20.0, 20.0, 20.0)
+    let make_box = Solid::cube(DVec3::ZERO, DVec3::splat(20.0))
         .translate(DVec3::X * -10.+ DVec3:: Y*-10.)
         .color("#4a90d9");
-    let make_cyl = Solid::cylinder(8.0, DVec3::Z, 30.0)
+    let make_cyl = Solid::cylinder(8.0, DVec3::Z * 30.0)
         .translate(DVec3::Z*-5.)
         .color("#e67e22");
 
@@ -21,7 +21,7 @@ fn main() -> Result<(), cadrum::Error> {
     // intersect: only the overlapping volume — offset X=80
     let intersect: Solid = (&make_box * &make_cyl).build()?;
 
-    let cylinder = Solid::cylinder(8.0, DVec3::Z, 30.0)
+    let cylinder = Solid::cylinder(8.0, DVec3::Z * 30.0)
         .translate(DVec3::X*4.);
     let [cylinder0, cylinder1, cylinder2] = [cylinder.clone(), cylinder.clone().rotate_z(std::f64::consts::TAU/3.), cylinder.clone().rotate_z(-std::f64::consts::TAU/3.)];
 

--- a/examples/07_sweep.rs
+++ b/examples/07_sweep.rs
@@ -47,12 +47,12 @@ fn build_m2_screw() -> Result<Solid, Error> {
 	// Reconstruct the ISO 68-1 basic profile (trapezoid) from the sharp triangle:
 	//   union(shaft) fills the bottom H/4 → P/4-wide flat at the root
 	//   intersect(crest) trims the top H/8 → P/8-wide flat at the crest
-	let shaft = Solid::cylinder(r - r_delta * 6.0 / 8.0, DVec3::Z, h_thread);
-	let crest = Solid::cylinder(r - r_delta / 8.0, DVec3::Z, h_thread);
+	let shaft = Solid::cylinder(r - r_delta * 6.0 / 8.0, DVec3::Z * h_thread);
+	let crest = Solid::cylinder(r - r_delta / 8.0, DVec3::Z * h_thread);
 	let thread_shaft: Solid = ((&thread + &shaft) * &crest).build()?;
 
 	// Stack the flat head on top. Screw ends up centered on the origin.
-	let head = Solid::cylinder(r_head, DVec3::Z, h_head).translate(DVec3::Z * h_thread);
+	let head = Solid::cylinder(r_head, DVec3::Z * h_head).translate(DVec3::Z * h_thread);
 	let res: Solid = (&thread_shaft + &head).build()?;
 	Ok(res.color("red"))
 }

--- a/examples/08_shell.rs
+++ b/examples/08_shell.rs
@@ -9,14 +9,14 @@
 use cadrum::{DVec3, Error, Solid};
 
 fn hollow_cube() -> Result<Solid, Error> {
-	let cube = Solid::cube(8.0, 8.0, 8.0);
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(8.0));
 	// TopExp_Explorer order on a box is stable; +Z face ends up last.
 	let top = cube.iter_face().last().expect("cube has faces");
 	cube.shell(-1.0, [top])
 }
 
 fn sealed_cube() -> Result<Solid, Error> {
-	let cube = Solid::cube(8.0, 8.0, 8.0);
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(8.0));
 	cube.shell(-1.0, std::iter::empty::<&cadrum::Face>())
 }
 

--- a/examples/101_joint.rs
+++ b/examples/101_joint.rs
@@ -1,10 +1,10 @@
 use cadrum::{Boolean, Edge, Error, Solid};
 use glam::DVec3;
 fn part(inner: f64, outer: f64, height: f64) -> Result<[Solid; 3], Error> {
-	let outer_solid = Solid::cube(outer, outer, height).translate(DVec3::ONE * -outer / 2.0);
+	let outer_solid = Solid::cube(DVec3::ZERO, DVec3::new(outer, outer, height)).translate(DVec3::ONE * -outer / 2.0);
 	let between_edge = Edge::polygon(&[DVec3::new(outer / 2.0, height - outer / 2.0, 0.0), DVec3::new(outer / 2.0, outer / 2.0, 0.0), DVec3::new(height - outer / 2.0, outer / 2.0, 0.0)])?;
 	let between_solid = Solid::extrude(&between_edge, DVec3::Z * outer / 2.0)?;
-	let inner_solid = Solid::cylinder(inner / 2.0, DVec3::Z, height * 1000.0);
+	let inner_solid = Solid::cylinder(inner / 2.0, DVec3::Z * height * 1000.0);
 	Ok([outer_solid, between_solid, inner_solid])
 }
 fn main() -> Result<(), Error> {

--- a/examples/10_fillet.rs
+++ b/examples/10_fillet.rs
@@ -6,13 +6,13 @@
 use cadrum::{DVec3, Error, Solid};
 
 fn rounded_cube(size: f64) -> Result<Solid, Error> {
-	let cube = Solid::cube(size, size, size).translate(-DVec3::ONE * (size / 2.0));
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(size)).translate(-DVec3::ONE * (size / 2.0));
 	let radius = size * 0.2;
 	cube.fillet_edges(radius, cube.iter_edge())
 }
 
 fn soft_top_cube(size: f64) -> Result<Solid, Error> {
-	let cube = Solid::cube(size, size, size).translate(-DVec3::ONE * (size / 2.0));
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(size)).translate(-DVec3::ONE * (size / 2.0));
 	let radius = size * 0.2;
 	// Top cap boundary: a closed circular edge whose start == end lives at z = h.
 	let top_edges = cube
@@ -22,7 +22,7 @@ fn soft_top_cube(size: f64) -> Result<Solid, Error> {
 }
 
 fn coin(radius: f64, height: f64) -> Result<Solid, Error> {
-	let cyl = Solid::cylinder(radius, DVec3::Z, height);
+	let cyl = Solid::cylinder(radius, DVec3::Z * height);
 	let radius = height * 0.3;
 	// Top cap boundary: a closed circular edge whose start == end lives at z = h.
 	let top_circle = cyl

--- a/examples/11_chamfer.rs
+++ b/examples/11_chamfer.rs
@@ -6,13 +6,13 @@
 use cadrum::{DVec3, Error, Solid};
 
 fn beveled_cube(size: f64) -> Result<Solid, Error> {
-	let cube = Solid::cube(size, size, size).translate(-DVec3::ONE * (size / 2.0));
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(size)).translate(-DVec3::ONE * (size / 2.0));
 	let distance = size * 0.2;
 	cube.chamfer_edges(distance, cube.iter_edge())
 }
 
 fn beveled_top_cube(size: f64) -> Result<Solid, Error> {
-	let cube = Solid::cube(size, size, size).translate(-DVec3::ONE * (size / 2.0));
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(size)).translate(-DVec3::ONE * (size / 2.0));
 	let distance = size * 0.2;
 	// Top cap boundary: a closed circular edge whose start == end lives at z = h.
 	let top_edges = cube
@@ -22,7 +22,7 @@ fn beveled_top_cube(size: f64) -> Result<Solid, Error> {
 }
 
 fn beveled_coin(radius: f64, height: f64) -> Result<Solid, Error> {
-	let cyl = Solid::cylinder(radius, DVec3::Z, height);
+	let cyl = Solid::cylinder(radius, DVec3::Z * height);
 	let distance = height * 0.3;
 	// Top cap boundary: a closed circular edge whose start == end lives at z = h.
 	let top_circle = cyl

--- a/examples/12_multiview.rs
+++ b/examples/12_multiview.rs
@@ -10,9 +10,9 @@ use cadrum::{DVec3, Solid};
 fn main() -> Result<(), cadrum::Error> {
 	let example_name = std::path::Path::new(file!()).file_stem().unwrap().to_str().unwrap();
 
-	let block = Solid::cube(40.0, 30.0, 20.0)
+	let block = Solid::cube(DVec3::ZERO, DVec3::new(40.0, 30.0, 20.0))
 		.translate(-DVec3::new(20.0, 15.0, 10.0));
-	let hole = Solid::cylinder(5.0, DVec3::Z, 30.0)
+	let hole = Solid::cylinder(5.0, DVec3::Z * 30.0)
 		.translate(-DVec3::Z * 15.0);
 	// Axis-orientation check: carve only the +X+Y+Z corner with a sphere.
 	// Which corner the notch appears in on each panel uniquely confirms the gnomon's direction.

--- a/sandbox-wasm/src/lib.rs
+++ b/sandbox-wasm/src/lib.rs
@@ -6,6 +6,6 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 pub fn box_svg() -> String {
-	let solid = Solid::cube(10.0, 20.0, 30.0).color("#4a90d9");
+	let solid = Solid::cube(DVec3::ZERO, DVec3::new(10.0, 20.0, 30.0)).color("#4a90d9");
 	cadrum::Solid::mesh(&[solid], 0.5).unwrap().to_svg(DVec3::new(1.0, 1.0, 1.0), false).unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,10 +66,10 @@ impl Face{
 impl Solid{
     ////////// codegen.rs
 	pub fn id(&self) -> u64 {<Self as crate::traits::SolidStruct>::id(self)}
-	pub fn cube(x: f64, y: f64, z: f64) -> crate::Solid {<Self as crate::traits::SolidStruct>::cube(x, y, z)}
+	pub fn cube(corner0: DVec3, corner1: DVec3) -> crate::Solid {<Self as crate::traits::SolidStruct>::cube(corner0, corner1)}
 	pub fn sphere(radius: f64) -> crate::Solid {<Self as crate::traits::SolidStruct>::sphere(radius)}
-	pub fn cylinder(r: f64, axis: DVec3, h: f64) -> crate::Solid {<Self as crate::traits::SolidStruct>::cylinder(r, axis, h)}
-	pub fn cone(r1: f64, r2: f64, axis: DVec3, h: f64) -> crate::Solid {<Self as crate::traits::SolidStruct>::cone(r1, r2, axis, h)}
+	pub fn cylinder(r: f64, height: DVec3) -> crate::Solid {<Self as crate::traits::SolidStruct>::cylinder(r, height)}
+	pub fn cone(r1: f64, r2: f64, height: DVec3) -> crate::Solid {<Self as crate::traits::SolidStruct>::cone(r1, r2, height)}
 	pub fn torus(r1: f64, r2: f64, axis: DVec3) -> crate::Solid {<Self as crate::traits::SolidStruct>::torus(r1, r2, axis)}
 	pub fn half_space(plane_origin: DVec3, plane_normal: DVec3) -> crate::Solid {<Self as crate::traits::SolidStruct>::half_space(plane_origin, plane_normal)}
 	pub fn iter_edge(&self) -> impl Iterator<Item = &Edge> + '_ {<Self as crate::traits::SolidStruct>::iter_edge(self)}

--- a/src/occt/solid.rs
+++ b/src/occt/solid.rs
@@ -141,8 +141,8 @@ impl SolidStruct for Solid {
 
 	// ==================== Constructors ====================
 
-	fn cube(x: f64, y: f64, z: f64) -> Solid {
-		let inner = ffi::make_box(0.0, 0.0, 0.0, x, y, z);
+	fn cube(corner0: DVec3, corner1: DVec3) -> Solid {
+		let inner = ffi::make_box(corner0.x, corner0.y, corner0.z, corner1.x, corner1.y, corner1.z);
 		Solid::new(
 			inner,
 			#[cfg(feature = "color")]
@@ -151,8 +151,8 @@ impl SolidStruct for Solid {
 		)
 	}
 
-	fn cylinder(r: f64, axis: DVec3, h: f64) -> Solid {
-		let inner = ffi::make_cylinder(0.0, 0.0, 0.0, axis.x, axis.y, axis.z, r, h);
+	fn cylinder(r: f64, height: DVec3) -> Solid {
+		let inner = ffi::make_cylinder(0.0, 0.0, 0.0, height.x, height.y, height.z, r, height.length());
 		Solid::new(
 			inner,
 			#[cfg(feature = "color")]
@@ -171,8 +171,8 @@ impl SolidStruct for Solid {
 		)
 	}
 
-	fn cone(r1: f64, r2: f64, axis: DVec3, h: f64) -> Solid {
-		let inner = ffi::make_cone(0.0, 0.0, 0.0, axis.x, axis.y, axis.z, r1, r2, h);
+	fn cone(r1: f64, r2: f64, height: DVec3) -> Solid {
+		let inner = ffi::make_cone(0.0, 0.0, 0.0, height.x, height.y, height.z, r1, r2, height.length());
 		Solid::new(
 			inner,
 			#[cfg(feature = "color")]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -444,10 +444,10 @@ pub trait SolidStruct: Sized + Clone + Transform{
 	fn id(&self) -> u64;
 
 	// --- Constructors ---
-	fn cube(x: f64, y: f64, z: f64) -> Self;
+	fn cube(corner0: DVec3, corner1: DVec3) -> Self;
 	fn sphere(radius: f64) -> Self;
-	fn cylinder(r: f64, axis: DVec3, h: f64) -> Self;
-	fn cone(r1: f64, r2: f64, axis: DVec3, h: f64) -> Self;
+	fn cylinder(r: f64, height: DVec3) -> Self;
+	fn cone(r1: f64, r2: f64, height: DVec3) -> Self;
 	fn torus(r1: f64, r2: f64, axis: DVec3) -> Self;
 	fn half_space(plane_origin: DVec3, plane_normal: DVec3) -> Self;
 

--- a/tests/boolean.rs
+++ b/tests/boolean.rs
@@ -8,7 +8,7 @@ use cadrum::{Boolean, DVec3, Solid};
 
 /// 原点に置いた cube を `(tx, ty, tz)` だけ平行移動して返す。
 fn cube(x: f64, y: f64, z: f64, tx: f64, ty: f64, tz: f64) -> Solid {
-	Solid::cube(x, y, z).translate(DVec3::new(tx, ty, tz))
+	Solid::cube(DVec3::ZERO, DVec3::new(x, y, z)).translate(DVec3::new(tx, ty, tz))
 }
 
 // ==================== union (`+` / `Sum`) ====================
@@ -16,8 +16,8 @@ fn cube(x: f64, y: f64, z: f64, tx: f64, ty: f64, tz: f64) -> Solid {
 #[test]
 fn test_union_two_cylinders() {
 	// 2 つのオーバーラップする円柱の union は 1 つの Solid になる。
-	let a = Solid::cylinder(1.1, DVec3::Z, 1.0).translate(DVec3::new(1.0, 0.0, 0.0));
-	let b = Solid::cylinder(1.1, DVec3::Z, 1.0).translate(DVec3::new(-1.0, 0.0, 0.0));
+	let a = Solid::cylinder(1.1, DVec3::Z * 1.0).translate(DVec3::new(1.0, 0.0, 0.0));
+	let b = Solid::cylinder(1.1, DVec3::Z * 1.0).translate(DVec3::new(-1.0, 0.0, 0.0));
 	let v: Vec<Solid> = (&a + &b).build_vec().unwrap();
 	assert_eq!(v.len(), 1, "overlapping cylinders should union to 1 solid");
 }
@@ -25,10 +25,10 @@ fn test_union_two_cylinders() {
 #[test]
 fn test_union_disjoint() {
 	// 距離 4.0 離れた 2 つの円柱を 4 つ union → 2 つ x 2 つで disjoint なので 4 ペア
-	let a = Solid::cylinder(1.1, DVec3::Z, 1.0);
-	let b = Solid::cylinder(1.1, DVec3::Z, 1.0).translate(DVec3::new(4.0, 0.0, 0.0));
-	let c = Solid::cylinder(1.1, DVec3::Z, 1.0).translate(DVec3::new(0.0, 1.0, 0.0));
-	let d = Solid::cylinder(1.1, DVec3::Z, 1.0).translate(DVec3::new(4.0, 1.0, 0.0));
+	let a = Solid::cylinder(1.1, DVec3::Z * 1.0);
+	let b = Solid::cylinder(1.1, DVec3::Z * 1.0).translate(DVec3::new(4.0, 0.0, 0.0));
+	let c = Solid::cylinder(1.1, DVec3::Z * 1.0).translate(DVec3::new(0.0, 1.0, 0.0));
+	let d = Solid::cylinder(1.1, DVec3::Z * 1.0).translate(DVec3::new(4.0, 1.0, 0.0));
 	let v: Vec<Solid> = [&a, &b, &c, &d].into_iter().map(Boolean::from).reduce(|a, b| a + b).unwrap().build_vec().unwrap();
 	// A∪C と B∪D の 2 グループに分かれる (重なる距離 1.0 で連結)
 	assert!(v.len() == 2, "disjoint groups should be 2 solids, got {}", v.len());
@@ -51,7 +51,7 @@ fn test_union_olympic_rings_out_of_order() {
 	// CellsBuilder は全交差を 1 パスで計算するので並び順に依存しない。
 	let s = 1.0;
 	let step = 0.8;
-	let mk = |i: f64| Solid::cube(s, s, s).translate(DVec3::new(i * step, 0.0, 0.0));
+	let mk = |i: f64| Solid::cube(DVec3::ZERO, DVec3::splat(s)).translate(DVec3::new(i * step, 0.0, 0.0));
 	let ring1 = mk(0.0);
 	let ring2 = mk(1.0);
 	let ring3 = mk(2.0);
@@ -84,9 +84,9 @@ fn test_intersect_sphere_with_multiple_cylinders() {
 	let r = 0.8;
 	let len = 20.0;
 	let half = len / 2.0;
-	let cyl_x = Solid::cylinder(r, DVec3::X, len).translate(DVec3::new(-half, 0.0, 0.0));
-	let cyl_y = Solid::cylinder(r, DVec3::Y, len).translate(DVec3::new(0.0, -half, 0.0));
-	let cyl_z = Solid::cylinder(r, DVec3::Z, len).translate(DVec3::new(0.0, 0.0, -half));
+	let cyl_x = Solid::cylinder(r, DVec3::X * len).translate(DVec3::new(-half, 0.0, 0.0));
+	let cyl_y = Solid::cylinder(r, DVec3::Y * len).translate(DVec3::new(0.0, -half, 0.0));
+	let cyl_z = Solid::cylinder(r, DVec3::Z * len).translate(DVec3::new(0.0, 0.0, -half));
 
 	let multi: Solid = [&sphere, &cyl_x, &cyl_y, &cyl_z].into_iter().map(Boolean::from).reduce(|x, y| x * y).unwrap().build().unwrap();
 	// 中心の小さなボリュームのみ ≈ 2.4
@@ -103,9 +103,9 @@ fn test_subtract_sphere_with_multiple_holes() {
 	let len = 12.0;
 	let half = len / 2.0;
 	let r = 1.0;
-	let hole_x = Solid::cylinder(r, DVec3::X, len).translate(DVec3::new(-half, 0.0, 0.0));
-	let hole_y = Solid::cylinder(r, DVec3::Y, len).translate(DVec3::new(0.0, -half, 0.0));
-	let hole_z = Solid::cylinder(r, DVec3::Z, len).translate(DVec3::new(0.0, 0.0, -half));
+	let hole_x = Solid::cylinder(r, DVec3::X * len).translate(DVec3::new(-half, 0.0, 0.0));
+	let hole_y = Solid::cylinder(r, DVec3::Y * len).translate(DVec3::new(0.0, -half, 0.0));
+	let hole_z = Solid::cylinder(r, DVec3::Z * len).translate(DVec3::new(0.0, 0.0, -half));
 
 	let multi: Solid = (&sphere - &hole_x - &hole_y - &hole_z).build().unwrap();
 	// V(sphere) ≈ 523.6, V(3 cylinders inside sphere) ≈ 81.9
@@ -118,8 +118,8 @@ fn test_subtract_sphere_with_multiple_holes() {
 #[test]
 fn test_operator_overloads() {
 	// `+` / `-` / `*` for Solid/&Solid combinations → Boolean<Solid>
-	let a = Solid::cube(10.0, 10.0, 10.0);
-	let b = Solid::cube(10.0, 10.0, 10.0).translate(DVec3::new(5.0, 5.0, 5.0));
+	let a = Solid::cube(DVec3::ZERO, DVec3::splat(10.0));
+	let b = Solid::cube(DVec3::ZERO, DVec3::splat(10.0)).translate(DVec3::new(5.0, 5.0, 5.0));
 
 	let u: Solid = (&a + &b).build().expect("a + b should yield one solid");
 	println!("a + b (union):     volume = {:.4}", u.volume());
@@ -131,7 +131,7 @@ fn test_operator_overloads() {
 	println!("a * b (intersect): volume = {:.4}", i.volume());
 
 	// 非交差での intersect → build_vec で 0 個、build で OneFailed(0)
-	let far = Solid::cube(1.0, 1.0, 1.0).translate(DVec3::new(100.0, 0.0, 0.0));
+	let far = Solid::cube(DVec3::ZERO, DVec3::ONE).translate(DVec3::new(100.0, 0.0, 0.0));
 	match (&a * &far).build() {
 		Err(e @ cadrum::Error::OneFailed(0)) => println!("a * far (disjoint) -> {:?}", e),
 		Err(e) => panic!("expected OneFailed(0), got {:?}", e),
@@ -141,7 +141,7 @@ fn test_operator_overloads() {
 
 #[test]
 fn test_singleton_build() {
-	let a = Solid::cube(10.0, 10.0, 10.0);
+	let a = Solid::cube(DVec3::ZERO, DVec3::splat(10.0));
 	let expected = a.volume();
 	let b = std::iter::once(&a).map(Boolean::from).reduce(|x, y| x + y).unwrap(); // fold でも reduce でも同じ結果 (単一要素はそのまま)
 	let s: Solid = b.build().unwrap();
@@ -161,9 +161,9 @@ fn test_empty_returns_error() {
 fn test_build_direct() {
 	// Solid::boolean_build を直接呼ぶ低レベルテスト。
 	// (A + B) - C で `A=cube@0, B=cube@5, C=cube@2` を計算。
-	let a = Solid::cube(10.0, 10.0, 10.0);
-	let b = Solid::cube(10.0, 10.0, 10.0).translate(DVec3::new(5.0, 0.0, 0.0));
-	let c = Solid::cube(10.0, 10.0, 10.0).translate(DVec3::new(2.0, 0.0, 0.0));
+	let a = Solid::cube(DVec3::ZERO, DVec3::splat(10.0));
+	let b = Solid::cube(DVec3::ZERO, DVec3::splat(10.0)).translate(DVec3::new(5.0, 0.0, 0.0));
+	let c = Solid::cube(DVec3::ZERO, DVec3::splat(10.0)).translate(DVec3::new(2.0, 0.0, 0.0));
 	let solids = vec![a, b, c];
 	// (A∪B)∖C → DNF: A∖C ∪ B∖C → clauses [1,-3,0, 2,-3,0]
 	let clauses = vec![1, -3, 0, 2, -3, 0];

--- a/tests/brep.rs
+++ b/tests/brep.rs
@@ -4,10 +4,10 @@
 //! then read it back.  If the reader only consumes what it needs
 //! (count-driven parsing) and ignores trailing data, these tests pass.
 
-use cadrum::Solid;
+use cadrum::{DVec3, Solid};
 
 fn test_box() -> Vec<Solid> {
-	vec![Solid::cube(1.0, 1.0, 1.0)]
+	vec![Solid::cube(DVec3::ZERO, DVec3::ONE)]
 }
 
 /// Write BRep binary, append 1 KB of 0xAB, read back.

--- a/tests/chamfer.rs
+++ b/tests/chamfer.rs
@@ -7,7 +7,7 @@
 //!   `V_removed = 6 d² (a − d)`.
 //! This is used below to validate OCCT's output within 0.1%.
 
-use cadrum::{Error, Solid};
+use cadrum::{DVec3, Error, Solid};
 
 const EPS: f64 = 1e-6;
 
@@ -15,7 +15,7 @@ const EPS: f64 = 1e-6;
 fn test_chamfer_cube_reduces_volume_and_area() {
 	let a = 10.0_f64;
 	let d = 1.0_f64;
-	let cube = Solid::cube(a, a, a);
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(a));
 	let original_volume = cube.volume();
 	let original_area = cube.area();
 	let edges: Vec<_> = cube.iter_edge().collect();
@@ -31,7 +31,7 @@ fn test_chamfer_cube_reduces_volume_and_area() {
 fn test_chamfer_cube_matches_analytical_volume() {
 	let a = 10.0_f64;
 	let d = 1.0_f64;
-	let cube = Solid::cube(a, a, a);
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(a));
 	let edges: Vec<_> = cube.iter_edge().collect();
 	let beveled = cube.chamfer_edges(d, edges).expect("chamfer cube");
 
@@ -49,7 +49,7 @@ fn test_chamfer_cube_matches_analytical_volume() {
 
 #[test]
 fn test_chamfer_empty_edges_is_noop() {
-	let cube = Solid::cube(5.0, 5.0, 5.0);
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(5.0));
 	let original_volume = cube.volume();
 	let unchanged = cube
 		.chamfer_edges(0.5, std::iter::empty::<&cadrum::Edge>())
@@ -60,7 +60,7 @@ fn test_chamfer_empty_edges_is_noop() {
 
 #[test]
 fn test_chamfer_distance_too_large_returns_err() {
-	let cube = Solid::cube(2.0, 2.0, 2.0);
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(2.0));
 	let edges: Vec<_> = cube.iter_edge().collect();
 	// d = 5 > a/2 = 1 → geometrically impossible; OCCT reports not-done.
 	let err = cube.chamfer_edges(5.0, edges).err().expect("oversized distance must fail");

--- a/tests/fillet.rs
+++ b/tests/fillet.rs
@@ -7,7 +7,7 @@
 //!     `r³ − (4/3) π r³ / 8 = r³ − π r³ / 6`
 //! The analytical result below is used to validate OCCT's output within 0.1%.
 
-use cadrum::{Error, Solid};
+use cadrum::{DVec3, Error, Solid};
 use std::f64::consts::PI;
 
 const EPS: f64 = 1e-6;
@@ -16,7 +16,7 @@ const EPS: f64 = 1e-6;
 fn test_fillet_cube_reduces_volume_and_area() {
 	let a = 10.0_f64;
 	let r = 1.0_f64;
-	let cube = Solid::cube(a, a, a);
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(a));
 	let original_volume = cube.volume();
 	let original_area = cube.area();
 	let edges: Vec<_> = cube.iter_edge().collect();
@@ -32,7 +32,7 @@ fn test_fillet_cube_reduces_volume_and_area() {
 fn test_fillet_cube_matches_analytical_volume() {
 	let a = 10.0_f64;
 	let r = 1.0_f64;
-	let cube = Solid::cube(a, a, a);
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(a));
 	let edges: Vec<_> = cube.iter_edge().collect();
 	let rounded = cube.fillet_edges(r, edges).expect("fillet cube");
 
@@ -47,7 +47,7 @@ fn test_fillet_cube_matches_analytical_volume() {
 
 #[test]
 fn test_fillet_empty_edges_is_noop() {
-	let cube = Solid::cube(5.0, 5.0, 5.0);
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(5.0));
 	let original_volume = cube.volume();
 	let unchanged = cube
 		.fillet_edges(0.5, std::iter::empty::<&cadrum::Edge>())
@@ -58,7 +58,7 @@ fn test_fillet_empty_edges_is_noop() {
 
 #[test]
 fn test_fillet_radius_too_large_returns_err() {
-	let cube = Solid::cube(2.0, 2.0, 2.0);
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(2.0));
 	let edges: Vec<_> = cube.iter_edge().collect();
 	// r = 5 > a/2 = 1 → geometrically impossible; OCCT reports not-done.
 	let err = cube.fillet_edges(5.0, edges).err().expect("oversized radius must fail");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -21,15 +21,15 @@ fn dvec3(x: f64, y: f64, z: f64) -> DVec3 {
 }
 
 fn test_box() -> Solid {
-	Solid::cube(10.0, 10.0, 10.0)
+	Solid::cube(DVec3::ZERO, DVec3::splat(10.0))
 }
 
 fn test_box_2() -> Solid {
-	Solid::cube(10.0, 10.0, 10.0).translate(dvec3(5.0, 5.0, 5.0))
+	Solid::cube(DVec3::ZERO, DVec3::splat(10.0)).translate(dvec3(5.0, 5.0, 5.0))
 }
 
 fn test_box_3() -> Solid {
-	Solid::cube(5.0, 5.0, 5.0).translate(dvec3(3.0, 3.0, 3.0))
+	Solid::cube(DVec3::ZERO, DVec3::splat(5.0)).translate(dvec3(3.0, 3.0, 3.0))
 }
 
 /// Helper: write shape to BRep binary bytes
@@ -119,7 +119,7 @@ fn test_t02_multiple_reads_no_crash() {
 
 #[test]
 fn test_t04_approximation_tolerance() {
-	let cyl = [Solid::cylinder(10.0, dvec3(0.0, 0.0, 1.0), 20.0)];
+	let cyl = [Solid::cylinder(10.0, dvec3(0.0, 0.0, 1.0) * 20.0)];
 	let mut has_difference = false;
 	for edge in cyl.iter().flat_map(|s| s.iter_edge()) {
 		let coarse = edge.approximation_segments(1.0).len();
@@ -190,8 +190,8 @@ fn test_t08_boolean_returns_shape() {
 
 #[test]
 fn test_hollow_cube_write_step() {
-	let outer = [Solid::cube(20.0, 20.0, 20.0).translate(dvec3(-10.0, -10.0, -10.0))];
-	let inner = [Solid::cube(10.0, 10.0, 10.0).translate(dvec3(-5.0, -5.0, -5.0))];
+	let outer = [Solid::cube(DVec3::ZERO, DVec3::splat(20.0)).translate(dvec3(-10.0, -10.0, -10.0))];
+	let inner = [Solid::cube(DVec3::ZERO, DVec3::splat(10.0)).translate(dvec3(-5.0, -5.0, -5.0))];
 	let hollow_cube: Vec<Solid> = (&outer[0] - &inner[0]).build_vec().unwrap();
 
 	std::fs::create_dir_all("out").unwrap();
@@ -211,7 +211,7 @@ fn test_half_space_intersect() {
 // cylinder プリミティブの体積が πr²h と一致することを確認。
 #[test]
 fn test_cylinder() {
-	let cyl = [Solid::cylinder(5.0, dvec3(0.0, 0.0, 1.0), 10.0)];
+	let cyl = [Solid::cylinder(5.0, dvec3(0.0, 0.0, 1.0) * 10.0)];
 	let expected = std::f64::consts::PI * 5.0f64.powi(2) * 10.0;
 	assert!((cyl.iter().map(|s| s.volume()).sum::<f64>() - expected).abs() < 1e-6);
 }

--- a/tests/integration_color_brep.rs
+++ b/tests/integration_color_brep.rs
@@ -48,7 +48,7 @@ fn bin_write_then_read_preserves_colors() {
 /// A shape with an empty colormap round-trips without error (binary).
 #[test]
 fn bin_colorless_shape_roundtrip() {
-	let shape = [Solid::cube(1.0, 1.0, 1.0)];
+	let shape = [Solid::cube(DVec3::ZERO, DVec3::ONE)];
 	let reloaded = roundtrip_bin(&shape);
 	assert_eq!(colormap_len(&reloaded), 0);
 }
@@ -85,7 +85,7 @@ fn text_write_then_read_preserves_colors() {
 /// A shape with an empty colormap round-trips without error (text).
 #[test]
 fn text_colorless_shape_roundtrip() {
-	let shape = [Solid::cube(1.0, 1.0, 1.0)];
+	let shape = [Solid::cube(DVec3::ZERO, DVec3::ONE)];
 	let reloaded = roundtrip_text(&shape);
 	assert_eq!(colormap_len(&reloaded), 0);
 }

--- a/tests/mass_properties.rs
+++ b/tests/mass_properties.rs
@@ -20,7 +20,7 @@ const EPS: f64 = 1e-6;
 #[test]
 fn test_cube_mass_properties_match_analytical() {
 	let a = 10.0_f64;
-	let cube = Solid::cube(a, a, a);
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(a));
 
 	assert!((cube.volume() - a.powi(3)).abs() < EPS);
 	assert!((cube.area() - 6.0 * a.powi(2)).abs() < EPS);
@@ -73,8 +73,8 @@ fn test_vec_center_is_volume_weighted_average() {
 	let a = 2.0_f64;
 	let offset = 10.0_f64;
 	let cubes = vec![
-		Solid::cube(a, a, a),
-		Solid::cube(a, a, a).translate(DVec3::new(offset, 0.0, 0.0)),
+		Solid::cube(DVec3::ZERO, DVec3::splat(a)),
+		Solid::cube(DVec3::ZERO, DVec3::splat(a)).translate(DVec3::new(offset, 0.0, 0.0)),
 	];
 
 	let expected_center = DVec3::new((a / 2.0 + (a / 2.0 + offset)) / 2.0, a / 2.0, a / 2.0);
@@ -96,8 +96,8 @@ fn test_vec_center_is_volume_weighted_average() {
 /// `map(..).fold(DMat3::ZERO, +)` idiom is the correct way to aggregate.
 #[test]
 fn test_inertia_is_additive_over_elements() {
-	let single = Solid::cube(3.0, 3.0, 3.0).inertia();
-	let cubes = vec![Solid::cube(3.0, 3.0, 3.0), Solid::cube(3.0, 3.0, 3.0)];
+	let single = Solid::cube(DVec3::ZERO, DVec3::splat(3.0)).inertia();
+	let cubes = vec![Solid::cube(DVec3::ZERO, DVec3::splat(3.0)), Solid::cube(DVec3::ZERO, DVec3::splat(3.0))];
 	let summed = cubes.iter().map(|c| c.inertia()).fold(glam::DMat3::ZERO, |a, b| a + b);
 	for col in 0..3 {
 		for row in 0..3 {

--- a/tests/png.rs
+++ b/tests/png.rs
@@ -22,7 +22,7 @@ fn png_dimensions(buf: &[u8]) -> (u32, u32) {
 
 #[test]
 fn test_png_box_isometric() {
-	let shape = [Solid::cube(10.0, 10.0, 10.0)];
+	let shape = [Solid::cube(DVec3::ZERO, DVec3::splat(10.0))];
 	let mesh = Solid::mesh(&shape, 0.1).unwrap();
 	let scene = mesh.scene(dvec3(1.0, 1.0, 1.0).normalize(), DVec3::Z, true, false);
 
@@ -38,7 +38,7 @@ fn test_png_box_isometric() {
 
 #[test]
 fn test_png_cylinder_shaded() {
-	let shape = [Solid::cylinder(5.0, DVec3::Z, 10.0)];
+	let shape = [Solid::cylinder(5.0, DVec3::Z * 10.0)];
 	let mesh = Solid::mesh(&shape, 0.1).unwrap();
 	let scene = mesh.scene(dvec3(1.0, 0.5, 0.3).normalize(), DVec3::Z, true, true);
 
@@ -56,7 +56,7 @@ fn test_png_cylinder_shaded() {
 fn test_png_dimensions_are_exact() {
 	// User-specified [width, height] must appear verbatim in the IHDR,
 	// regardless of viewbox aspect (letterboxed when aspects differ).
-	let shape = [Solid::cube(50.0, 10.0, 10.0)];
+	let shape = [Solid::cube(DVec3::ZERO, DVec3::new(50.0, 10.0, 10.0))];
 	let mesh = Solid::mesh(&shape, 0.5).unwrap();
 	let scene = mesh.scene(DVec3::Z, DVec3::Y, false, false);
 

--- a/tests/shape.rs
+++ b/tests/shape.rs
@@ -7,7 +7,7 @@ fn dvec3(x: f64, y: f64, z: f64) -> DVec3 {
 
 /// 10×10×10 ボックス（体積 1000）
 fn test_box() -> Solid {
-	Solid::cube(10.0, 10.0, 10.0)
+	Solid::cube(DVec3::ZERO, DVec3::splat(10.0))
 }
 
 // ==================== translated ====================
@@ -23,8 +23,8 @@ fn test_translated_preserves_volume() {
 fn test_union_of_translated_overlapping_solids_has_single_volume() {
 	// 異なる場所に同じ大きさの立方体を2つ作り、translatedで同じ場所に重ねてからunionする。
 	// 結果のvolumeは1つ分（1000）になるはず。
-	let a = [Solid::cube(10.0, 10.0, 10.0)];
-	let b = [Solid::cube(10.0, 10.0, 10.0).translate(dvec3(100.0, 0.0, 0.0))];
+	let a = [Solid::cube(DVec3::ZERO, DVec3::splat(10.0))];
+	let b = [Solid::cube(DVec3::ZERO, DVec3::splat(10.0)).translate(dvec3(100.0, 0.0, 0.0))];
 	let b_moved: Vec<Solid> = b.clone().into_iter().map(|s| s.translate(dvec3(-100.0, 0.0, 0.0))).collect();
 
 	// b と b_moved は実態が別であることを確認: a と b（移動前）を union するとvolumeは2つ分（2000）。
@@ -143,8 +143,8 @@ fn test_face_edge_incidence_via_id() {
 fn test_new_faces_subtract_b_inside_a() {
 	// small_box が big_box に完全に収まる → small の 6 面はすべて Modified されない
 	// 新実装（iter_history の post_id 集合）では unchanged 面も history に入る → tool faces = 6
-	let big = [Solid::cube(10.0, 10.0, 10.0)];
-	let small = [Solid::cube(4.0, 4.0, 4.0).translate(dvec3(3.0, 3.0, 3.0))];
+	let big = [Solid::cube(DVec3::ZERO, DVec3::splat(10.0))];
+	let small = [Solid::cube(DVec3::ZERO, DVec3::splat(4.0)).translate(dvec3(3.0, 3.0, 3.0))];
 	let small_face_ids: std::collections::HashSet<u64> =
 		small.iter().flat_map(|s| s.iter_face()).map(|f| f.id()).collect();
 	let solids: Vec<Solid> = (&big[0] - &small[0]).build_vec().unwrap();
@@ -164,8 +164,8 @@ fn test_new_faces_subtract_b_inside_a() {
 fn test_new_faces_intersect_b_inside_a() {
 	// intersect(big, small) の結果は small そのもの
 	// small の 6 面はすべて unchanged → tool faces = 結果の全フェイス = 6
-	let big = [Solid::cube(10.0, 10.0, 10.0)];
-	let small = [Solid::cube(4.0, 4.0, 4.0).translate(dvec3(3.0, 3.0, 3.0))];
+	let big = [Solid::cube(DVec3::ZERO, DVec3::splat(10.0))];
+	let small = [Solid::cube(DVec3::ZERO, DVec3::splat(4.0)).translate(dvec3(3.0, 3.0, 3.0))];
 	let small_face_ids: std::collections::HashSet<u64> =
 		small.iter().flat_map(|s| s.iter_face()).map(|f| f.id()).collect();
 	let solids: Vec<Solid> = (&big[0] * &small[0]).build_vec().unwrap();
@@ -178,17 +178,30 @@ fn test_new_faces_intersect_b_inside_a() {
 	assert_eq!(solids.iter().flat_map(|s| s.iter_face()).count(), tool_count, "intersect with B fully inside A: tool faces should cover all result faces");
 }
 
+// ==================== cube corner order ====================
+
+#[test]
+fn cube_corner_order_independent() {
+	// cube は対角の 2 隅で定義され、どちらが +x+y+z 側かは無関係。
+	// cube(ZERO, ONE) と cube(ONE, ZERO) は完全に同一の立方体になる。
+	let a = Solid::cube(DVec3::ZERO, DVec3::ONE);
+	let b = Solid::cube(DVec3::ONE, DVec3::ZERO);
+	assert_eq!(a.bounding_box(), b.bounding_box(), "corner order must not change the box");
+	assert!((a.volume() - b.volume()).abs() < 1e-9);
+	assert!((a.volume() - 1.0).abs() < 1e-9, "unit cube volume should be 1");
+}
+
 // ==================== bounding_box ====================
 
 #[test]
 fn test_bounding_box() {
 	// 単一 solid
-	let [min, max] = Solid::cube(3.0, 4.0, 5.0).translate(dvec3(1.0, 2.0, 3.0)).bounding_box();
+	let [min, max] = Solid::cube(DVec3::ZERO, DVec3::new(3.0, 4.0, 5.0)).translate(dvec3(1.0, 2.0, 3.0)).bounding_box();
 	assert!((min - dvec3(1.0, 2.0, 3.0)).length() < 1e-6);
 	assert!((max - dvec3(4.0, 6.0, 8.0)).length() < 1e-6);
 
 	// 複数 solid のマージ
-	let solids = [Solid::cube(2.0, 2.0, 2.0), Solid::cube(2.0, 3.0, 4.0).translate(dvec3(5.0, 5.0, 5.0))];
+	let solids = [Solid::cube(DVec3::ZERO, DVec3::splat(2.0)), Solid::cube(DVec3::ZERO, DVec3::new(2.0, 3.0, 4.0)).translate(dvec3(5.0, 5.0, 5.0))];
 	let bboxes: Vec<[DVec3; 2]> = solids.iter().map(|s| s.bounding_box()).collect();
 	let min = bboxes.iter().map(|b| b[0]).reduce(|a, b| a.min(b)).unwrap();
 	let max = bboxes.iter().map(|b| b[1]).reduce(|a, b| a.max(b)).unwrap();

--- a/tests/shell.rs
+++ b/tests/shell.rs
@@ -1,8 +1,8 @@
-use cadrum::Solid;
+use cadrum::{DVec3, Solid};
 
 #[test]
 fn test_shell_cube_reduces_volume() {
-	let cube = Solid::cube(10.0, 10.0, 10.0);
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(10.0));
 	let original_volume = cube.volume();
 
 	let open = cube.iter_face().next().unwrap();
@@ -14,7 +14,7 @@ fn test_shell_cube_reduces_volume() {
 
 #[test]
 fn test_shell_cube_preserves_solid_structure() {
-	let cube = Solid::cube(10.0, 10.0, 10.0);
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(10.0));
 	let open = cube.iter_face().next().unwrap();
 	let shelled = cube.shell(-0.5, [open]).expect("shell should succeed");
 	assert!(shelled.volume() > 0.0, "shelled cube should produce a valid solid");
@@ -22,7 +22,7 @@ fn test_shell_cube_preserves_solid_structure() {
 
 #[test]
 fn test_shell_outward_produces_wall() {
-	let cube = Solid::cube(10.0, 10.0, 10.0);
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(10.0));
 	let open = cube.iter_face().next().unwrap();
 	// Positive thickness: wall grows outward. The original solid becomes the
 	// inner cavity of a 0.5-thick shell.
@@ -32,7 +32,7 @@ fn test_shell_outward_produces_wall() {
 
 #[test]
 fn test_shell_empty_open_faces_inward_seals_cavity() {
-	let cube = Solid::cube(10.0, 10.0, 10.0);
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(10.0));
 	// Negative thickness + empty open_faces: sealed solid with an internal void.
 	// Expected wall-material volume = 10³ − 9³ = 271.
 	let sealed = cube.shell(-0.5, std::iter::empty::<&cadrum::Face>()).expect("inward empty-open shell should succeed");
@@ -41,7 +41,7 @@ assert!((sealed.volume() - 271.0).abs() < 1e-3, "inward empty shell volume = 10�
 
 #[test]
 fn test_shell_empty_open_faces_outward_seals_cavity() {
-	let cube = Solid::cube(10.0, 10.0, 10.0);
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(10.0));
 	// Positive thickness + empty open_faces: outer shell expands outward with
 	// GeomAbs_Arc join (spheres at corners, quarter-cylinders along edges),
 	// original surface becomes the internal cavity wall.

--- a/tests/svg.rs
+++ b/tests/svg.rs
@@ -16,7 +16,7 @@ fn svg_string(shape: &[Solid], direction: DVec3, tol: f64) -> String {
 
 #[test]
 fn test_svg_box_isometric() {
-	let shape = [Solid::cube(10.0, 10.0, 10.0)];
+	let shape = [Solid::cube(DVec3::ZERO, DVec3::splat(10.0))];
 	let svg = svg_string(&shape, dvec3(1.0, 1.0, 1.0).normalize(), 0.1);
 
 	assert!(svg.starts_with("<svg"), "should start with <svg tag");
@@ -33,7 +33,7 @@ fn test_svg_box_isometric() {
 
 #[test]
 fn test_svg_box_top_down() {
-	let shape = [Solid::cube(10.0, 10.0, 10.0)];
+	let shape = [Solid::cube(DVec3::ZERO, DVec3::splat(10.0))];
 	let svg = svg_string(&shape, DVec3::Z, 0.1);
 
 	assert!(svg.starts_with("<svg"));
@@ -45,7 +45,7 @@ fn test_svg_box_top_down() {
 
 #[test]
 fn test_svg_cylinder() {
-	let shape = [Solid::cylinder(5.0, DVec3::Z, 10.0)];
+	let shape = [Solid::cylinder(5.0, DVec3::Z * 10.0)];
 	let svg = svg_string(&shape, dvec3(1.0, 0.5, 0.3).normalize(), 0.1);
 
 	assert!(svg.contains("<polyline"));
@@ -56,8 +56,8 @@ fn test_svg_cylinder() {
 
 #[test]
 fn test_svg_has_hidden_lines() {
-	let a = [Solid::cube(10.0, 10.0, 10.0)];
-	let b = [Solid::cube(10.0, 10.0, 10.0).translate(dvec3(5.0, 5.0, 0.0))];
+	let a = [Solid::cube(DVec3::ZERO, DVec3::splat(10.0))];
+	let b = [Solid::cube(DVec3::ZERO, DVec3::splat(10.0)).translate(dvec3(5.0, 5.0, 0.0))];
 	let shape: Vec<Solid> = (&a[0] + &b[0]).build_vec().unwrap();
 	let svg = svg_string(&shape, dvec3(1.0, 1.0, 1.0).normalize(), 0.1);
 


### PR DESCRIPTION
@
## 概要

`cube` / `cylinder` / `cone` の引数を冗長なスカラー指定からベクトルに集約した。

| 旧 | 新 |
|---|---|
| `cube(x, y, z)` | `cube(corner0: DVec3, corner1: DVec3)` |
| `cylinder(r, axis, h)` | `cylinder(r, height: DVec3)` |
| `cone(r1, r2, axis, h)` | `cone(r1, r2, height: DVec3)` |

- **cube**: 対角の2隅で指定。どちらが +x+y+z 側かは無関係で、`cube(ONE, ZERO)` ≡ `cube(ZERO, ONE)`。C++ の `make_box` が既に `min`/`max` を取るため C++ 側は無変更。
- **cylinder / cone**: 方向と長さを1本の `height` ベクトルに統合（`height.length()` が高さ、`gp_Dir` が方向を内部正規化）。C++/FFI/build.rs は無変更。

## 変更点

- `src/traits.rs` のシグネチャ変更、`src/lib.rs` は codegen で再生成
- 全 example / test / sandbox-wasm / README を新 API に更新
  - 単位軸 (`DVec3::X/Y/Z`) は `軸 * 高さ` で旧挙動と完全一致
  - `00_chijin.rs` の斜め穴のみ非単位軸なので `.normalize() * 30.0` で幾何を厳密保持
- `tests/shape.rs` に `cube_corner_order_independent` を追加し順序非依存を検証

## テスト

- `cargo build` ✅
- `cargo test` ✅ 全テスト通過（doctest 含む、新規テスト含む）
@