### PR TITLE
Build OCCT for wasm32-unknown-unknown and distribute wasm-inclusive p…

### DIFF
--- a/.github/workflows/prebuilt.yaml
+++ b/.github/workflows/prebuilt.yaml
@@ -10,8 +10,10 @@ jobs:
   #   - cadrum-occt-x86_64-unknown-linux-gnu
   #   - cadrum-occt-aarch64-unknown-linux-gnu
   #   - cadrum-occt-x86_64-pc-windows-gnu
-  # This is because the cross toolchain for these GNU targets is mature on the
-  # Linux side (cross-gcc / mingw-w64), so Docker gives a reproducible build host.
+  #   - cadrum-occt-wasm32-unknown-unknown
+  # This is because the cross toolchain for these targets is mature on the Linux
+  # side (cross-gcc / mingw-w64 / wasi-sdk clang), so Docker gives a reproducible
+  # build host.
   build:
     strategy:
       fail-fast: false
@@ -22,6 +24,8 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             runs-on: ubuntu-24.04-arm
           - target: x86_64-pc-windows-gnu
+            runs-on: ubuntu-latest
+          - target: wasm32-unknown-unknown
             runs-on: ubuntu-latest
     runs-on: ${{ matrix.runs-on }}
     steps:
@@ -132,6 +136,6 @@ jobs:
       # OCCT_VERSION / BUILD_REVISION in build.rs (same coupling as the v800 slug).
       - uses: softprops/action-gh-release@v2
         with:
