### PR TITLE
Rename source-build→source, occt-<ver>_<rev> naming, unify wasm EH on exnref

### DIFF
--- a/.github/workflows/prebuilt.yaml
+++ b/.github/workflows/prebuilt.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: cadrum-occt-${{ matrix.target }}
-          path: out/${{ matrix.target }}/cadrum-occt-*.tar.gz
+          path: out/${{ matrix.target }}/occt-*.tar.gz
 
   # The following prebuilt tarball is built on a native Windows runner with
   # native cl.exe:
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: cadrum-occt-x86_64-pc-windows-msvc
-          path: out/cadrum-occt-*.tar.gz
+          path: out/occt-*.tar.gz
 
   # The following prebuilt tarballs are built on native macOS runners with Apple
   # clang/libc++:
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: cadrum-occt-${{ matrix.target }}
-          path: out/cadrum-occt-*.tar.gz
+          path: out/occt-*.tar.gz
 
   release:
     needs: [build, build-windows-msvc, build-macos]
@@ -132,10 +132,10 @@ jobs:
           merge-multiple: true
 
       # NOTE: tag_name must match build.rs `cadrum_occt_name(None)` =
-      # `cadrum-occt-<slug>-<BUILD_REVISION>`. Bump this in lockstep with
-      # OCCT_VERSION / BUILD_REVISION in build.rs (same coupling as the v800 slug).
+      # `occt-<occt_version>_<BUILD_REVISION>` (e.g. `occt-8_0_0_rev2`). Bump this in
+      # lockstep with OCCT_VERSION / BUILD_REVISION in build.rs.
       - uses: softprops/action-gh-release@v2
         with:
