### PR TITLE
OCCT prebuilt を slim 化し gnu/msvc ビルドと CI exit code を修正

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -365,9 +365,12 @@ mod source {
 
 		// lib/ からリンク対象(OCC_LIBS)以外を削除。cmake/pkgconfig も対象だが cadrum は build.rs で
 		// 直リンクし cmake/pkgconfig を消費しないので実害なし。min_depth(1) で lib root 自身は消さない。
+		// 拡張子を外した basename(file_stem)が OCC_LIBS のいずれかで終わるものだけ残す。contains だと
+		// "TKDE" が TKDEIGES 等を巻き込むので suffix 判定にする（libcadrum_* は後段で同梱され無関係）。
 		if let Some([_include_dir, lib_dir]) = find_occt_dirs(effective_root) {
 			for child in walkdir::WalkDir::new(&lib_dir).min_depth(1).into_iter().flatten() {
-				if !OCC_LIBS.iter().any(|lib| child.file_name().to_str().unwrap_or_default().contains(lib)) {
+				let stem = child.path().file_stem().and_then(|s| s.to_str()).unwrap_or_default();
+				if !OCC_LIBS.iter().any(|lib| stem.ends_with(lib)) {
 					if child.file_type().is_file() {
 						let _ = std::fs::remove_file(child.path());
 					} else {

--- a/build.rs
+++ b/build.rs
@@ -249,7 +249,7 @@ fn bundle_runtime_libs(occt_lib_dir: &Path, libs: &[&str]) {
 // ---------------------------------------------------------------------------
 #[cfg(feature = "source-build")]
 mod source {
-	use super::{download_and_extract_tar_gz, find_occt_dirs, OCCT_VERSION};
+	use super::{download_and_extract_tar_gz, find_occt_dirs, OCC_LIBS, OCCT_VERSION};
 	use std::env;
 	use std::path::{Path, PathBuf};
 

--- a/build.rs
+++ b/build.rs
@@ -338,17 +338,15 @@ mod source {
 			.define("BUILD_ENABLE_FPE_SIGNAL_HANDLER", "OFF")
 			.define("CMAKE_RC_FLAGS_INIT", "-C 1252");
 
-		// cmake クレートは cc-rs の CC_<target>/CXX_<target>/AR_<target> を CMAKE_* へ転送しない。
-		// クロスツールチェインを env で差せるよう、ここで橋渡しする（target 非依存）。
-		// 汎用(CC/CXX/AR) → target 固有(CC_<target> 等) の順で後勝ち。env が無い target(native 等)は
-		// 何もせず cmake の既定探索に任せる。generator は CMAKE_GENERATOR env、target/sysroot 等は
-		// CFLAGS_/CXXFLAGS_<target> から供給される（いずれも cmake クレートが env を読む）。
+		// cmake クレートは cc-rs の CC_<target>/CXX_<target> を CMAKE_C/CXX_COMPILER へ転送しない。
+		// クロスツールチェインを env で差せるよう、ここで橋渡しする（target 非依存）。汎用(CC/CXX)
+		// → target 固有(CC_<target>) の順で後勝ち。env が無い target(native 等)は何もせず cmake の
+		// 既定探索に任せる。generator は CMAKE_GENERATOR env、target/sysroot 等は CFLAGS_/CXXFLAGS_<target>。
+		// AR は転送しない: cmake は CMAKE_AR を PATH 解決せず bare 名だとリンクが壊れる。
+		// CMAKE_C_COMPILER を指定すれば cmake が compiler prefix から正しい ar を自動導出する
+		// （AR_<target> は cc-rs が wrapper.cpp の archive に使うので無駄にはならない）。
 		let tgt = env::var("TARGET").unwrap_or_default().replace('-', "_");
-		for (cmake_key, base) in [
-			("CMAKE_C_COMPILER", "CC"),
-			("CMAKE_CXX_COMPILER", "CXX"),
-			("CMAKE_AR", "AR"),
-		] {
+		for (cmake_key, base) in [("CMAKE_C_COMPILER", "CC"), ("CMAKE_CXX_COMPILER", "CXX")] {
 			for name in [base.to_string(), format!("{base}_{tgt}")] {
 				if let Ok(v) = env::var(&name) {
 					cfg.define(cmake_key, &v);
@@ -359,6 +357,26 @@ mod source {
 
 		eprintln!("OCCT built at: {}", built.display());
 
+		// tarball を slim 化: cadrum は include/lib しか使わない。share/(doc・resource) と
+		// bin/(OCCT スクリプト) を削除。OCCT-8_0_0/(改変ソース) は LGPL 2.1 §2 のため下で残す。
+		for d in ["share", "bin"] {
+			let _ = std::fs::remove_dir_all(effective_root.join(d));
+		}
+
+		// lib/ からリンク対象(OCC_LIBS)以外を削除。cmake/pkgconfig も対象だが cadrum は build.rs で
+		// 直リンクし cmake/pkgconfig を消費しないので実害なし。min_depth(1) で lib root 自身は消さない。
+		if let Some([_include_dir, lib_dir]) = find_occt_dirs(effective_root) {
+			for child in walkdir::WalkDir::new(&lib_dir).min_depth(1).into_iter().flatten() {
+				if !OCC_LIBS.iter().any(|lib| child.file_name().to_str().unwrap_or_default().contains(lib)) {
+					if child.file_type().is_file() {
+						let _ = std::fs::remove_file(child.path());
+					} else {
+						let _ = std::fs::remove_dir_all(child.path());
+					}
+				}
+			}
+		}
+
 		// LGPL 2.1 §2: keep only patched files; remove everything else
 		walk_occt_sources(&source_dir, |path| {
 			if path.is_dir() {
@@ -367,7 +385,6 @@ mod source {
 				let _ = std::fs::remove_file(path);
 			}
 		});
-
 		find_occt_dirs(effective_root)
 	}
 
@@ -615,9 +632,13 @@ mod source {
 				let before = sig_norm[..pos].trim_end();
 				let id_start = before.rfind(|c: char| !(c.is_ascii_alphanumeric() || c == '_')).map(|p| p + 1).unwrap_or(0);
 				let ident = &before[id_start..];
+				// Handle(X) は OCCT のスマートポインタマクロ。返り値型に現れる `(` を関数の引数 `(`
+				// と誤認しないよう、ALL_CAPS マクロと同様に読み飛ばす（さもないと Handle 返り関数が
+				// `{}` になり MSVC C4716「must return a value」で落ちる）。
 				let is_macro = !ident.is_empty()
-					&& ident.chars().all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
-					&& ident.chars().any(|c| c.is_ascii_uppercase());
+					&& (ident == "Handle"
+						|| (ident.chars().all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+							&& ident.chars().any(|c| c.is_ascii_uppercase())));
 				if !is_macro {
 					break pos;
 				}

--- a/makefile
+++ b/makefile
@@ -16,12 +16,14 @@ publish: deploy # publish to crates.io
 cadrum-occt: generate # build occt from source natively
 	cargo clean
 	# CADRUM_BUNDLE_GCC_RUNTIME=1 で OCCT lib dir に libstdc++.a / libgcc.a / libgcc_eh.a を libcadrum_* として同梱し、ホスト側 GCC との ABI 不整合を回避する (#89 / #147 対策)。
-	CADRUM_BUNDLE_GCC_RUNTIME=1 cargo build --example 01_primitives --release --features source-build 2>&1 | tee out/log.txt
+	# pipefail is required so tee's exit code does not mask a cargo build failure
+	bash -c "set -o pipefail && CADRUM_BUNDLE_GCC_RUNTIME=1 cargo build --example 01_primitives --release --features source-build 2>&1 | tee out/log.txt"
 	find target -maxdepth 1 -type d -name 'cadrum*' | xargs -IX sh -c 'tar -czf out/$$(basename X).tar.gz -C $$(dirname X) $$(basename X)'
 cadrum-occt-%: # build occt from source in cross ( = native build in container ) cadrum-occt-aarch64-unknown-linux-gnu cadrum-occt-x86_64-pc-windows-gnu cadrum-occt-x86_64-unknown-linux-gnu
 	docker build -f docker/Dockerfile_$(*) -t cadrum-occt-$(*) .
 	docker run --rm -v $(PWD)/out/$(*):/src/out cadrum-occt-$(*) make cadrum-occt
-check-cadrum-occt-%: cadrum-occt-% # varidate builded occt to run binary which is linked with host's code and container's static occt libraries
+cadrum-occt-%-check: # varidate builded occt to run binary which is linked with host's code and container's static occt libraries
+	$(MAKE) cadrum-occt-$*
 	mkdir -p target
 	find out -maxdepth 2 -type f -name '*.tar.gz' | xargs -IX tar -xzf X -C target
 	timeout 300 cargo run --example 01_primitives

--- a/sandbox-wasm/makefile
+++ b/sandbox-wasm/makefile
@@ -48,7 +48,7 @@ run-cadrum: run-raw-cadrum
 run-raw-%: # build wasm, and run it with node. hyphens in % become comma-separated features (e.g. run-raw-cc-libc -> --features cc,libc).
 	cargo build --target wasm32-unknown-unknown --features "$(subst -, ,$*)"
 	../out/bin/wasm-pack build . -d ./target --features "$(subst -, ,$*)"
-	node --experimental-wasm-exnref -e "import('./target/wasm_experiment.js').then(m=>console.log(m.print_volume()))"
+	node -e "import('./target/wasm_experiment.js').then(m=>console.log(m.print_volume()))"
 download: # download wasi-sdk (clang + prebuilt sysroot with libc / libc++).
 	cargo install --root ../out wasm-pack
 	cd ../out && ( ls $(call stem,$(WASI_SDK))/bin/clang.exe || ( curl -L -O $(WASI_SDK) && tar xf $(notdir $(WASI_SDK)) --transform="s,^[^/]+,$(call stem,$(WASI_SDK)),x" ) )


### PR DESCRIPTION
Close #183

## 概要
OCCT prebuilt のリリースビルド（`make cadrum-occt-%` 系・CI）で発生していた肥大・ビルド失敗・CI 緑誤判定をまとめて修正する。

## 変更
### build.rs
- **slim 化**: install 後に `share/`(doc・resource)・`bin/`(スクリプト) と `lib/` のリンク非対象を削除。リンク非対象の判定は `file_stem`(拡張子を外した basename)が `OCC_LIBS` のいずれかで末尾一致しないもの、とする（`contains` だと `TKDE` が `TKDEIGES` 等を巻き込むため suffix 判定）。`cmake`/`pkgconfig` も削除（cadrum は build.rs で直リンクし消費しない）。`OCCT-8_0_0/`(改変ソース) は LGPL 2.1 §2 のため残す。`min_depth(1)` で `lib/` root 自身は保持。
- **windows-gnu 修正**: `CMAKE_AR` の転送を撤去。bare 名を cmake が PATH 解決せずリンクが壊れていた。`CMAKE_C_COMPILER` 指定で cmake が compiler prefix から ar を自動導出する。
- **windows-msvc 修正**: body-stub 生成器が `Handle(X)` 返り関数を `{}`（return 無し）化して MSVC C4716「must return a value」で落ちる件を修正。返り値型の `Handle(` を ALL_CAPS マクロ同様に読み飛ばし `{ return {}; }`（null handle）を出す。

### makefile
- **CI exit code 修正**: `cargo build ... | tee` の終了コードが `tee`(0) になり cargo 失敗が CI に伝播しなかった件を `bash -c "set -o pipefail && ..."` で修正。
- **check ターゲットの suffix 化**: `check-cadrum-occt-%` → `cadrum-occt-%-check`。prereq を持たせると貪欲な暗黙ルール `cadrum-occt-%` に食われるため、ビルドはレシピ先頭の `$(MAKE) cadrum-occt-$*` で呼ぶ形にした。

### sandbox-wasm/makefile
- node の `--experimental-wasm-exnref` を撤去。

## 検証
`make cadrum-occt-x86_64-pc-windows-gnu-check` を docker で実走し、コンテナ内 OCCT クロスビルド → tarball → ホストで `01_primitives` 実行（`.step/.svg/.png` 出力）まで EXIT=0 で完走。ホストが slim 済み静的 OCCT とリンクして実行できる＝必要 lib を消していない確証。

slim 効果（tarball 実測, x86_64-pc-windows-gnu）:

| | slim 前 | slim 後 |
|---|---|---|
| tarball 内 `.a` | 35 | **27**（`OCC_LIBS` 24 + 同梱ランタイム `libcadrum_*` 3） |
| tarball サイズ | 55.0 MB | **50.7 MB** |

`TKDEIGES/TKBinL/TKBinXCAF/TKDEOBJ/TKDEPLY/TKDESTL/TKDEVRML/TKStdL/TKTObj/TKRWMesh/TKService/TKHLR/TKHelix/TKExpress/TKFeat` 等の余剰ツールキットを除去（`share/`/`bin/` 削除と合わせると元の ~272 MB から大幅減）。

- `make -n cadrum-occt-x86_64-pc-windows-gnu-check`: suffix ルールが選択され、ビルド→チェックの順に走ることを確認。
- windows-msvc の C4716 修正は CI 再実行で確認（ローカルに VS なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)