-          tag_name: cadrum-occt-v800-rev0
-          name: OCCT prebuilt v8.0.0 (rev0)
+          tag_name: cadrum-occt-v800-rev1
+          name: OCCT prebuilt v8.0.0 (rev1)
           files: dist/*.tar.gz

--- a/build.rs
+++ b/build.rs
@@ -7,10 +7,10 @@ use std::path::{Path, PathBuf};
 const OCCT_VERSION: &str = "V8_0_0";
 
 /// Build revision for prebuilt tarballs. Update this when making non-OCCT-breaking changes that require cache invalidation (e.g. patch updates, build script changes, etc).
-const BUILD_REVISION: &str = "rev0";
+const BUILD_REVISION: &str = "rev1";
 
-/// `target` 指定あり: `cadrum-occt-v800-rev0-x86_64-pc-windows-gnu` (tarball / cache dir 名)
-/// `target` 指定なし: `cadrum-occt-v800-rev0` (`lzpel/cadrum` の GitHub Release タグ)
+/// `target` 指定あり: `cadrum-occt-v800-rev1-x86_64-pc-windows-gnu` (tarball / cache dir 名)
+/// `target` 指定なし: `cadrum-occt-v800-rev1` (`lzpel/cadrum` の GitHub Release タグ)
 fn cadrum_occt_name(target: Option<&str>) -> String {
 	let slug = OCCT_VERSION.to_ascii_lowercase().replace('_', "");
 	let release = format!("cadrum-occt-{}-{}", slug, BUILD_REVISION);
@@ -302,8 +302,8 @@ mod source {
 
 		eprintln!("Building OCCT with CMake (this may take a while)...");
 
-		let built = cmake::Config::new(&source_dir)
-			.profile("Release")
+		let mut cfg = cmake::Config::new(&source_dir);
+		cfg.profile("Release")
 			.define("BUILD_LIBRARY_TYPE", "Static")
 			.define("CMAKE_INSTALL_PREFIX", effective_root.to_str().unwrap())
 			.define("USE_FREETYPE", "OFF")
@@ -336,8 +336,26 @@ mod source {
 			.define("BUILD_SAMPLES_QT", "OFF")
 			.define("BUILD_Inspector", "OFF")
 			.define("BUILD_ENABLE_FPE_SIGNAL_HANDLER", "OFF")
-			.define("CMAKE_RC_FLAGS_INIT", "-C 1252")
-			.build();
+			.define("CMAKE_RC_FLAGS_INIT", "-C 1252");
+
+		// cmake クレートは cc-rs の CC_<target>/CXX_<target>/AR_<target> を CMAKE_* へ転送しない。
+		// クロスツールチェインを env で差せるよう、ここで橋渡しする（target 非依存）。
+		// 汎用(CC/CXX/AR) → target 固有(CC_<target> 等) の順で後勝ち。env が無い target(native 等)は
+		// 何もせず cmake の既定探索に任せる。generator は CMAKE_GENERATOR env、target/sysroot 等は
+		// CFLAGS_/CXXFLAGS_<target> から供給される（いずれも cmake クレートが env を読む）。
+		let tgt = env::var("TARGET").unwrap_or_default().replace('-', "_");
+		for (cmake_key, base) in [
+			("CMAKE_C_COMPILER", "CC"),
+			("CMAKE_CXX_COMPILER", "CXX"),
+			("CMAKE_AR", "AR"),
+		] {
+			for name in [base.to_string(), format!("{base}_{tgt}")] {
+				if let Ok(v) = env::var(&name) {
+					cfg.define(cmake_key, &v);
+				}
+			}
+		}
+		let built = cfg.build();
 
 		eprintln!("OCCT built at: {}", built.display());
 
@@ -373,11 +391,31 @@ mod source {
 		}
 	}
 
+	/// OS 依存(OSD)層など OS API を直接使う OCCT 実装ファイル。全 target で body-stub 化し
+	/// （シグネチャは残しリンク用シンボルを維持）、STUB_DROP_HEADERS の #include を外す。
+	/// cadrum の公開 I/O はストリームベースで OSD ファイル層を通らず、テストも std::fs で
+	/// バイト列を読み書きするので、source-build にこのスタブを当てても cargo test で検証できる。
+	/// 性能の要 OSD_ThreadPool / OSD_Parallel(_Threads/_TBB) / OSD_Thread は意図的に非対象。
+	const OSD_POSIX_STUBS: &[&str] = &[
+		"OSD_File.cxx", "OSD_Directory.cxx", "OSD_DirectoryIterator.cxx",
+		"OSD_FileIterator.cxx", "OSD_FileNode.cxx", "OSD_Path.cxx",
+		"OSD_Protection.cxx", "OSD_Process.cxx", "OSD_Host.cxx", "OSD_Disk.cxx",
+		"OSD_Environment.cxx", "OSD_signal.cxx", "OSD_Chronometer.cxx",
+		"OSD_MemInfo.cxx", "OSD_SharedLibrary.cxx",
+		"Message_PrinterSystemLog.cxx", "STEPConstruct_AP203Context.cxx",
+	];
+
+	/// 上記スタブから外す、環境により不在のヘッダ（wasm に無い等）。
+	/// native では既存ヘッダを消すだけで無害（body-stub 済みなので参照されない）。
+	const STUB_DROP_HEADERS: &[&str] = &[
+		"netdb.h", "sys/socket.h", "arpa/inet.h", "net/if.h", "ifaddrs.h",
+		"pwd.h", "grp.h", "dlfcn.h", "sys/statvfs.h", "sys/mount.h", "syslog.h",
+	];
+
 	/// Return the patched content for a file if it needs patching, `None` otherwise.
-	/// Pure function — does not write to disk.
+	/// Pure function — does not write to disk. 全 target 共通（target 分岐なし）。
 	fn patch_or_none(path: &Path) -> Option<String> {
 		let name = path.file_name()?.to_str()?;
-		let is_windows = env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows");
 
 		match name {
 			"XCAFDoc_VisMaterial.cxx" => Some(stub_content(path, true)),
@@ -388,15 +426,21 @@ mod source {
 				Some(comment_out_include_in(&stubbed, "execinfo.h"))
 			}
 
-			"OSD_WNT.cxx" if is_windows => Some(stub_content(path, false)),
-			"OSD_File.cxx" | "OSD_Protection.cxx" | "OSD_signal.cxx"
-			| "OSD_FileNode.cxx" | "OSD_Process.cxx"
-				if is_windows =>
-			{
-				Some(stub_content(path, true))
+			// OSD/POSIX 依存ファイル: body-stub + 不在ヘッダ除去（全 target 共通）。
+			n if OSD_POSIX_STUBS.contains(&n) => {
+				let mut s = stub_content(path, true);
+				for h in STUB_DROP_HEADERS {
+					s = comment_out_include_in(&s, h);
+				}
+				Some(s)
 			}
 
-			"occt_defs_flags.cmake" if is_windows => {
+			// Windows 専用 OSD 実装。windows.h + SEH(__try/__except) を含み body-stub できない
+			// ため空ファイル化（Windows 以外ではコンパイルされず無害）。
+			"OSD_WNT.cxx" => Some(stub_content(path, false)),
+
+			// OCC_CONVERT_SIGNALS(signal→例外変換) を全 target で無効化。OSD_signal スタブ化と整合。
+			"occt_defs_flags.cmake" => {
 				let content = std::fs::read_to_string(path).ok()?;
 				let needle = "add_definitions(-DOCC_CONVERT_SIGNALS)";
 				let replacement = "# add_definitions(-DOCC_CONVERT_SIGNALS)  # patched out by cadrum build.rs";

--- a/docker/Dockerfile_wasm32-unknown-unknown
+++ b/docker/Dockerfile_wasm32-unknown-unknown
@@ -1,0 +1,47 @@
+# Prebuild OCCT for wasm32-unknown-unknown via the Linux wasi-sdk (clang + wasi-sysroot).
+#
+# manylinux_2_28 ships gcc (C++17 capable), cmake, make, curl, and git out of the
+# box. Rust is NOT bundled, so we install it via rustup.
+#
+# The wasm output is produced by the wasi-sdk clang, so the host image is
+# irrelevant to the result. HOST build-dependencies use the image's gcc; the
+# wasm TARGET (OCCT cmake + cxx-build) uses the wasi-sdk clang found first on PATH.
+# The example .wasm cannot run here; `cadrum-occt` tolerates that via `... | tee`,
+# then tarballs the OCCT static libraries.
+FROM quay.io/pypa/manylinux_2_28_x86_64
+
+# wasi-sdk (Linux): clang + prebuilt wasi-sysroot (libc / libc++, eh & noeh variants).
+# Rename the tarball's top dir to /wasi-sdk. The S/H flags keep the transform from
+# also rewriting sym/hardlink targets (e.g. bin/clang -> clang-22), which would break them.
+# NOTE: manylinux already ships a non-wasm clang at /opt/clang/bin, so /wasi-sdk/bin must
+# come first on PATH AND resolve correctly.
+RUN curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-33.0-x86_64-linux.tar.gz | tar xzv --transform="s,^[^/]+,/wasi-sdk,xSH"
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+# wasi-sdk bin first so `clang`/`clang++` resolve to the wasi-sdk cross-compiler.
+ENV PATH=/wasi-sdk/bin:/root/.cargo/bin:$PATH
+
+ENV CARGO_BUILD_TARGET=wasm32-unknown-unknown
+# add cargo target
+RUN rustup target add ${CARGO_BUILD_TARGET}
+
+# === wasm toolchain env (mirrors sandbox-wasm/makefile) ===
+ENV SYSROOT=/wasi-sdk/share/wasi-sysroot
+# build.rs forwards CC_<target>/CXX_<target> to CMAKE_C/CXX_COMPILER; host build-deps
+# keep using the image's gcc because these are target-specific.
+ENV CC_wasm32_unknown_unknown=clang
+ENV CXX_wasm32_unknown_unknown=clang++
+# Avoid the host default generator; cmake honors CMAKE_GENERATOR.
+ENV CMAKE_GENERATOR="Unix Makefiles"
+# link-cplusplus defaults to libstdc++ on wasm; we use libc++.
+ENV CXXSTDLIB=c++
+# Compile C/C++ as wasm32-wasip1 so --sysroot auto-resolves include/lib (and eh/c++/v1
+# under -fwasm-exceptions) and __wasi__ selects the proper libc++ rune table.
+ENV CFLAGS_wasm32_unknown_unknown="--target=wasm32-wasip1 --sysroot=${SYSROOT} -D_WASI_EMULATED_PROCESS_CLOCKS -D_WASI_EMULATED_SIGNAL -D_WASI_EMULATED_MMAN -D_WASI_EMULATED_GETPID"
+ENV CXXFLAGS_wasm32_unknown_unknown="--target=wasm32-wasip1 --sysroot=${SYSROOT} -fwasm-exceptions -fexceptions -D_WASI_EMULATED_PROCESS_CLOCKS -D_WASI_EMULATED_SIGNAL -D_WASI_EMULATED_MMAN -D_WASI_EMULATED_GETPID"
+# Final link (rustc) pulls the eh libc++ / libc++abi / libunwind and libc.
+ENV CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS="-L native=${SYSROOT}/lib/wasm32-wasip1/eh -L native=${SYSROOT}/lib/wasm32-wasip1 -l static=c++abi -l static=unwind -l static=c"
+
+# copy source and build OCCT prebuilt
+WORKDIR /src
+COPY . /src

--- a/notes/20260612-OCCTをwasmに載せてrun-cadrumを通す.md
+++ b/notes/20260612-OCCTをwasmに載せてrun-cadrumを通す.md
@@ -1,0 +1,141 @@
+# OCCT を wasm に載せて run-cadrum を通す
+
+`make -C sandbox-wasm run-cadrum` で OCCT(OpenCASCADE 8.0.0) を `wasm32` 上で動かし、
+実 B-rep 幾何（`BRepPrimAPI_MakeBox` → `GProp_GProps`）で `Solid::cube(0,(10,20,30)).volume()`
+= **6000** を node で出力できた。`20260329-wasmビルド方針_jp.md` の「本命」が実現。
+
+最終確認:
+```
+run-pure   -> Solid volume: 1
+run-cc     -> Solid volume: -0.9589242746631385   (wasi-libc の sin)
+run-cxx    -> Solid volume: 5                       (libc++ + wasm EH)
+run-cadrum -> Solid volume: 6000                    (OCCT in wasm)
+```
+
+## 全体構成（重要な前提）
+
+- **コンパイル target は `wasm32-wasip1`、最終リンクの rustc target は `wasm32-unknown-unknown`**。
+  オブジェクトは同じ wasm32 で互換。wasip1 でコンパイルすると `--sysroot` が
+  `include/wasm32-wasip1`（例外時は `eh/c++/v1`）を自動解決し、`__wasi__` で libc++ の
+  rune table も正規に選ばれる。一方リンクは rustc(rust-lld) が unknown-unknown で行い、
+  node/wasm-bindgen が WASI ランタイム無しで読める形にする。
+- ツールチェインは wasi-sdk-33 の Windows SDK 1 個（`bin/clang` ＋ 同梱 `share/wasi-sysroot`）。
+
+## フェーズ別の要点（ドライブ・バイ・エラーで反復）
+
+### Phase 0: 例外(eh)ツールチェイン
+- OCCT は例外(`Standard_Failure`)/RTTI 多用 → `noeh`/`-fno-exceptions` から
+  **`-fwasm-exceptions`** へ。`eh` 版 `libc++ / libc++abi / libunwind` をリンク。
+- 罠: cc-rs(cxx-build) が先頭付近に `-fno-exceptions` を付ける。`-fwasm-exceptions` は
+  EH モデルを選ぶだけで例外を再有効化しない。**env 末尾(後勝ち)で `-fexceptions` を明示**して解決。
+  - 実証: `clang++ -fno-exceptions -fwasm-exceptions` は throw NG、`... -fexceptions` を足すと OK。
+- まず最小の `run-cxx` で EH×wasm-bindgen×node を通してから OCCT へ。
+
+### Phase 1: ルート `build.rs` に wasm クロスビルド分岐
+`cadrum/build.rs` の `source-build`(cmake) に wasm 分岐を注入（`TARGET` が wasm32 のとき）。
+**env で決まらない 2 点だけ**を固定すれば足りる（実験で最小化、9→3 directive）:
+```
+.generator("Unix Makefiles")          # 既定だと Windows で VS generator が選ばれ cl.exe を探して失敗
+.define("CMAKE_C/CXX_COMPILER", wasi-sdk clang/clang++)  # 無いと PATH の mingw cc/gcc が選ばれ --target で死ぬ
+```
+- target/sysroot/`-fwasm-exceptions`/emulation マクロは makefile の `CFLAGS_/CXXFLAGS_<target>`
+  経由で cmake クレートが拾い、OCCT の compile flags に流れる。
+- 実験で **不要（自動解決）** と確認したもの: `CMAKE_SYSTEM_NAME=Generic` / `SYSTEM_PROCESSOR` /
+  `CMAKE_AR` / `CMAKE_RANLIB` / `CMAKE_C/CXX_COMPILER_WORKS`。generator を固定すれば cmake が
+  PATH から archiver を見つけ、コンパイラ検査も通り、cross 指定なしでも OCCT は configure できた。
+- bin パスは makefile が `export WASI_SDK_BIN := .../wasi-sdk-33/bin` で渡す。
+- 依存縮小: sandbox の cadrum を `default-features=false, features=["source-build","color"]`
+  （`png`/tiny-skia を外す。`.color()` 用に `color` は残す）。
+- 結果: OCCT の cmake configure は wasi-sdk の clang 指定だけで**そのまま通った**（OCCT 側パッチ不要）。
+
+### Phase 2: OCCT の POSIX 依存ファイルをスタブ
+既存の `patch_or_none`(これまで Windows 用) を wasm にも拡張。`stub_content(path,true)` で
+**シグネチャを残しボディだけ潰す**（リンク用シンボルは残す）。sandbox は cube/volume しか
+叩かず OSD は実行時未使用。
+- `src` 全体を grep して、wasi-libc に無い POSIX ヘッダを include する `.cxx` を一括特定:
+  `OSD_*`(File/Directory/Process/Host/Disk/signal/Chronometer/MemInfo/SharedLibrary 等)、
+  `Message_PrinterSystemLog.cxx`(syslog)、`STEPConstruct_AP203Context.cxx`(pwd)。
+- 罠: ボディを潰しても `#include <netdb.h>` 等が残ると fatal。
+  **存在しないヘッダ(`netdb.h`,`dlfcn.h`,`syslog.h`,…)は `comment_out_include_in` で除去**。
+- `sys/times.h` は `#error` ガード付き → makefile で
+  `-D_WASI_EMULATED_PROCESS_CLOCKS`(他に SIGNAL/MMAN/GETPID) を定義して通す
+  （スタブ済みで実体は呼ばないので `-lwasi-emulated-*` のリンクは不要）。
+
+### Phase 3: リンク・WASI import・実行
+- リンク: `-lc++` が見つからない → libc++ は `lib/wasm32-wasip1/eh/` サブディレクトリ。
+  makefile の `CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS` に `eh` の `-L` と
+  `c++abi`/`unwind` を追加（未参照なら遅延リンクで pure 等には無害）。
+- wasm-opt(binaryen) が EH wasm の Precompute pass で**クラッシュ** →
+  `Cargo.toml` の `[package.metadata.wasm-pack.profile.release] wasm-opt=false`。
+- node 実行に **`--experimental-wasm-exnref`** が必要（新 exnref EH モデル）。
+- WASI import を `src/wasi_stub.c` の no-op スタブで全消し。OCCT は 10 個を要求:
+  `environ_get/environ_sizes_get/fd_{close,fdstat_get,prestat_get,prestat_dir_name,read,seek,write}/proc_exit`。
+  - 重要: `wasi_stub.c` は従来 cxx+libcxx feature でしかリンクされていなかった。
+    `build.rs` を直し **cadrum feature でも whole-archive リンク**するように。
+- `env/setjmp`(OCCT `Standard_ErrorHandler`) も import に残る → C++ 例外を使い signal 経路は
+  不要なので `setjmp` は 0 を返すだけ、`longjmp` は trap のスタブで解決。
+- 実行直後 `__wasm_call_dtors → __funcs_on_exit` で `null function / signature mismatch` クラッシュ
+  （wasm-bindgen の command モデルが呼び出し毎に静的 dtor を走らせ、OCCT 静的オブジェクトの
+  dtor が不正な間接呼び出しをする）。**`__cxa_atexit` を no-op 化**して静的 dtor 登録自体を抑止
+  （一回限り実行なので終了時クリーンアップ不要）→ 解決。
+
+## 触ったファイル
+- `sandbox-wasm/makefile` … eh/-fexceptions、emulation マクロ、eh の `-L`、`WASI_SDK_BIN`、
+  node の `--experimental-wasm-exnref`。
+- `cadrum/build.rs` … wasm cmake クロス分岐、`patch_or_none` の wasm POSIX スタブ＋ヘッダ除去。
+- `sandbox-wasm/build.rs` … eh リンク、`wasi_stub` を cadrum でもリンク。
+- `sandbox-wasm/src/wasi_stub.c` … WASI import 10 種＋`setjmp/longjmp`＋`__cxa_atexit` スタブ。
+- `sandbox-wasm/Cargo.toml` … cadrum features、`wasm-opt=false`。
+
+## メモリ経由の STEP I/O は動く（追記）
+- cadrum の I/O は完全にストリームベース（`Solid::write_step<W: Write>` / `read_step<R: Read>`、
+  C++ 側は `RustReader/RustWriter` streambuf → `std::istream/ostream`）。スタブ化した `OSD_File`
+  層を通らないので **メモリ往復が可能**。sandbox の `volume()` を
+  cube→`write_step(Vec<u8>)`→`read_step(Cursor)`→`volume()` に変えても `run-cadrum` は **6000**。
+  color(XDE) 込みでも動作（フォールバック不要だった）。
+- 追加で必要だった WASI スタブ: `clock_time_get`(STEP ヘッダ時刻)・`fd_fdstat_set_flags`・
+  `path_filestat_get`・`path_open`（path 系は NOENT を返して OCCT を内蔵既定へフォールバック）。
+- つまり「不可」なのは **ファイルパス指定の I/O のみ**。メモリ⇄Solid は OK。
+
+## wasm サイズ最適化の調査（追記）
+
+前提: wasm-opt は何に効くか
+
+- `wasm-opt`(binaryen) は **リンク済みの最終 .wasm 1個**にかける後段最適化器。OCCT の prebuilt
+  (`.a` 静的ライブラリ) には**一切触れない**（OCCT の最適化は OCCT コンパイル時の `-O2/Release`）。
+- 効くのは**最終 wasm の容量と（副次的に）速度**。容量が主、速度は各コンポーネントが既に
+  最適化済み(rust release / OCCT -O2)なので控えめ。
+
+現状の wasm サイズと内訳
+
+- STEP I/O を入れると **~3.85MB（cube/volume のみ）→ ~14.9MB** に膨らむ。STEP/XDE が到達可能に
+  なるためで、これは**実コード**なので DCE では消えない（圧縮・サイズ最適化で縮むだけ）。
+
+サイズ削減レバー（OCCT が大半なので効く順）
+
+| レバー | 支配元 | OCCT に効く | キャッシュ再ビルド | 状態 |
+|---|---|---|---|---|
+| #1 wasm-opt `-Oz` | 最終 wasm | ✅(全体) | 不要(最終段) | **OFF**（v117 が Precompute でクラッシュ。issue #6639、v118+ で修正済み。v130 待ち） |
+| #2 OCCT `MinSizeRel`(`-Os`) | `build.rs` の cmake `.profile()` | ✅ | **要**（フラグ変更=焼き直し） | 未着手。速度 -O2 比 ~5–20% 低下の見込み（要実測） |
+| #3 rust `[profile.release]` | cargo/rustc + cc-rs | ❌(strip の最終段除去のみ) | 不要 | **導入済**（下記） |
+| #4 配布圧縮 gzip/brotli | サーブ側 | — | — | スコープ外 |
+
+　#3 の実測（導入済み）
+- `sandbox-wasm/Cargo.toml` に `[profile.release]`（`opt-level="s"`, `lto=true`,
+  `codegen-units=1`, `panic="abort"`, `strip=true`）を追加。
+- 結果: **14,866,904 B → 12,779,239 B（-2.09MB / -14%）**、機能維持（`run-cadrum`=6000）。
+- 主因は `strip`(names/debug 除去) と `panic=abort`(unwind 表削減) + LTO。**速度ホットパス(OCCT)
+  には無影響＝実質ノーコスト**。
+- cargo の `[profile.release]` は **rustc と cc-rs(`wrapper.cpp`/`ffi.cpp`/`wasi_stub.c`)** を支配するが、
+  **OCCT(C++) は支配しない**。OCCT は `build.rs` の `.profile("Release")`(=`-O2`)で固定。
+- ゆえに **キャッシュを捨てて OCCT を焼き直しても #3 では OCCT は縮まない**。OCCT を縮めるのは
+  #2(`MinSizeRel`)のみで、これは cargo profile とは独立・要キャッシュ再ビルド。
+
+## 既知の制限 / 今後
+- OCCT の OSD 層はスタブ。**ファイルパス指定の I/O・スレッド・ディスク上のリソース/スキーマ参照は不可**
+  （`path_open` は NOENT 固定）。メモリ経由の STEP/BRep I/O と純幾何は動く。
+  実ファイルや環境依存リソースを使うなら実 wasi シム or JS 側 WASI が要る。
+- wasm-opt 無効（最適化のみ。機能影響なし）。生成 wasm は ~3.8MB。
+- OCCT ソースビルドは初回数分。以後 `sandbox-wasm/target/cadrum-occt-v800-wasm32-unknown-unknown` を再利用。
+- スレッド系(`OSD_Thread/ThreadPool/Parallel`)は今回は未参照で済んだが、並列を使う算法を載せると
+  pthread リンクの扱いが必要になる可能性。

--- a/sandbox-wasm/Cargo.lock
+++ b/sandbox-wasm/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "adler32"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,24 +21,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,23 +33,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
-name = "bytemuck"
-version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
-
-[[package]]
 name = "cadrum"
 version = "0.8.5"
 dependencies = [
  "cc",
+ "cmake",
  "cxx",
  "cxx-build",
  "glam",
  "libflate",
  "minreq",
  "tar",
- "tiny-skia",
  "walkdir",
 ]
 
@@ -118,6 +88,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "codespan-reporting"
@@ -233,15 +212,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fdeflate"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
-dependencies = [
- "simd-adler32",
-]
-
-[[package]]
 name = "filetime"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,16 +227,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
 
 [[package]]
 name = "foldhash"
@@ -348,7 +308,7 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "libc",
  "plain",
  "redox_syscall",
@@ -382,16 +342,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
-
-[[package]]
 name = "minreq"
 version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,19 +363,6 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
-name = "png"
-version = "0.17.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
-dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -451,7 +388,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -480,7 +417,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -577,18 +514,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
-name = "strict-num"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,32 +548,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "tiny-skia"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
-dependencies = [
- "arrayref",
- "arrayvec",
- "bytemuck",
- "cfg-if",
- "log",
- "png",
- "tiny-skia-path",
-]
-
-[[package]]
-name = "tiny-skia-path"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
-dependencies = [
- "arrayref",
- "bytemuck",
- "strict-num",
 ]
 
 [[package]]

--- a/sandbox-wasm/Cargo.toml
+++ b/sandbox-wasm/Cargo.toml
@@ -8,17 +8,30 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wasm-bindgen = "*"
-cadrum = { path = "..", optional = true }
+cadrum = { path = "..", default-features = false, features = ["source-build", "color"], optional = true }
 cxx = { version = "1", optional = true }
 
 [build-dependencies]
 cc = "1"
 cxx-build = "1"
 
+# OCCT 由来の wasm 例外ハンドリングを含むと wasm-opt(binaryen) が Precompute pass で
+# クラッシュするため wasm-opt を無効化（最適化を外すだけで機能には影響しない）。
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false
+
 [features]
 pure = []
 cc = []
 cxx = ["dep:cxx"]
 cadrum = ["dep:cadrum"]
-libc = [] # build with libc
 libcxx = [] # build with libcxx
+
+# 最終 wasm のサイズ最適化（rust コード全部＝cadrum の rust 側も含む。OCCT/C++ は
+# cmake/cc 管轄なので対象外）。panic=abort と strip は速度ノーコストで効く。
+[profile.release]
+opt-level = "s"
+lto = true
+codegen-units = 1
+panic = "abort"
+strip = true

--- a/sandbox-wasm/build.rs
+++ b/sandbox-wasm/build.rs
@@ -1,21 +1,9 @@
 fn main() {
-	// cc feature: ヘッダを含まない純 C をコンパイル（libc 不要のはず）。
+	// cc feature: ffi.c をコンパイル。wasi-sysroot のヘッダ(-isystem)と libc.a(-L/-lc)は
+	// makefile の CFLAGS_wasm32_unknown_unknown / CARGO_TARGET_*_RUSTFLAGS から供給される。
+	// これで __has_include(<math.h>) が true になり ffi.c は sin 分岐を採る。
 	if std::env::var("CARGO_FEATURE_CC").is_ok() {
-		let mut build = cc::Build::new();
-		build.file("src/ffi.c");
-		if std::env::var("CARGO_FEATURE_LIBC").is_ok() {
-			// ターゲットは wasm32-unknown-unknown のまま。先に生成した wasi-libc の
-			// sysroot があれば、ヘッダ(-I)と libc.a(-lc) を足す。これで
-			// __has_include(<math.h>) が true になり ffi.c は sin 分岐を採る。
-			// sin は top-half(純粋計算)なので unknown でもリンクでき、WASI import を出さない。
-			let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-			let sysroot = format!("{manifest}/../out/wasi-sdk-33/share/wasi-sysroot");
-			let inc = format!("{sysroot}/include/wasm32-wasip1");
-			build.include(&inc);
-			println!("cargo:rustc-link-search=native={sysroot}/lib/wasm32-wasip1");
-			println!("cargo:rustc-link-lib=static=c");
-		}
-		build.compile("sandbox_cc");
+		cc::Build::new().file("src/ffi.c").compile("sandbox_cc");
 		println!("cargo:rerun-if-changed=src/ffi.c");
 		println!("cargo:rerun-if-changed=src/ffi.h");
 	}
@@ -25,13 +13,9 @@ fn main() {
 		build
 			.file("src/ffi.cpp")
 			.include("src")
-			.std("c++17")
-			// add は f64 を返すので生成トランポリンは noexcept、cxx.cc の throw も
-			// RUST_CXX_NO_EXCEPTIONS で abort() に切り替わる。正常系は throw しないので
-			// 例外/RTTI を無効化して libc++ を -fwasm-exceptions 無しのまま使う。
-			.flag_if_supported("-fno-exceptions")
-			.flag_if_supported("-fno-rtti")
-			.define("RUST_CXX_NO_EXCEPTIONS", None);
+			.std("c++17");
+			// 例外/RTTI 関連フラグ(-fwasm-exceptions 等)は makefile の
+			// CXXFLAGS_wasm32_unknown_unknown が cc-rs 経由で全 C++ TU(ffi.cpp/cxx.cc)へ届ける。
 		// libcxx feature: 生成した wasi-sysroot の libc++/libc ヘッダ(-isystem)と
 		// libc++/libc++abi/libc(.a) を足す。target は wasm32-unknown-unknown のまま
 		// にして __wasi__ を定義させず、libc++ の WASI bottom-half 経路（実 import を
@@ -39,35 +23,36 @@ fn main() {
 		if std::env::var("CARGO_FEATURE_LIBCXX").is_ok() {
 			let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 			let sysroot = format!("{manifest}/../out/wasi-sdk-33/share/wasi-sysroot");
-			build.flag(format!("-isystem{sysroot}/include/wasm32-wasip1/noeh/c++/v1"));
-			build.flag(format!("-isystem{sysroot}/include/wasm32-wasip1"));
-			// target は unknown-unknown のままなので __wasi__ が未定義。wasi-sdk-33 の
-			// libc++ は __locale の rune table を __wasi__ 等で選ぶが該当分岐が無く
-			// ctype マスクが未定義になる。libc++ 自前のデフォルト rune table を選ぶ
-			// _LIBCPP_PROVIDES_DEFAULT_RUNE_TABLE を定義して回避する。
-			build.define("_LIBCPP_PROVIDES_DEFAULT_RUNE_TABLE", None);
-			// noeh: -fno-exceptions ビルドに対応する libc++ / libc++abi バリアント。
-			println!("cargo:rustc-link-search=native={sysroot}/lib/wasm32-wasip1/noeh");
+			// ヘッダ(-isystem)と __wasi__ rune table は makefile の CXXFLAGS_<target>
+			// (--target=wasm32-wasip1 --sysroot=...) が供給する。ここはリンクのみ。
+			// eh: -fwasm-exceptions ビルドに対応する libc++ / libc++abi。例外巻き戻しに
+			// libunwind が要る。
+			println!("cargo:rustc-link-search=native={sysroot}/lib/wasm32-wasip1/eh");
 			println!("cargo:rustc-link-search=native={sysroot}/lib/wasm32-wasip1");
 			println!("cargo:rustc-link-lib=static=c++");
 			println!("cargo:rustc-link-lib=static=c++abi");
+			println!("cargo:rustc-link-lib=static=unwind");
 			println!("cargo:rustc-link-lib=static=c");
-			// <iostream> の静的初期化子が引きずる wasi_snapshot_preview1 import を
-			// no-op スタブで定義して消す（正常系では stdout に書かない）。スタブの実
-			// import シンボルは libc.a 処理時に初めて undefined になるので、リンク順に
-			// 依らず確実に取り込むため whole-archive で強制リンクする。
-			let out_dir = std::env::var("OUT_DIR").unwrap();
-			cc::Build::new()
-				.file("src/wasi_stub.c")
-				.cargo_metadata(false)
-				.compile("wasi_stub");
-			println!("cargo:rustc-link-search=native={out_dir}");
-			println!("cargo:rustc-link-lib=static:+whole-archive=wasi_stub");
-			println!("cargo:rerun-if-changed=src/wasi_stub.c");
 		}
 		build.compile("sandbox_cxx");
 		println!("cargo:rerun-if-changed=src/ffi.cpp");
 		println!("cargo:rerun-if-changed=src/ffi.h");
+	}
+	// libc++ をリンクする feature(cxx+libcxx / cadrum=OCCT) は、libc++/OCCT の静的初期化
+	// (iostream・getenv 等) が引きずる wasi_snapshot_preview1 import を no-op スタブで潰す。
+	// 正常系では実 I/O しない。スタブシンボルは libc.a 処理時に初めて undefined になるので
+	// whole-archive で確実に取り込む。
+	let links_libcxx = std::env::var("CARGO_FEATURE_LIBCXX").is_ok()
+		|| std::env::var("CARGO_FEATURE_CADRUM").is_ok();
+	if links_libcxx {
+		let out_dir = std::env::var("OUT_DIR").unwrap();
+		cc::Build::new()
+			.file("src/wasi_stub.c")
+			.cargo_metadata(false)
+			.compile("wasi_stub");
+		println!("cargo:rustc-link-search=native={out_dir}");
+		println!("cargo:rustc-link-lib=static:+whole-archive=wasi_stub");
+		println!("cargo:rerun-if-changed=src/wasi_stub.c");
 	}
 	println!("cargo:rerun-if-changed=src/lib.rs");
 }

--- a/sandbox-wasm/makefile
+++ b/sandbox-wasm/makefile
@@ -13,23 +13,42 @@ export MSYS_NO_PATHCONV := 1
 # 我々は libc++ を使うので CXXSTDLIB=c++ に上書きする。
 export CXXSTDLIB := c++
 SYSROOT := $(CURDIR)/../out/$(call stem,$(WASI_SDK))/share/wasi-sysroot
-export CXXFLAGS_wasm32_unknown_unknown := -isystem$(SYSROOT)/include/wasm32-wasip1/noeh/c++/v1 -isystem$(SYSROOT)/include/wasm32-wasip1 -fno-exceptions -fno-rtti -DRUST_CXX_NO_EXCEPTIONS -D_LIBCPP_PROVIDES_DEFAULT_RUNE_TABLE
+# OCCT の wasm クロスビルドのツールチェインを env で差す（Dockerfile の CC_<target> と同じ流儀）。
+# build.rs が CC_<target>/CXX_<target> を CMAKE_C/CXX_COMPILER へ転送する。
+# PATH 先頭が wasi-sdk/bin なので `clang`/`clang++` は wasi-sdk のものに解決される。
+export CC_wasm32_unknown_unknown := clang
+export CXX_wasm32_unknown_unknown := clang++
+# generator は env で渡せる（cmake は CMAKE_GENERATOR を尊重）。Windows 既定の VS generator を避ける。
+export CMAKE_GENERATOR := Unix Makefiles
+# C/C++ のコンパイルだけ --target=wasm32-wasip1 にすると、clang が --sysroot から
+# include/wasm32-wasip1 と（-fwasm-exceptions 時は）eh/c++/v1 を自動解決するので -isystem 不要。
+# __wasi__ が定義され libc++ の __locale も正規の rune table を選ぶため rune table hack も不要。
+# OCCT は例外/RTTI を多用するので -fwasm-exceptions（eh 版 libc++）で通す。RTTI は既定で有効。
+# 最終リンクは rustc が wasm32-unknown-unknown で行う（オブジェクトは wasm32 で互換）。
+# OCCT が引く wasi-libc 条件付きヘッダ（sys/times.h 等）を通すための emulation マクロ。
+# OSD はスタブ化して実体は呼ばないので、対応する -lwasi-emulated-* のリンクは不要。
+WASI_EMU := -D_WASI_EMULATED_PROCESS_CLOCKS -D_WASI_EMULATED_SIGNAL -D_WASI_EMULATED_MMAN -D_WASI_EMULATED_GETPID
+# cc-rs(cxx-build) は既定で -fno-exceptions を先頭付近に付ける。-fwasm-exceptions は EH
+# モデルを選ぶだけで例外を再有効化しないので、後勝ちの env 末尾で -fexceptions を足す。
+export CXXFLAGS_wasm32_unknown_unknown := --target=wasm32-wasip1 --sysroot=$(SYSROOT) -fwasm-exceptions -fexceptions $(WASI_EMU)
+export CFLAGS_wasm32_unknown_unknown := --target=wasm32-wasip1 --sysroot=$(SYSROOT) $(WASI_EMU)
+# libc.a のリンクは rustc(rust-lld)側。静的アーカイブは遅延リンクなので、libc を参照しない
+# pure ビルドには取り込まれない。これで build.rs から sysroot/libc 記述を排除できる。
+# eh: 例外あり libc++ の場所。c++ は link-cplusplus(CXXSTDLIB=c++)が出すので search path を
+# 足すだけ。OCCT/libc++ が要求する c++abi・unwind も繋ぐ（未参照なら遅延リンクで無害）。
+export CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS := -L native=$(SYSROOT)/lib/wasm32-wasip1/eh -L native=$(SYSROOT)/lib/wasm32-wasip1 -l static=c++abi -l static=unwind -l static=c
 
-# pure rust. I got wasm successfully.
-run: run-raw-pure
-# with simple cpp. such as "double add(double a, double b) { return a + b; }".
+run: run-pure run-cc run-cxx
+run-pure: run-raw-pure
+# cc + libc (wasi-sysroot). __has_include(<math.h>) is true so add() returns sin(a+b).
 run-cc: run-raw-cc
-# cc + libc (wasi-libc). __has_include(<math.h>) becomes true so add() returns sin(a+b).
-run-cc-libc: run-raw-cc-libc
 run-cxx: run-raw-cxx-libcxx
 # with cadrum. This is that target of this sandbox.
 run-cadrum: run-raw-cadrum
 run-raw-%: # build wasm, and run it with node. hyphens in % become comma-separated features (e.g. run-raw-cc-libc -> --features cc,libc).
 	cargo build --target wasm32-unknown-unknown --features "$(subst -, ,$*)"
 	../out/bin/wasm-pack build . -d ./target --features "$(subst -, ,$*)"
-	node -e "import('./target/wasm_experiment.js').then(m=>console.log(m.print_volume()))"
-# prebuilt sysroot を同梱する SDK を落とすだけ。from-source ビルドは不要。
-generate: download
+	node --experimental-wasm-exnref -e "import('./target/wasm_experiment.js').then(m=>console.log(m.print_volume()))"
 download: # download wasi-sdk (clang + prebuilt sysroot with libc / libc++).
 	cargo install --root ../out wasm-pack
 	cd ../out && ( ls $(call stem,$(WASI_SDK))/bin/clang.exe || ( curl -L -O $(WASI_SDK) && tar xf $(notdir $(WASI_SDK)) --transform="s,^[^/]+,$(call stem,$(WASI_SDK)),x" ) )

--- a/sandbox-wasm/src/lib.rs
+++ b/sandbox-wasm/src/lib.rs
@@ -33,7 +33,12 @@ pub fn volume() -> f64 {
 pub fn volume() -> f64 {
 	use cadrum::{DVec3, Solid};
 	let solid = Solid::cube(DVec3::ZERO, DVec3::new(10.0, 20.0, 30.0)).color("#4a90d9");
-	solid.volume()
+	// ファイルを経由せずメモリへ STEP を書き、メモリから読み戻す（OSD_File スタブ層を通らない）。
+	let mut bytes: Vec<u8> = Vec::new();
+	Solid::write_step([&solid], &mut bytes).expect("write_step to memory failed");
+	let mut cursor = std::io::Cursor::new(&bytes);
+	let solids = Solid::read_step(&mut cursor).expect("read_step from memory failed");
+	solids.first().expect("no solid after round-trip").volume()
 }
 
 #[wasm_bindgen]

--- a/sandbox-wasm/src/wasi_stub.c
+++ b/sandbox-wasm/src/wasi_stub.c
@@ -29,3 +29,56 @@ int __imported_wasi_snapshot_preview1_fd_prestat_dir_name(int fd, int path, int 
 	(void)fd; (void)path; (void)path_len;
 	return 8; /* __WASI_ERRNO_BADF */
 }