-          tag_name: cadrum-occt-v800-rev1
-          name: OCCT prebuilt v8.0.0 (rev1)
+          tag_name: occt-8_0_0_rev2
+          name: OCCT prebuilt v8.0.0 (rev2)
           files: dist/*.tar.gz

--- a/.github/workflows/prebuilt.yaml
+++ b/.github/workflows/prebuilt.yaml
@@ -131,7 +131,7 @@ jobs:
           path: dist
           merge-multiple: true
 
-      # NOTE: tag_name must match build.rs `cadrum_occt_name(None)` =
+      # NOTE: tag_name must match build.rs `release_name(None, false)` =
       # `occt-<occt_version>_<BUILD_REVISION>` (e.g. `occt-8_0_0_rev2`). Bump this in
       # lockstep with OCCT_VERSION / BUILD_REVISION in build.rs.
       - uses: softprops/action-gh-release@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to `cadrum` will be documented in this file.
 This document is written according to the [Keep a Changelog][kac] style.
 
 1. [Version 0](#version-0)
+	1. [Unreleased](#unreleased)
 	1. [0.8.10](#0810)
 	1. [0.8.0](#080)
 	1. [0.7.6](#076)
@@ -17,6 +18,25 @@ This document is written according to the [Keep a Changelog][kac] style.
 
 `cadrum` is in the `0.x` series. Minor-version bumps may include breaking
 changes until `1.0`.
+
+### Unreleased
+
+#### Breaking
+
+- **Renamed the `source-build` feature to `source`.** Update
+  `--features source-build` to `--features source`. (#182)
+
+#### Changes
+
+- **New prebuilt artifact naming scheme.** Tarballs / release tag move to
+  `occt-<version>_<rev>-<target>` (single sorted list, `-` between fields and
+  `_` within a field, target hyphens underscored), e.g.
+  `occt-8_0_0_rev2-wasm32_unknown_unknown.tar.gz` under tag `occt-8_0_0_rev2`. (#203)
+- **wasm exception-handling unified on exnref.** OCCT and the cxx wrapper are
+  now compiled with `-mllvm -wasm-use-legacy-eh=false` so their EH encoding
+  matches the exnref-built wasi-sdk eh sysroot, fixing the `module uses a mix of
+  legacy and new exception handling instructions` error. (#199)
+- Prebuilt `BUILD_REVISION` bumped to `rev2` (naming + EH encoding change).
 
 ### 0.8.10
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ out with anything you need.
 You should be comfortable with `cargo` and the basics of building Rust
 projects. The first build downloads a prebuilt OCCT 8.0.0 tarball for
 supported targets and links it statically; on unsupported targets you will
-need CMake plus a C++17 compiler and `cargo build --features source-build`.
+need CMake plus a C++17 compiler and `cargo build --features source`.
 See the [README](./README.md#build) for the full build matrix.
 
 The project uses **tab indentation** (`U+0009`) throughout. `rustfmt.toml`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ color = []
 # Build OCCT from upstream sources when the cache is empty, instead of
 # downloading a prebuilt tarball. Off by default — most users will use the
 # prebuilt binary path.
-source-build = ["dep:cmake"]
+source = ["dep:cmake"]
 # PNG raster output for Scene2D via tiny-skia.
 png = ["dep:tiny-skia"]
 # Pure Rust CAD backend (no OCCT dependency)
@@ -39,9 +39,9 @@ minreq = { version = "2", features = ["https-rustls"] }
 libflate = "2"
 tar = "0.4"
 walkdir = "2"
-# source-build only: build OCCT from upstream sources
+# source feature only: build OCCT from upstream sources
 cmake = { version = "0.1", optional = true }
-# source-build + CADRUM_BUNDLE_GCC_RUNTIME: query the target compiler for libstdc++.a path
+# source feature + CADRUM_BUNDLE_GCC_RUNTIME: query the target compiler for libstdc++.a path
 cc = "1"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ cadrum = "^0.8"
 For other targets, build OCCT from source:
 
 ```sh
-OCCT_ROOT=/path/to/occt cargo build --features source-build
+OCCT_ROOT=/path/to/occt cargo build --features source
 ```
 
 If `OCCT_ROOT` is not set, built binaries are cached under `target/`.
@@ -102,7 +102,7 @@ If `OCCT_ROOT` is not set, built binaries are cached under `target/`.
   `Solid::write_multiview_png` — via the pure-Rust `tiny-skia` rasterizer.
   Disable to drop the `tiny-skia` dependency when SVG / STL / glTF output is
   enough.
-- **`source-build`**: Build OCCT from upstream sources with CMake instead of
+- **`source`**: Build OCCT from upstream sources with CMake instead of
   downloading a prebuilt tarball. Off by default — most users use the
   prebuilt path. Enable it for targets that have no published prebuilt.
 

--- a/build.rs
+++ b/build.rs
@@ -6,16 +6,18 @@ use std::path::{Path, PathBuf};
 /// the prebuilt tarball / cache directory name (with target) from this.
 const OCCT_VERSION: &str = "V8_0_0";
 
-/// Build revision for prebuilt tarballs. Update this when making non-OCCT-breaking changes that require cache invalidation (e.g. patch updates, build script changes, etc).
-const BUILD_REVISION: &str = "rev1";
+/// Build revision for prebuilt tarballs. Update this when making non-OCCT-breaking changes that require cache invalidation (e.g. patch updates, build script changes, EH encoding changes, etc).
+const BUILD_REVISION: &str = "rev2";
 
-/// `target` 指定あり: `cadrum-occt-v800-rev1-x86_64-pc-windows-gnu` (tarball / cache dir 名)
-/// `target` 指定なし: `cadrum-occt-v800-rev1` (`lzpel/cadrum` の GitHub Release タグ)
+/// Artifact name. Fields are separated by `-` and characters within a field by `_`,
+/// so the name parses by splitting on `-` (the target's hyphens are underscored too).
+/// `target` 指定あり: `occt-8_0_0_rev2-wasm32_unknown_unknown` (tarball / cache dir 名)
+/// `target` 指定なし: `occt-8_0_0_rev2` (`lzpel/cadrum` の GitHub Release タグ)
 fn cadrum_occt_name(target: Option<&str>) -> String {
-	let slug = OCCT_VERSION.to_ascii_lowercase().replace('_', "");
-	let release = format!("cadrum-occt-{}-{}", slug, BUILD_REVISION);
+	let occt = OCCT_VERSION.trim_start_matches(['V', 'v']);
+	let release = format!("occt-{}_{}", occt, BUILD_REVISION);
 	match target {
-		Some(target) => format!("{}-{}", release, target),
+		Some(target) => format!("{}-{}", release, target.replace('-', "_")),
 		None => release,
 	}
 }
@@ -66,7 +68,7 @@ fn cargo_target_dir(target: &str) -> PathBuf {
 /// Resolve `[include_dir, lib_dir]` for OCCT.
 ///
 ///   1. Cache hit → use it
-///   2. Cache miss + `source-build` → build from upstream sources
+///   2. Cache miss + `source` → build from upstream sources
 ///   3. Cache miss otherwise → download prebuilt tarball
 fn resolve_occt(effective_root: &Path, target: &str) -> [PathBuf; 2] {
 	println!("cargo:rerun-if-changed={}", effective_root.display());
@@ -74,26 +76,26 @@ fn resolve_occt(effective_root: &Path, target: &str) -> [PathBuf; 2] {
 	match find_occt_dirs(effective_root) {
 		Some(dirs) => return dirs,
 		None => {
-			#[cfg(feature = "source-build")]
+			#[cfg(feature = "source")]
 			{
 				eprintln!("cargo:warning=OCCT cache miss at {} — building from source (this may take 10-30 minutes)", effective_root.display());
 				let dirs = source::build_from_source(effective_root).expect("Failed to build OCCT from source");
 				// Prebuilt tarball 作成時のみ host GCC runtime を OCCT lib dir に同梱 (#89 / #147 対策)。
-				// gate を切らないと source-build user 全員のホスト libstdc++ が静的取り込みされてしまう。
+				// gate を切らないと source user 全員のホスト libstdc++ が静的取り込みされてしまう。
 				// mingw と Linux GNU で必要 (Windows MSVC は MSVC ランタイム、Mac は別系統)
 				if env::var("CADRUM_BUNDLE_GCC_RUNTIME").is_ok() && (target.ends_with("windows-gnu") || target.contains("linux-gnu")) {
 					bundle_runtime_libs(&dirs[1], &["libstdc++.a", "libgcc.a", "libgcc_eh.a"]);
 				}
 				return dirs;
 			}
-			#[cfg(not(feature = "source-build"))]
+			#[cfg(not(feature = "source"))]
 			{
 				return download_prebuilt(effective_root, target).unwrap_or_else(|| {
 					panic!(
 						"\nFailed to download prebuilt OCCT for target `{}`.\n\
 						 See README for the list of supported prebuilt targets, or enable\n\
-						 the `source-build` feature to build OCCT from upstream sources:\n\
-						 \n    cargo build --features source-build\n",
+						 the `source` feature to build OCCT from upstream sources:\n\
+						 \n    cargo build --features source\n",
 						target
 					)
 				});
@@ -178,6 +180,13 @@ fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path) {
 		build.flag("/utf-8");
 	}
 
+	// wasm: emit the new (exnref) wasm EH encoding so wrapper.cpp + cxx glue match the
+	// exnref-built wasi-sdk eh sysroot libs and the exnref OCCT (#199). No-op without
+	// -fwasm-exceptions, so it is safe even when exceptions are off.
+	if env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("wasm32") {
+		build.flag("-mllvm").flag("-wasm-use-legacy-eh=false");
+	}
+
 	#[cfg(feature = "color")]
 	build.define("CADRUM_COLOR", None);
 
@@ -189,7 +198,7 @@ fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path) {
 }
 
 /// Download a prebuilt OCCT tarball for `target` into `dest`.
-#[cfg(not(feature = "source-build"))]
+#[cfg(not(feature = "source"))]
 fn download_prebuilt(dest: &Path, target: &str) -> Option<[PathBuf; 2]> {
 	let top_name = cadrum_occt_name(Some(target));
 	let tarball_name = format!("{}.tar.gz", top_name);
@@ -242,8 +251,8 @@ fn fetch_bytes(url: &str) -> Result<Vec<u8>, String> {
 /// Bundle GCC runtime archives (libstdc++.a / libgcc.a / libgcc_eh.a) into
 /// the OCCT lib dir as `libcadrum_*.a`. Triggered by `CADRUM_BUNDLE_GCC_RUNTIME`
 /// only — used by the prebuilt-tarball makefile recipe so end users running
-/// source-build don't get their host libstdc++ silently bundled.
-#[cfg(feature = "source-build")]
+/// source don't get their host libstdc++ silently bundled.
+#[cfg(feature = "source")]
 fn bundle_runtime_libs(occt_lib_dir: &Path, libs: &[&str]) {
 	let compiler = cc::Build::new().get_compiler();
 	for &lib in libs {
@@ -260,10 +269,10 @@ fn bundle_runtime_libs(occt_lib_dir: &Path, libs: &[&str]) {
 }
 
 // ---------------------------------------------------------------------------
-// source-build: build OCCT from upstream sources.
+// source: build OCCT from upstream sources.
 // Dependencies on cmake and walkdir live here only.
 // ---------------------------------------------------------------------------
-#[cfg(feature = "source-build")]
+#[cfg(feature = "source")]
 mod source {
 	use super::{download_and_extract_tar_gz, find_occt_dirs, OCCT_VERSION, OCC_LIBS};
 	use std::env;
@@ -364,6 +373,13 @@ mod source {
 				}
 			}
 		}
+
+		// wasm: build OCCT with the new (exnref) wasm EH encoding so it matches the
+		// wrapper and the exnref wasi-sdk eh sysroot (#199). No-op without -fwasm-exceptions.
+		if env::var("TARGET").unwrap_or_default().starts_with("wasm32") {
+			cfg.cxxflag("-mllvm").cxxflag("-wasm-use-legacy-eh=false");
+		}
+
 		let built = cfg.build();
 
 		eprintln!("OCCT built at: {}", built.display());
@@ -425,7 +441,7 @@ mod source {
 	/// OS 依存(OSD)層など OS API を直接使う OCCT 実装ファイル。全 target で body-stub 化し
 	/// （シグネチャは残しリンク用シンボルを維持）、STUB_DROP_HEADERS の #include を外す。
 	/// cadrum の公開 I/O はストリームベースで OSD ファイル層を通らず、テストも std::fs で
-	/// バイト列を読み書きするので、source-build にこのスタブを当てても cargo test で検証できる。
+	/// バイト列を読み書きするので、source にこのスタブを当てても cargo test で検証できる。
 	/// 性能の要 OSD_ThreadPool / OSD_Parallel(_Threads/_TBB) / OSD_Thread は意図的に非対象。
 	const OSD_POSIX_STUBS: &[&str] = &["OSD_File.cxx", "OSD_Directory.cxx", "OSD_DirectoryIterator.cxx", "OSD_FileIterator.cxx", "OSD_FileNode.cxx", "OSD_Path.cxx", "OSD_Protection.cxx", "OSD_Process.cxx", "OSD_Host.cxx", "OSD_Disk.cxx", "OSD_Environment.cxx", "OSD_signal.cxx", "OSD_Chronometer.cxx", "OSD_MemInfo.cxx", "OSD_SharedLibrary.cxx", "Message_PrinterSystemLog.cxx", "STEPConstruct_AP203Context.cxx"];
 

--- a/build.rs
+++ b/build.rs
@@ -2,24 +2,33 @@ use std::env;
 use std::path::{Path, PathBuf};
 
 /// OCCT release used by cadrum. Update this tag when bumping OCCT versions.
-/// `cadrum_occt_name()` derives both the GitHub Release tag (no target) and
-/// the prebuilt tarball / cache directory name (with target) from this.
+/// `release_name()` derives the GitHub Release tag, the prebuilt tarball, and the
+/// cache directory name from this.
 const OCCT_VERSION: &str = "V8_0_0";
 
 /// Build revision for prebuilt tarballs. Update this when making non-OCCT-breaking changes that require cache invalidation (e.g. patch updates, build script changes, EH encoding changes, etc).
 const BUILD_REVISION: &str = "rev2";
 
-/// Artifact name. Fields are separated by `-` and characters within a field by `_`,
-/// so the name parses by splitting on `-` (the target's hyphens are underscored too).
-/// `target` 指定あり: `occt-8_0_0_rev2-wasm32_unknown_unknown` (tarball / cache dir 名)
-/// `target` 指定なし: `occt-8_0_0_rev2` (`lzpel/cadrum` の GitHub Release タグ)
-fn cadrum_occt_name(target: Option<&str>) -> String {
+/// Release tag / tarball / cache-dir name (#203). Fields are separated by `-` and
+/// characters within a field by `_`, so the name parses by splitting on `-` (the
+/// target's hyphens are underscored too). `has_version` appends the cadrum crate
+/// version for the per-crate FFI artifact.
+///
+/// - `release_name(None, false)`    → `occt-8_0_0_rev2`                              (GitHub Release タグ)
+/// - `release_name(Some(t), false)` → `occt-8_0_0_rev2-wasm32_unknown_unknown`       (OCCT tarball / cache dir)
+/// - `release_name(Some(t), true)`  → `occt-8_0_0_rev2-wasm32_unknown_unknown-cadrum-0_8_11` (FFI tarball)
+fn release_name(target: Option<&str>, has_version: bool) -> String {
 	let occt = OCCT_VERSION.trim_start_matches(['V', 'v']);
-	let release = format!("occt-{}_{}", occt, BUILD_REVISION);
-	match target {
-		Some(target) => format!("{}-{}", release, target.replace('-', "_")),
-		None => release,
+	let mut name = format!("occt-{}_{}", occt, BUILD_REVISION);
+	if let Some(target) = target {
+		name.push('-');
+		name.push_str(&target.replace('-', "_"));
 	}
+	if has_version {
+		name.push_str("-cadrum-");
+		name.push_str(&env!("CARGO_PKG_VERSION").replace('.', "_"));
+	}
+	name
 }
 
 fn main() {
@@ -43,7 +52,7 @@ fn main() {
 				p
 			}
 		})
-		.unwrap_or(cargo_target_dir(&target).join(cadrum_occt_name(Some(&target))));
+		.unwrap_or(cargo_target_dir(&target).join(release_name(Some(&target), false)));
 
 	let [occt_include, occt_lib_dir] = resolve_occt(&effective_root, &target);
 
@@ -210,9 +219,9 @@ fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path) {
 /// Download a prebuilt OCCT tarball for `target` into `dest`.
 #[cfg(not(feature = "source"))]
 fn download_prebuilt(dest: &Path, target: &str) -> Option<[PathBuf; 2]> {
-	let top_name = cadrum_occt_name(Some(target));
+	let top_name = release_name(Some(target), false);
 	let tarball_name = format!("{}.tar.gz", top_name);
-	let url = env::var("CADRUM_PREBUILT_URL").unwrap_or_else(|_| format!("https://github.com/lzpel/cadrum/releases/download/{}/{}", cadrum_occt_name(None), tarball_name));
+	let url = env::var("CADRUM_PREBUILT_URL").unwrap_or_else(|_| format!("https://github.com/lzpel/cadrum/releases/download/{}/{}", release_name(None, false), tarball_name));
 
 	eprintln!("cargo:warning=Downloading prebuilt OCCT from {}", url);
 

--- a/build.rs
+++ b/build.rs
@@ -145,6 +145,23 @@ const OCC_LIBS: &[&str] = &[
 	"TKCDF",
 ];
 
+/// Apply target-conditional C++ compiler flags through `apply`, which forwards each flag
+/// to the concrete builder (`cc::Build::flag` for the wrapper, `cmake::Config::cxxflag` for
+/// the OCCT source build). Shared so the wrapper and OCCT get identical flags — in particular
+/// the same wasm EH encoding, which must match the exnref-built wasi-sdk eh sysroot (#199).
+fn apply_compiler_flags(mut apply: impl FnMut(&str)) {
+	// MSVC: compile sources as UTF-8.
+	if env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc") {
+		apply("/utf-8");
+	}
+	// wasm: force the new (exnref) EH encoding so it matches the exnref wasi-sdk eh sysroot.
+	// No-op without -fwasm-exceptions, so it is safe even when exceptions are off.
+	if env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("wasm32") {
+		apply("-mllvm");
+		apply("-wasm-use-legacy-eh=false");
+	}
+}
+
 fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path) {
 	println!("cargo:rustc-link-search=native={}", occt_lib_dir.display());
 	for lib in OCC_LIBS {
@@ -176,16 +193,9 @@ fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path) {
 	let mut build = cxx_build::bridge("src/occt/ffi.rs");
 	build.file("cpp/wrapper.cpp").include(occt_include).std("c++17").define("_USE_MATH_DEFINES", None);
 
-	if target_env == "msvc" {
-		build.flag("/utf-8");
-	}
-
-	// wasm: emit the new (exnref) wasm EH encoding so wrapper.cpp + cxx glue match the
-	// exnref-built wasi-sdk eh sysroot libs and the exnref OCCT (#199). No-op without
-	// -fwasm-exceptions, so it is safe even when exceptions are off.
-	if env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("wasm32") {
-		build.flag("-mllvm").flag("-wasm-use-legacy-eh=false");
-	}
+	apply_compiler_flags(|s| {
+		build.flag(s);
+	});
 
 	#[cfg(feature = "color")]
 	build.define("CADRUM_COLOR", None);
@@ -374,11 +384,11 @@ mod source {
 			}
 		}
 
-		// wasm: build OCCT with the new (exnref) wasm EH encoding so it matches the
-		// wrapper and the exnref wasi-sdk eh sysroot (#199). No-op without -fwasm-exceptions.
-		if env::var("TARGET").unwrap_or_default().starts_with("wasm32") {
-			cfg.cxxflag("-mllvm").cxxflag("-wasm-use-legacy-eh=false");
-		}
+		// Same target-conditional flags as the wrapper (MSVC `/utf-8`, wasm exnref EH) so
+		// OCCT's EH encoding matches the wrapper and the exnref eh sysroot (#199).
+		super::apply_compiler_flags(|s| {
+			cfg.cxxflag(s);
+		});
 
 		let built = cfg.build();
 

--- a/docker/Dockerfile_wasm32-unknown-unknown
+++ b/docker/Dockerfile_wasm32-unknown-unknown
@@ -38,7 +38,10 @@ ENV CXXSTDLIB=c++
 # Compile C/C++ as wasm32-wasip1 so --sysroot auto-resolves include/lib (and eh/c++/v1
 # under -fwasm-exceptions) and __wasi__ selects the proper libc++ rune table.
 ENV CFLAGS_wasm32_unknown_unknown="--target=wasm32-wasip1 --sysroot=${SYSROOT} -D_WASI_EMULATED_PROCESS_CLOCKS -D_WASI_EMULATED_SIGNAL -D_WASI_EMULATED_MMAN -D_WASI_EMULATED_GETPID"
-ENV CXXFLAGS_wasm32_unknown_unknown="--target=wasm32-wasip1 --sysroot=${SYSROOT} -fwasm-exceptions -fexceptions -D_WASI_EMULATED_PROCESS_CLOCKS -D_WASI_EMULATED_SIGNAL -D_WASI_EMULATED_MMAN -D_WASI_EMULATED_GETPID"
+# `-mllvm -wasm-use-legacy-eh=false` emits the new (exnref) wasm EH encoding so OCCT /
+# wrapper match the exnref-built wasi-sdk eh sysroot libs (#199). cmake forwards this
+# env CXXFLAGS to OCCT's CMAKE_CXX_FLAGS; build.rs adds the same flag for the wrapper.
+ENV CXXFLAGS_wasm32_unknown_unknown="--target=wasm32-wasip1 --sysroot=${SYSROOT} -fwasm-exceptions -fexceptions -mllvm -wasm-use-legacy-eh=false -D_WASI_EMULATED_PROCESS_CLOCKS -D_WASI_EMULATED_SIGNAL -D_WASI_EMULATED_MMAN -D_WASI_EMULATED_GETPID"
 # Final link (rustc) pulls the eh libc++ / libc++abi / libunwind and libc.
 ENV CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS="-L native=${SYSROOT}/lib/wasm32-wasip1/eh -L native=${SYSROOT}/lib/wasm32-wasip1 -l static=c++abi -l static=unwind -l static=c"
 

--- a/docker/Dockerfile_wasm32-unknown-unknown
+++ b/docker/Dockerfile_wasm32-unknown-unknown
@@ -38,10 +38,7 @@ ENV CXXSTDLIB=c++
 # Compile C/C++ as wasm32-wasip1 so --sysroot auto-resolves include/lib (and eh/c++/v1
 # under -fwasm-exceptions) and __wasi__ selects the proper libc++ rune table.
 ENV CFLAGS_wasm32_unknown_unknown="--target=wasm32-wasip1 --sysroot=${SYSROOT} -D_WASI_EMULATED_PROCESS_CLOCKS -D_WASI_EMULATED_SIGNAL -D_WASI_EMULATED_MMAN -D_WASI_EMULATED_GETPID"
-# `-mllvm -wasm-use-legacy-eh=false` emits the new (exnref) wasm EH encoding so OCCT /
-# wrapper match the exnref-built wasi-sdk eh sysroot libs (#199). cmake forwards this
-# env CXXFLAGS to OCCT's CMAKE_CXX_FLAGS; build.rs adds the same flag for the wrapper.
-ENV CXXFLAGS_wasm32_unknown_unknown="--target=wasm32-wasip1 --sysroot=${SYSROOT} -fwasm-exceptions -fexceptions -mllvm -wasm-use-legacy-eh=false -D_WASI_EMULATED_PROCESS_CLOCKS -D_WASI_EMULATED_SIGNAL -D_WASI_EMULATED_MMAN -D_WASI_EMULATED_GETPID"
+ENV CXXFLAGS_wasm32_unknown_unknown="--target=wasm32-wasip1 --sysroot=${SYSROOT} -fwasm-exceptions -fexceptions -D_WASI_EMULATED_PROCESS_CLOCKS -D_WASI_EMULATED_SIGNAL -D_WASI_EMULATED_MMAN -D_WASI_EMULATED_GETPID"
 # Final link (rustc) pulls the eh libc++ / libc++abi / libunwind and libc.
 ENV CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS="-L native=${SYSROOT}/lib/wasm32-wasip1/eh -L native=${SYSROOT}/lib/wasm32-wasip1 -l static=c++abi -l static=unwind -l static=c"
 

--- a/makefile
+++ b/makefile
@@ -17,8 +17,8 @@ cadrum-occt: generate # build occt from source natively
 	cargo clean
 	# CADRUM_BUNDLE_GCC_RUNTIME=1 で OCCT lib dir に libstdc++.a / libgcc.a / libgcc_eh.a を libcadrum_* として同梱し、ホスト側 GCC との ABI 不整合を回避する (#89 / #147 対策)。
 	# pipefail is required so tee's exit code does not mask a cargo build failure
-	bash -c "set -o pipefail && CADRUM_BUNDLE_GCC_RUNTIME=1 cargo build --example 01_primitives --release --features source-build 2>&1 | tee out/log.txt"
-	find target -maxdepth 1 -type d -name 'cadrum*' | xargs -IX sh -c 'tar -czf out/$$(basename X).tar.gz -C $$(dirname X) $$(basename X)'
+	bash -c "set -o pipefail && CADRUM_BUNDLE_GCC_RUNTIME=1 cargo build --example 01_primitives --release --features source 2>&1 | tee out/log.txt"
+	find target -maxdepth 1 -type d -name 'occt*' | xargs -IX sh -c 'tar -czf out/$$(basename X).tar.gz -C $$(dirname X) $$(basename X)'
 cadrum-occt-%: # build occt from source in cross ( = native build in container ) cadrum-occt-aarch64-unknown-linux-gnu cadrum-occt-x86_64-pc-windows-gnu cadrum-occt-x86_64-unknown-linux-gnu
 	docker build -f docker/Dockerfile_$(*) -t cadrum-occt-$(*) .
 	docker run --rm -v $(PWD)/out/$(*):/src/out cadrum-occt-$(*) make cadrum-occt

--- a/makefile
+++ b/makefile
@@ -22,8 +22,12 @@ cadrum-occt: generate # build occt from source natively
 cadrum-occt-%: # build occt from source in cross ( = native build in container ) cadrum-occt-aarch64-unknown-linux-gnu cadrum-occt-x86_64-pc-windows-gnu cadrum-occt-x86_64-unknown-linux-gnu
 	docker build -f docker/Dockerfile_$(*) -t cadrum-occt-$(*) .
 	docker run --rm -v $(PWD)/out/$(*):/src/out cadrum-occt-$(*) make cadrum-occt
-cadrum-occt-%-check: # varidate builded occt to run binary which is linked with host's code and container's static occt libraries
+cadrum-occt-%-check: # validate the built occt: link+run a host binary, or for wasm build+run sandbox-wasm under node
 	$(MAKE) cadrum-occt-$*
 	mkdir -p target
 	find out -maxdepth 2 -type f -name '*.tar.gz' | xargs -IX tar -xzf X -C target
-	timeout 300 cargo run --example 01_primitives
+	if [ "$*" = "wasm32-unknown-unknown" ]; then \
+		$(MAKE) -C sandbox-wasm check-cadrum; \
+	else \
+		timeout 300 cargo run --example 01_primitives; \
+	fi

--- a/sandbox-wasm/Cargo.toml
+++ b/sandbox-wasm/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wasm-bindgen = "*"
-cadrum = { path = "..", default-features = false, features = ["source-build", "color"], optional = true }
+cadrum = { path = "..", default-features = false, features = ["source", "color"], optional = true }
 cxx = { version = "1", optional = true }
 
 [build-dependencies]

--- a/sandbox-wasm/makefile
+++ b/sandbox-wasm/makefile
@@ -49,6 +49,12 @@ run-raw-%: # build wasm, and run it with node. hyphens in % become comma-separat
 	cargo build --target wasm32-unknown-unknown --features "$(subst -, ,$*)"
 	../out/bin/wasm-pack build . -d ./target --features "$(subst -, ,$*)"
 	node -e "import('./target/wasm_experiment.js').then(m=>console.log(m.print_volume()))"
+check-cadrum: download # build the cadrum wasm sample against ../target's extracted prebuilt OCCT (OCCT_ROOT, no re-source-build) and assert it runs under node (exnref EH)
+	cargo clean
+	OCCT="$$(find $(CURDIR)/../target -maxdepth 1 -type d -name 'occt-*-wasm32_unknown_unknown' | head -1)"; \
+	test -n "$$OCCT" || { echo "no extracted wasm OCCT under ../target — run 'make cadrum-occt-wasm32-unknown-unknown-check' first"; exit 1; }; \
+	OCCT_ROOT="$$OCCT" ../out/bin/wasm-pack build . -d ./target --features cadrum
+	node --experimental-wasm-exnref -e "import('./target/wasm_experiment.js').then(m=>{const v=m.print_volume();console.log(v);if(!/Solid volume:\s*[0-9]/.test(v))process.exit(1)}).catch(e=>{console.error(e);process.exit(1)})"
 download: # download wasi-sdk (clang + prebuilt sysroot with libc / libc++).
 	cargo install --root ../out wasm-pack
 	cd ../out && ( ls $(call stem,$(WASI_SDK))/bin/clang.exe || ( curl -L -O $(WASI_SDK) && tar xf $(notdir $(WASI_SDK)) --transform="s,^[^/]+,$(call stem,$(WASI_SDK)),x" ) )


### PR DESCRIPTION
Closes #203, closes #182
Refs #199

## Summary

Three related changes to the prebuilt distribution and wasm build, bundled together because they all force a prebuilt-cache invalidation (`BUILD_REVISION` → `rev2`).

### #182 — rename `source-build` feature to `source`
Mechanical rename across `Cargo.toml`, `build.rs` (cfg gates + the user-facing panic message), `sandbox-wasm/Cargo.toml`, `makefile`, `README.md`, `CONTRIBUTING.md`. **Breaking**: use `--features source` instead of `--features source-build`.

### #203 — single-list artifact naming
`cadrum_occt_name` now produces `occt-<version>_<rev>-<target>`:
- fields separated by `-`, characters within a field by `_` (so the name parses by splitting on `-`; the target's hyphens are underscored too)
- ordered by volatility so a name-sorted release list keeps related artifacts adjacent

```
occt-8_0_0_rev2-wasm32_unknown_unknown.tar.gz      (tarball)
occt-8_0_0_rev2                                     (release tag)
```

CI (`prebuilt.yaml`) tag/globs and the `makefile` tarball glob follow suit.

### #199 — unify wasm exception handling on exnref
The wasi-sdk eh sysroot libs (`libc++`/`libc++abi`/`libunwind`) are built with `-mllvm -wasm-use-legacy-eh=false` (exnref), but cadrum's C++ was compiled at the LLVM default (legacy) — that legacy-C++ ⇔ exnref-sysroot mismatch is the real source of `module uses a mix of legacy and new exception handling instructions` (Rust is `panic=abort` on this target and emits no EH at all).

`build.rs` now applies `-mllvm -wasm-use-legacy-eh=false` for wasm32 to **both** the cxx wrapper (`cc::Build`) and the OCCT source build (`cmake::Config`) through a shared `apply_compiler_flags(impl FnMut(&str))` helper (which also carries the existing MSVC `/utf-8`). Because the flag is supplied entirely from `build.rs`, **the Dockerfile is unchanged** — `-fwasm-exceptions -fexceptions` stays in the env `CXXFLAGS` next to the matching eh-sysroot link flags, while the EH *encoding* is enforced in code so the wrapper and OCCT can't diverge.

This PR implements #203's naming only; the prebuilt-FFI distribution part of #203 is not included.

## Verification

- `cargo test` (default features) — green (against an existing local OCCT cache via `OCCT_ROOT`).
- `cargo check --features source` and `cargo check --no-default-features` — compile.
- `cargo fmt` — clean.
- wasm exnref is verified post-merge by disassembling the rev2 prebuilt (`llvm-objdump -d … | grep -E 'try_table|throw_ref|delegate|rethrow'`) and confirming the downstream `mix of legacy and new EH` error is gone.

## Rollout note
After merge, run the `prebuilt` workflow to publish the `occt-8_0_0_rev2` release **before** the next crate publish — otherwise the new `build.rs` prebuilt download 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
