### PR TITLE
wasm: cxx bridge を libc++ とリンクして run-cxx を通す

### DIFF
--- a/sandbox-wasm/README.md
+++ b/sandbox-wasm/README.md
@@ -332,3 +332,70 @@ foreach(target IN LISTS WASI_SDK_TARGETS)
   define_libcxx(${target})
 endforeach()
 ```
+
+### cxx ビルド完了 ✅ok
+
+`cxx` crate 経由の C++ を libc++ とリンクして wasm 化、node で実行できるようになった。
+
+```
+make -C sandbox-wasm generate   # wasi-libc + libc++/libc++abi を out/wasi-sysroot にビルド（初回のみ）
+make -C sandbox-wasm run-cxx     # => Solid volume: 5
+```
+
+`run-cxx` は `run-raw-cxx-libcxx`（`--features "cxx libcxx"`）に張り替えてある。`cc`/`libc` の関係と同様、`cxx` が C++ ソース、`libcxx` が libc++ sysroot 供給を担当する。bridge は些末な `double add(double,double)` で、`volume() = add(2,3) = 5`。
+
+#### libc++ のビルド（generate）
+
+`out/wasi-sysroot`（target `wasm32-wasip1`）に wasi-libc と libc++ を同居させる。libc++ は LLVM monorepo の `runtimes` を入口に `libcxx;libcxxabi` をビルド。詰まった点:
+
+- **`CMAKE_SYSTEM_NAME=WASI` は LLVM が知らない**（`HandleLLVMOptions` は Win32/UNIX/Generic のみ）→ `Generic` を使う。wasm のコード生成は `--target=wasm32-wasip1` が駆動する。
+- **`runtimes` は実 Python3 必須**（`find_package(Python3 REQUIRED)`）→ Store スタブではダメ。`out/python` に公式 embeddable を落として PATH に通す。
+- **`CMAKE_AR=llvm-ar`（相対名）は CWD 前置で誤絶対化**されアーカイブで `no such file or directory` → AR/RANLIB/NM/clang を絶対パスで渡す。
+- threads/filesystem は OFF、localization と例外は ON（既定）。`__config_site` に `_LIBCPP_HAS_NO_THREADS` / `_LIBCPP_HAS_NO_FILESYSTEM` が入る。
+
+> 補足: wasi-sdk の prebuilt（このファイル冒頭の表）を使えば libc++ ビルドを丸ごと省略できる。ただし配布版は eh/noeh など構成が固定なので、例外の扱いを自前で選びたいなら source ビルドのほうが融通が利く。
+
+#### 実装中の発見（run-cxx を通すまで）
+
+`wasm32-unknown-unknown`（Rust 側）のまま、C++ TU だけ libc++ ヘッダを食わせる方針（`cc-libc` と同じ）。`--target=wasm32-wasip1` にすると `__wasi__` が定義され libc++/libc が WASI bottom-half 経路（実 import を出す）に化けるので避ける。
+
+1. **`cxx` crate は `cxx.cc`（C++ ランタイム）を自前の `cc::Build` でコンパイル**する。ここに libc++ ヘッダを届けるには `build.rs` の `.flag()` では不足で、`cc` crate が読む env `CXXFLAGS_wasm32_unknown_unknown` を **Makefile から export** する必要がある。
+2. **MSYS/Git-bash の env パス変換**が、値中 2 つ目の `C:` をパスリスト区切りと誤認し `C;` に化けさせる → `MSYS2_ENV_CONV_EXCL` でその変数を変換対象外に。
+3. **`__wasi__` 未定義だと libc++ の `__locale` が ctype マスク（`alpha`/`digit`…）を定義できない**（`#elif defined(__wasi__)` ブランチを外すため）。同じ musl ロケールを選ぶ **`-D_LIBCPP_HAS_MUSL_LIBC`** で回避。target は unknown-unknown のまま。
+4. **`cxx::bridge` は `mod` 形式必須**（`cxx_build::bridge()` が「expected a module」）。`#[cxx::bridge] mod ffi { unsafe extern "C++" { ... } }` に直し、呼び出しを `ffi::add` に。
+5. **`link-cplusplus`（cxx の依存）は wasm 既定で `-lstdc++`** を要求 → 我々は libc++ なので `CXXSTDLIB=c++`。
+
+#### 例外の扱い（今後）
+
+今は **例外オフ**で通している:
+
+- bridge fn `add` は `f64` 返却 → cxx は `noexcept` トランポリンを生成し try/catch を出さない。
+- `cxx.cc` の唯一の `throw` は `-DRUST_CXX_NO_EXCEPTIONS` で `abort()` に切り替わる。
+- よって `-fno-exceptions -fno-rtti` でコンパイルでき、libc++ を `-fwasm-exceptions` で作り直す必要がない。正常系は決して throw しないので実害なし。
+
+**OCCT を載せる段階では例外が要る**（`Standard_Failure` 等）。その時は wasi-sdk の `define_libcxx`（このファイル上部）が示すとおり、
+
+- libc++/libc++abi/**libunwind** を `-fwasm-exceptions -mllvm -wasm-use-legacy-eh=false` で**作り直し**、
+- cadrum/cxx 側も同じ `-fwasm-exceptions` でコンパイルし（ABI 一致）、
+- 実行する node が wasm EH 対応（最近の Node は既定で可）、
+
+が必要になる。wasi-sdk が eh/noeh の 2 系統を別ディレクトリに分けているのはこのため。`RUST_CXX_NO_EXCEPTIONS` / `-fno-exceptions` は外すことになる。
+
+#### libc bottom-half（WASI import）の扱い
+
+`wasm32-unknown-unknown` には WASI ランタイムが無い。ところが `cxx.cc` の `#include <iostream>` が生成する `std::ios_base::Init` 静的初期化子が stdio を参照し、リンク後の wasm に **`wasi_snapshot_preview1` への import（`fd_write`/`fd_seek`/`fd_close`）が残る**（グローバルコンストラクタなので `--gc-sections` で消えない）。node は ESM 解決でこれを package と誤認し `ERR_MODULE_NOT_FOUND` になる。
+
+対処は **bottom-half import を no-op スタブで定義して消す**（`src/wasi_stub.c`）:
+
+- 実 import シンボルは `__wasi_fd_write` ではなく **`__imported_wasi_snapshot_preview1_fd_*`**（`__wasi_*` は libc.a 側で定義済みの wrapper）。`llvm-nm libc.a` で確認した。
+- スタブは静的アーカイブで、実 import シンボルは libc.a 処理時に初めて undefined になりリンク順で取りこぼすため、**`+whole-archive` で強制リンク**する。
+- 正常系で stdout に書かないので no-op で実害なし。最終的に残る import は wasm-bindgen の glue のみ（`node -e "...WebAssembly.Module.imports..."` で確認可）。
+
+将来 wasm 内で本当に stdout 等を使いたくなったら、スタブを外して node 側に WASI shim を渡す（`wasi_snapshot_preview1` を import object で供給）か、wasm-bindgen のターゲット設定を変える方向になる。
+
+#### 懸念点 / 残課題
+
+- **cmake が project 内の `out/cmake-3.31.12` でなく PATH 上の別 cmake を使っている**（PATH 行が `$(CMAKE)`=URL で壊れている）。動くが再現性のため要修正。
+- stale な `build-libcxx` が「Device or resource busy」で `rm` 不可になることがある（AV/エクスプローラのハンドル）。`CMakeCache.txt` 削除で回避できる。
+- `wasm32-unknown-unknown` の C++ オブジェクトと `wasm32-wasip1` ビルドの libc++/libc を混在リンクしている。今は純計算経路のみで成立しているが、使う libc++ 機能が増えると新たな bottom-half import が出る可能性がある（その都度スタブを足す or wasip1 + shim へ移行）。
+- 次は `make -C sandbox-wasm run-cadrum`（本命）。OCCT は例外多用なので、上記「例外の扱い（今後）」の eh 版 libc++ ビルドが前提になる。

--- a/sandbox-wasm/build.rs
+++ b/sandbox-wasm/build.rs
@@ -21,11 +21,48 @@ fn main() {
 	}
 	// cxx feature: cxx bridge 経由で C++ をコンパイル。
 	if std::env::var("CARGO_FEATURE_CXX").is_ok() {
-		cxx_build::bridge("src/lib.rs")
-			.file("src/cpp.cpp")
+		let mut build = cxx_build::bridge("src/lib.rs");
+		build
+			.file("src/ffi.cpp")
 			.include("src")
 			.std("c++17")
-			.compile("sandbox_cxx");
+			// add は f64 を返すので生成トランポリンは noexcept、cxx.cc の throw も
+			// RUST_CXX_NO_EXCEPTIONS で abort() に切り替わる。正常系は throw しないので
+			// 例外/RTTI を無効化して libc++ を -fwasm-exceptions 無しのまま使う。
+			.flag_if_supported("-fno-exceptions")
+			.flag_if_supported("-fno-rtti")
+			.define("RUST_CXX_NO_EXCEPTIONS", None);
+		// libcxx feature: 生成した wasi-sysroot の libc++/libc ヘッダ(-isystem)と
+		// libc++/libc++abi/libc(.a) を足す。target は wasm32-unknown-unknown のまま
+		// にして __wasi__ を定義させず、libc++ の WASI bottom-half 経路（実 import を
+		// 出す）に化けるのを避ける（cc+libc と同じ方式）。
+		if std::env::var("CARGO_FEATURE_LIBCXX").is_ok() {
+			let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+			let sysroot = format!("{manifest}/../out/wasi-sysroot");
+			build.flag(format!("-isystem{sysroot}/include/c++/v1"));
+			build.flag(format!("-isystem{sysroot}/include/wasm32-wasip1"));
+			// target は unknown-unknown のままなので __wasi__ が未定義。libc++ の
+			// __locale は __wasi__ で musl ロケールを選ぶため、同じ musl 分岐を選ぶ
+			// _LIBCPP_HAS_MUSL_LIBC を定義して ctype マスク未定義を回避する。
+			build.define("_LIBCPP_HAS_MUSL_LIBC", None);
+			println!("cargo:rustc-link-search=native={sysroot}/lib/wasm32-wasip1");
+			println!("cargo:rustc-link-lib=static=c++");
+			println!("cargo:rustc-link-lib=static=c++abi");
+			println!("cargo:rustc-link-lib=static=c");
+			// <iostream> の静的初期化子が引きずる wasi_snapshot_preview1 import を
+			// no-op スタブで定義して消す（正常系では stdout に書かない）。スタブの実
+			// import シンボルは libc.a 処理時に初めて undefined になるので、リンク順に
+			// 依らず確実に取り込むため whole-archive で強制リンクする。
+			let out_dir = std::env::var("OUT_DIR").unwrap();
+			cc::Build::new()
+				.file("src/wasi_stub.c")
+				.cargo_metadata(false)
+				.compile("wasi_stub");
+			println!("cargo:rustc-link-search=native={out_dir}");
+			println!("cargo:rustc-link-lib=static:+whole-archive=wasi_stub");
+			println!("cargo:rerun-if-changed=src/wasi_stub.c");
+		}
+		build.compile("sandbox_cxx");
 		println!("cargo:rerun-if-changed=src/ffi.cpp");
 		println!("cargo:rerun-if-changed=src/ffi.h");
 	}

--- a/sandbox-wasm/makefile
+++ b/sandbox-wasm/makefile
@@ -7,6 +7,16 @@ WASI = https://github.com/WebAssembly/wasi-libc/archive/refs/tags/wasi-sdk-32.ta
 # LLVM runtimes (libc++) build hard-requires a real Python3; portable embeddable build avoids a system install.
 PYTHON = https://www.python.org/ftp/python/3.12.7/python-3.12.7-embed-amd64.zip
 export PATH := $(CURDIR)/../out/$(call stem,$(CLANG))/bin:$(CURDIR)/../out/python:$(CURDIR)/../out/$(CMAKE)/bin:$(PATH)
+# cxx crate は cxx.cc を自前の cc::Build でコンパイルするので、libc++ ヘッダ(-isystem)と
+# 例外無効フラグを cc crate が読む CXXFLAGS_<target> 経由で全 C++ TU に届ける。
+# MSYS/Git-bash は env 値中の 2 つ目の `C:` をパスリスト区切りと誤認し `C;` に化けさせる
+# ので、この env 変数だけパス変換の対象外にする。
+export MSYS2_ENV_CONV_EXCL := CXXFLAGS_wasm32_unknown_unknown
+# cxx が依存する link-cplusplus は wasm では既定で libstdc++ をリンクしようとする。
+# 我々は libc++ を使うので CXXSTDLIB=c++ に上書きする。
+export CXXSTDLIB := c++
+SYSROOT := $(CURDIR)/../out/wasi-sysroot
+export CXXFLAGS_wasm32_unknown_unknown := -isystem$(SYSROOT)/include/c++/v1 -isystem$(SYSROOT)/include/wasm32-wasip1 -fno-exceptions -fno-rtti -DRUST_CXX_NO_EXCEPTIONS -D_LIBCPP_HAS_MUSL_LIBC
 
 # pure rust. I got wasm successfully.
 run: run-raw-pure
@@ -14,10 +24,10 @@ run: run-raw-pure
 run-cc: run-raw-cc
 # cc + libc (wasi-libc). __has_include(<math.h>) becomes true so add() returns sin(a+b).
 run-cc-libc: run-raw-cc-libc
-run-cxx: run-raw-cxx
+run-cxx: run-raw-cxx-libcxx
 # with cadrum. This is that target of this sandbox.
 run-cadrum: run-raw-cadrum
-run-raw-%: download # build wasm, and run it with node. hyphens in % become comma-separated features (e.g. run-raw-cc-libc -> --features cc,libc).
+run-raw-%: # build wasm, and run it with node. hyphens in % become comma-separated features (e.g. run-raw-cc-libc -> --features cc,libc).
 	cargo build --target wasm32-unknown-unknown --features "$(subst -, ,$*)"
 	../out/bin/wasm-pack build . -d ./target --features "$(subst -, ,$*)"
 	node -e "import('./target/wasm_experiment.js').then(m=>console.log(m.print_volume()))"

--- a/sandbox-wasm/src/lib.rs
+++ b/sandbox-wasm/src/lib.rs
@@ -17,14 +17,16 @@ pub fn volume() -> f64 {
 
 #[cfg(feature = "cxx")]
 #[cxx::bridge]
-unsafe extern "C++" {
-	include!("ffi.h");
-	fn add(a: f64, b: f64) -> f64;
+mod ffi {
+	unsafe extern "C++" {
+		include!("ffi.h");
+		fn add(a: f64, b: f64) -> f64;
+	}
 }
 
 #[cfg(feature = "cxx")]
 pub fn volume() -> f64 {
-	add(2.0, 3.0)
+	ffi::add(2.0, 3.0)
 }
 
 #[cfg(feature = "cadrum")]

--- a/sandbox-wasm/src/wasi_stub.c
+++ b/sandbox-wasm/src/wasi_stub.c
@@ -1,0 +1,17 @@
+// wasm32-unknown-unknown には WASI ランタイムが無いが、libc++ の <iostream> が
+// 生成する std::ios_base::Init 静的初期化子が stdio を参照し、その先で
+// wasi_snapshot_preview1 への import (__imported_wasi_snapshot_preview1_*) が残る。
+// 正常系では一切 stdout/stderr に書かないので、その実 import シンボルを no-op で
+// 定義して import を消す。シグネチャは WASI ABI（i32/i64）に一致させる。
+int __imported_wasi_snapshot_preview1_fd_write(int fd, int iovs, int iovs_len, int nwritten) {
+	(void)fd; (void)iovs; (void)iovs_len; (void)nwritten;
+	return 0;
+}
+int __imported_wasi_snapshot_preview1_fd_seek(int fd, long long offset, int whence, int newoffset) {
+	(void)fd; (void)offset; (void)whence; (void)newoffset;
+	return 0;
+}
+int __imported_wasi_snapshot_preview1_fd_close(int fd) {
+	(void)fd;
+	return 0;
+}


### PR DESCRIPTION
## 概要

`make -C sandbox-wasm run-cxx` が通り、`cxx` crate 経由の C++ を libc++ とリンクして wasm 化・node 実行できるようになった（`Solid volume: 5`）。target は `wasm32-unknown-unknown` のまま、C++ TU だけ `out/wasi-sysroot` の libc++/libc ヘッダを食わせる方式（`cc-libc` と同じ）。

## 変更

- **`sandbox-wasm/build.rs`** — cxx 分岐のファイル名バグ（`cpp.cpp`→`ffi.cpp`）修正、`libcxx` feature で libc++ sysroot を配線、`-fno-exceptions -fno-rtti -DRUST_CXX_NO_EXCEPTIONS`、`_LIBCPP_HAS_MUSL_LIBC`、bottom-half スタブの whole-archive リンク
- **`sandbox-wasm/makefile`** — `cxx.cc`（cxx crate 自身の `cc::Build`）へ `CXXFLAGS_wasm32_unknown_unknown` を export、`MSYS2_ENV_CONV_EXCL`（`C:`→`C;` 化け回避）、`CXXSTDLIB=c++`、`run-cxx` → `run-raw-cxx-libcxx`
- **`sandbox-wasm/src/lib.rs`** — `cxx::bridge` をモジュール形式に（`cxx_build` 要件）、呼び出しを `ffi::add` に
- **`sandbox-wasm/src/wasi_stub.c`**（新規）— `<iostream>` 静的初期化子が引く `__imported_wasi_snapshot_preview1_fd_{write,seek,close}` を no-op で定義し WASI import を除去
- **`sandbox-wasm/README.md`** — 経緯・発見・例外の今後の扱い・bottom-half スタブを記載

## 主な発見

- `cxx.cc` は cxx crate が自前の `cc::Build` でコンパイルするため、フラグは env 経由でないと届かない
- `__wasi__` 未定義だと libc++ `__locale` の ctype マスクが欠落 → `-D_LIBCPP_HAS_MUSL_LIBC` で同じ musl 分岐を選択
- 残った `wasi_snapshot_preview1` import は no-op スタブ＋whole-archive で除去（正常系は stdout に書かない）

## 検証

`run` / `run-cc` / `run-cc-libc` / `run-cxx` すべて期待値を出力（回帰なし）。最終 wasm の import は wasm-bindgen glue のみ。

## 残課題

- 例外（OCCT 用）は未対応。eh 版 libc++（`-fwasm-exceptions` + libunwind）再ビルドが前提
- cmake が PATH 上の別バージョンを使う問題（`$(CMAKE)`=URL のため）