+// OCCT(getenv 等)が引きずる環境変数 import。環境は空として扱う。出力ポインタには 0 を書く。
+int __imported_wasi_snapshot_preview1_environ_sizes_get(unsigned *count, unsigned *buf_size) {
+	*count = 0; *buf_size = 0;
+	return 0;
+}
+int __imported_wasi_snapshot_preview1_environ_get(int environ, int buf) {
+	(void)environ; (void)buf;
+	return 0;
+}
+// stdio 初期化の isatty 等が引く fd_fdstat_get。BADF を返して無効 fd 扱いにする。
+int __imported_wasi_snapshot_preview1_fd_fdstat_get(int fd, int stat) {
+	(void)fd; (void)stat;
+	return 8; /* __WASI_ERRNO_BADF */
+}
+// fd_read。0 バイト読込(EOF)として返す。
+int __imported_wasi_snapshot_preview1_fd_read(int fd, int iovs, int iovs_len, unsigned *nread) {
+	(void)fd; (void)iovs; (void)iovs_len;
+	*nread = 0;
+	return 0;
+}
+// STEP write/read が引きずる時刻・ファイル系 import。
+// 時刻は 0、path 系は NOENT(44) を返して「ファイル無し」とし OCCT を内蔵既定へフォールバックさせる。
+int __imported_wasi_snapshot_preview1_clock_time_get(int id, long long precision, unsigned long long *time) {
+	(void)id; (void)precision;
+	*time = 0;
+	return 0;
+}
+int __imported_wasi_snapshot_preview1_fd_fdstat_set_flags(int fd, int flags) {
+	(void)fd; (void)flags;
+	return 0;
+}
+int __imported_wasi_snapshot_preview1_path_filestat_get(int fd, int flags, int path, int path_len, int buf) {
+	(void)fd; (void)flags; (void)path; (void)path_len; (void)buf;
+	return 44; /* __WASI_ERRNO_NOENT */
+}
+int __imported_wasi_snapshot_preview1_path_open(int fd, int dirflags, int path, int path_len, int oflags,
+                                                long long rights_base, long long rights_inheriting, int fdflags, int opened_fd) {
+	(void)fd; (void)dirflags; (void)path; (void)path_len; (void)oflags;
+	(void)rights_base; (void)rights_inheriting; (void)fdflags; (void)opened_fd;
+	return 44; /* __WASI_ERRNO_NOENT */
+}
+// OCCT の Standard_ErrorHandler が参照する setjmp/longjmp。wasm では env import になる。
+// シグナル経由の例外変換は使わず C++ 例外を使うので、setjmp は 0 を返すだけでよく
+// (保護ブロックへ素通り)、longjmp は到達しない（万一来たら trap）。
+int setjmp(void *env) { (void)env; return 0; }
+void longjmp(void *env, int val) { (void)env; (void)val; __builtin_trap(); }
+// 静的デストラクタ登録を抑止する。一回限りの実行なので終了時クリーンアップは不要で、
+// __wasm_call_dtors 経由で OCCT 静的オブジェクトの dtor が不正な間接呼び出し
+// (null function / signature mismatch) を起こすのを根本回避する。
+int __cxa_atexit(void (*f)(void *), void *arg, void *dso) {
+	(void)f; (void)arg; (void)dso;
+	return 0;
+}


