### PR TITLE
version/0.8.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to `cadrum` will be documented in this file.
 This document is written according to the [Keep a Changelog][kac] style.
 
 1. [Version 0](#version-0)
+	1. [0.8.10](#0810)
 	1. [0.8.0](#080)
 	1. [0.7.6](#076)
 	1. [0.7.5](#075)
@@ -16,6 +17,31 @@ This document is written according to the [Keep a Changelog][kac] style.
 
 `cadrum` is in the `0.x` series. Minor-version bumps may include breaking
 changes until `1.0`.
+
+### 0.8.10
+
+> 0.8.6〜0.8.9 は欠番。wasm 対応の節目として 0.8.10 へ飛ばした
+> (`^0.8` 互換は維持)。
+
+#### Added
+
+- **`wasm32-unknown-unknown` ターゲット対応。** OCCT (OpenCASCADE 8.0.0) を
+  WebAssembly 向けに静的ビルドし、cadrum をブラウザ／wasm ランタイム上で
+  動かせるようにした。メモリ経由の STEP / BRep I/O と純幾何が動作する。
+  現状 OCCT の OSD 層はスタブのため、ファイルパス I/O・スレッド・ディスク上
+  リソースは利用できない。default(prebuilt) 解決は後続で、現状 wasm は
+  `--features source-build` 前提。
+
+#### Changed
+
+- **Prebuilt tarball を rev1 (`cadrum-occt-v800-rev1`) に更新。** `build.rs` の
+  `BUILD_REVISION` を `rev1` に上げ、wasm を含むビルドマトリクスで再生成・配布。
+  既存ターゲット (Linux / Windows / macOS × x86_64 / aarch64) の解決挙動は不変。
+- **README を全面改訂。** 冒頭に `What is cadrum` を新設し、`Summary` /
+  `Introduction` を削除。セクション順を What is cadrum → Build → Capabilities に
+  整理し、Build に wasm ターゲットを追加。Capabilities / Features の記述を現状
+  API (`Scene2D::write_svg` / `write_png`、`Mesh::write_gltf_binary`、
+  `Solid::write_multiview_png`、`png` feature、glTF カラー往復) に合わせて修正。
 
 ### 0.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ changes until `1.0`.
 - **Prebuilt tarball を rev1 (`cadrum-occt-v800-rev1`) に更新。** `build.rs` の
   `BUILD_REVISION` を `rev1` に上げ、wasm を含むビルドマトリクスで再生成・配布。
   既存ターゲット (Linux / Windows / macOS × x86_64 / aarch64) の解決挙動は不変。
+- **Prebuilt tarball を slim 化（配布サイズを大幅削減）。** インストール後に
+  リンク対象の 24 ツールキット (`.a` / `.lib`) だけを残し、`doc` / `resource` /
+  `bin` スクリプト・`cmake` / `pkgconfig` を除去。`cargo build` 時のダウンロード量・
+  ディスク使用量・CI キャッシュが大きく減る。LGPL 2.1 §2 の都合で改変 OCCT ソース
+  (`OCCT-8_0_0/`) は同梱を維持。
 - **README を全面改訂。** 冒頭に `What is cadrum` を新設し、`Summary` /
   `Introduction` を削除。セクション順を What is cadrum → Build → Capabilities に
   整理し、Build に wasm ターゲットを追加。Capabilities / Features の記述を現状

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "cadrum"
-version = "0.8.5"
+version = "0.8.10"
 dependencies = [
  "cc",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cadrum"
-version = "0.8.5"
+version = "0.8.10"
 edition = "2021"
 description = "Rust CAD library powered by statically linked, headless OpenCASCADE (OCCT 8.0.0) — runs natively and in the browser via WebAssembly"
 license = "MIT"


### PR DESCRIPTION
crates.io 0.8.5 → 0.8.10 へバージョンを上げる。wasm32 対応の節目として `0.8.6`〜`0.8.9` を飛ばし、`^0.8` 互換は維持する（cargo caret: `>=0.8.5, <0.9.0` の範囲内）。`src/` に変更はなく公開 Rust API は不変のため、minor (0.9.0) ではなく patch 位置で据え置く。

## 変更

- `Cargo.toml` / `Cargo.lock`: `version` を `0.8.10` に更新
- `CHANGELOG.md`: `0.8.10` エントリを追加（wasm32 対応 / prebuilt rev1 / README 改訂）

## publish 前の必須事項

- **`cargo publish` は未実施**（ビルドを待ってメンテナが実行）
- ⚠️ `build.rs` は `cadrum-occt-v800-rev1` を取得する。**publish 前に `prebuilt.yaml` を回して rev1 リリース一式（wasm 含む各ターゲットの tarball）を公開する必要がある**。現状の最新は rev0。

## semver メモ

- 破壊的変更ゼロ・公開 API 不変 → `^0.8` 利用者にそのまま自動追従される
- wasm 機能は Rust API 追加ではなく build.rs + prebuilt 配布で提供