### PR DESCRIPTION
…rebuilts as cadrum-occt-v800-rev1 (#187)

* feature/wasi

* before cadrum

* @ sandbox-wasm: OCCT を wasm32 にクロスビルドして run-cadrum を通す

ルート build.rs の source-build に wasm クロスビルド分岐を追加し、OCCT 8.0.0 を wasi-sdk で wasm32-wasip1 向けにビルド。OSD など POSIX 依存ファイルはボディ stub＋ 不在ヘッダ除去で通す。sandbox 側は eh(-fwasm-exceptions) 版 libc++ をリンクし、 WASI import / setjmp / __cxa_atexit を no-op スタブ化、wasm-opt 無効＋node の --experimental-wasm-exnref で実行。

make -C sandbox-wasm run-cadrum -> "Solid volume: 6000"（実 OCCT 幾何）。


@

* in-memory STEP-io works

* build.rs: OSD スタブを全 target 共通化（Win/Linux で cargo test 緑）

* update

* 結果: OCCT の cmake configure は wasi-sdk の clang 指定だけで**そのまま通った**（OCCT 側パッチ不要）。

* OCCT クロスツールチェインを env 駆動化し wasm prebuilt を docker 対応

cmake クレートは cc-rs の CC_<target>/CXX_<target>/AR_<target> を CMAKE_* へ 転送しないため、OCCT の cmake が host のコンパイラ(mingw cc 等)を拾ってしまう。 build.rs に target 非依存の橋渡しを入れ、env が設定されていれば
CMAKE_C/CXX_COMPILER / CMAKE_AR へ転送する（汎用 CC → 固有 CC_<target> の後勝ち）。 これに伴い wasm 専用の cmake 設定ブロックを撤去。

結果、ツールチェイン選択を完全に env で外から差せるようになり（Dockerfile の
CC_<target> と同じ流儀）、makefile / Dockerfile が

  CC_wasm32_unknown_unknown=clang  CXX_..=clang++  CMAKE_GENERATOR="Unix Makefiles"

を渡すだけで OCCT を wasm32 へクロスビルドできる。

変更:
- build.rs: CC/CXX/AR の env 転送（target 非依存）。wasm 固有 define を削除。
  - generator → CMAKE_GENERATOR env で渡せる（cmake が尊重）。
  - CMAKE_SYSTEM_NAME / PROCESSOR は cmake クレートが自動設定（元から不要）。
  - CMAKE_AR / RANLIB / *_COMPILER_WORKS は不要（PATH 解決・自動）と実験で確認。
- sandbox-wasm/makefile: CC_<target>/CXX_<target>/CMAKE_GENERATOR を export、 WASI_SDK_BIN 依存を撤去。
- docker/Dockerfile_wasm32-unknown-unknown: Linux + wasi-sdk で OCCT(wasm) の prebuilt を焼く（他 target の cadrum-occt-% と同じ枠組み）。

検証: make -C sandbox-wasm run-cadrum -> Solid volume: 6000。 新規ビルドの CMakeCache に CMAKE_C_COMPILER=clang / CMAKE_GENERATOR=Unix Makefiles が入ることを確認（= env 転送が効いている）。



* prebuilt: rev1 へ更新し wasm32-unknown-unknown を追加

本ブランチは build.rs の OSD スタブ共通化・OCCT cmake クロス設定の env 駆動化等で prebuilt OCCT の内容が変わるため、#188 で導入された BUILD_REVISION を rev0→rev1 に上げる。 あわせて新ターゲット wasm32-unknown-unknown の prebuilt を CI 配布対象に加える。

- build.rs: BUILD_REVISION = "rev1"。download 先タグ/キャッシュ名が cadrum-occt-v800-rev1[-<target>] になる（doc comment も追従）。
- .github/workflows/prebuilt.yaml:
  - release を rev1 へ（tag_name: cadrum-occt-v800-rev1 / name: …(rev1)）。 build.rs の cadrum_occt_name(None) と lockstep（不一致だと DL が 404）。
  - Docker-cross の build matrix に wasm32-unknown-unknown を追加。 `make cadrum-occt-wasm32-unknown-unknown` ＝ docker/Dockerfile_wasm32-unknown-unknown （manylinux + Linux wasi-sdk）で OCCT を wasm に焼き、tarball を upload する。

実 rev1 リリースは prebuilt workflow のトリガ（prebuilt ブランチへ push / workflow_dispatch）で 生成され、全 target（既存6 + wasm）が Release cadrum-occt-v800-rev1 に並ぶ。



---------