### PR TITLE
Make cadrum wasm32 run self-contained (WASI stubs + OCCT ctor init), validated via --target web

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -211,6 +211,19 @@ fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path) {
 
 	build.compile("cadrum_cpp");
 
+	// wasm: libc++ <iostream> static init and OCCT (getenv / STEP I/O / Standard_ErrorHandler
+	// setjmp) drag in `wasi_snapshot_preview1` imports, which have no runtime on
+	// wasm32-unknown-unknown. Define them as no-ops so cadrum's wasm output is self-contained
+	// (no WASI stub needed downstream). Compiled separately and linked +whole-archive because
+	// the stub symbols only become undefined when libc.a is processed, after cadrum_cpp.
+	if env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("wasm32") {
+		let out_dir = env::var("OUT_DIR").unwrap();
+		cc::Build::new().file("cpp/wasi_stub.c").cargo_metadata(false).compile("wasi_stub");
+		println!("cargo:rustc-link-search=native={}", out_dir);
+		println!("cargo:rustc-link-lib=static:+whole-archive=wasi_stub");
+		println!("cargo:rerun-if-changed=cpp/wasi_stub.c");
+	}
+
 	println!("cargo:rerun-if-changed=src/occt/ffi.rs");
 	println!("cargo:rerun-if-changed=cpp/wrapper.h");
 	println!("cargo:rerun-if-changed=cpp/wrapper.cpp");

--- a/cpp/wasi_stub.c
+++ b/cpp/wasi_stub.c
@@ -75,10 +75,6 @@ int __imported_wasi_snapshot_preview1_path_open(int fd, int dirflags, int path, 
 // (保護ブロックへ素通り)、longjmp は到達しない（万一来たら trap）。
 int setjmp(void *env) { (void)env; return 0; }
 void longjmp(void *env, int val) { (void)env; (void)val; __builtin_trap(); }
-// 静的デストラクタ登録を抑止する。一回限りの実行なので終了時クリーンアップは不要で、
-// __wasm_call_dtors 経由で OCCT 静的オブジェクトの dtor が不正な間接呼び出し
-// (null function / signature mismatch) を起こすのを根本回避する。
-int __cxa_atexit(void (*f)(void *), void *arg, void *dso) {
-	(void)f; (void)arg; (void)dso;
-	return 0;
-}
+// 注: __cxa_atexit は libc が実定義を持つため、ここで no-op 再定義すると wasm リンクで
+// duplicate symbol になる。cadrum は cdylib 用途で終了時 dtor を自動実行しない
+// (__wasm_call_dtors は呼ばれない) ので、静的 dtor 抑止のための再定義は不要・有害。

--- a/cpp/wasi_stub.c
+++ b/cpp/wasi_stub.c
@@ -1,0 +1,84 @@
+// wasm32-unknown-unknown には WASI ランタイムが無いが、libc++ の <iostream> が
+// 生成する std::ios_base::Init 静的初期化子が stdio を参照し、その先で
+// wasi_snapshot_preview1 への import (__imported_wasi_snapshot_preview1_*) が残る。
+// 正常系では一切 stdout/stderr に書かないので、その実 import シンボルを no-op で
+// 定義して import を消す。シグネチャは WASI ABI（i32/i64）に一致させる。
+int __imported_wasi_snapshot_preview1_fd_write(int fd, int iovs, int iovs_len, int nwritten) {
+	(void)fd; (void)iovs; (void)iovs_len; (void)nwritten;
+	return 0;
+}
+int __imported_wasi_snapshot_preview1_fd_seek(int fd, long long offset, int whence, int newoffset) {
+	(void)fd; (void)offset; (void)whence; (void)newoffset;
+	return 0;
+}
+int __imported_wasi_snapshot_preview1_fd_close(int fd) {
+	(void)fd;
+	return 0;
+}
+// libc++abi の terminate / abort 経路が引きずる proc_exit。正常系では呼ばれない。
+void __imported_wasi_snapshot_preview1_proc_exit(int code) {
+	(void)code;
+}
+// 起動時の preopen 走査 (__wasilibc_populate_preopens) が引きずる。fd_prestat_get は
+// エラーが返るまで fd を増やしながら呼ばれるので、BADF(8) を返して即座に走査を終わらせる。
+int __imported_wasi_snapshot_preview1_fd_prestat_get(int fd, int buf) {
+	(void)fd; (void)buf;
+	return 8; /* __WASI_ERRNO_BADF */
+}
+int __imported_wasi_snapshot_preview1_fd_prestat_dir_name(int fd, int path, int path_len) {
+	(void)fd; (void)path; (void)path_len;
+	return 8; /* __WASI_ERRNO_BADF */
+}
+// OCCT(getenv 等)が引きずる環境変数 import。環境は空として扱う。出力ポインタには 0 を書く。
+int __imported_wasi_snapshot_preview1_environ_sizes_get(unsigned *count, unsigned *buf_size) {
+	*count = 0; *buf_size = 0;
+	return 0;
+}
+int __imported_wasi_snapshot_preview1_environ_get(int environ, int buf) {
+	(void)environ; (void)buf;
+	return 0;
+}
+// stdio 初期化の isatty 等が引く fd_fdstat_get。BADF を返して無効 fd 扱いにする。
+int __imported_wasi_snapshot_preview1_fd_fdstat_get(int fd, int stat) {
+	(void)fd; (void)stat;
+	return 8; /* __WASI_ERRNO_BADF */
+}
+// fd_read。0 バイト読込(EOF)として返す。
+int __imported_wasi_snapshot_preview1_fd_read(int fd, int iovs, int iovs_len, unsigned *nread) {
+	(void)fd; (void)iovs; (void)iovs_len;
+	*nread = 0;
+	return 0;
+}
+// STEP write/read が引きずる時刻・ファイル系 import。
+// 時刻は 0、path 系は NOENT(44) を返して「ファイル無し」とし OCCT を内蔵既定へフォールバックさせる。
+int __imported_wasi_snapshot_preview1_clock_time_get(int id, long long precision, unsigned long long *time) {
+	(void)id; (void)precision;
+	*time = 0;
+	return 0;
+}
+int __imported_wasi_snapshot_preview1_fd_fdstat_set_flags(int fd, int flags) {
+	(void)fd; (void)flags;
+	return 0;
+}
+int __imported_wasi_snapshot_preview1_path_filestat_get(int fd, int flags, int path, int path_len, int buf) {
+	(void)fd; (void)flags; (void)path; (void)path_len; (void)buf;
+	return 44; /* __WASI_ERRNO_NOENT */
+}
+int __imported_wasi_snapshot_preview1_path_open(int fd, int dirflags, int path, int path_len, int oflags,
+                                                long long rights_base, long long rights_inheriting, int fdflags, int opened_fd) {
+	(void)fd; (void)dirflags; (void)path; (void)path_len; (void)oflags;
+	(void)rights_base; (void)rights_inheriting; (void)fdflags; (void)opened_fd;
+	return 44; /* __WASI_ERRNO_NOENT */
+}
+// OCCT の Standard_ErrorHandler が参照する setjmp/longjmp。wasm では env import になる。
+// シグナル経由の例外変換は使わず C++ 例外を使うので、setjmp は 0 を返すだけでよく
+// (保護ブロックへ素通り)、longjmp は到達しない（万一来たら trap）。
+int setjmp(void *env) { (void)env; return 0; }
+void longjmp(void *env, int val) { (void)env; (void)val; __builtin_trap(); }
+// 静的デストラクタ登録を抑止する。一回限りの実行なので終了時クリーンアップは不要で、
+// __wasm_call_dtors 経由で OCCT 静的オブジェクトの dtor が不正な間接呼び出し
+// (null function / signature mismatch) を起こすのを根本回避する。
+int __cxa_atexit(void (*f)(void *), void *arg, void *dso) {
+	(void)f; (void)arg; (void)dso;
+	return 0;
+}

--- a/sandbox-wasm/Cargo.lock
+++ b/sandbox-wasm/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "cadrum"
-version = "0.8.5"
+version = "0.8.11"
 dependencies = [
  "cc",
  "cmake",

--- a/sandbox-wasm/build.rs
+++ b/sandbox-wasm/build.rs
@@ -10,12 +10,9 @@ fn main() {
 	// cxx feature: cxx bridge 経由で C++ をコンパイル。
 	if std::env::var("CARGO_FEATURE_CXX").is_ok() {
 		let mut build = cxx_build::bridge("src/lib.rs");
-		build
-			.file("src/ffi.cpp")
-			.include("src")
-			.std("c++17");
-			// 例外/RTTI 関連フラグ(-fwasm-exceptions 等)は makefile の
-			// CXXFLAGS_wasm32_unknown_unknown が cc-rs 経由で全 C++ TU(ffi.cpp/cxx.cc)へ届ける。
+		build.file("src/ffi.cpp").include("src").std("c++17");
+		// 例外/RTTI 関連フラグ(-fwasm-exceptions 等)は makefile の
+		// CXXFLAGS_wasm32_unknown_unknown が cc-rs 経由で全 C++ TU(ffi.cpp/cxx.cc)へ届ける。
 		// libcxx feature: 生成した wasi-sysroot の libc++/libc ヘッダ(-isystem)と
 		// libc++/libc++abi/libc(.a) を足す。target は wasm32-unknown-unknown のまま
 		// にして __wasi__ を定義させず、libc++ の WASI bottom-half 経路（実 import を
@@ -46,10 +43,7 @@ fn main() {
 	let links_libcxx = std::env::var("CARGO_FEATURE_LIBCXX").is_ok();
 	if links_libcxx {
 		let out_dir = std::env::var("OUT_DIR").unwrap();
-		cc::Build::new()
-			.file("src/wasi_stub.c")
-			.cargo_metadata(false)
-			.compile("wasi_stub");
+		cc::Build::new().file("src/wasi_stub.c").cargo_metadata(false).compile("wasi_stub");
 		println!("cargo:rustc-link-search=native={out_dir}");
 		println!("cargo:rustc-link-lib=static:+whole-archive=wasi_stub");
 		println!("cargo:rerun-if-changed=src/wasi_stub.c");

--- a/sandbox-wasm/build.rs
+++ b/sandbox-wasm/build.rs
@@ -38,12 +38,12 @@ fn main() {
 		println!("cargo:rerun-if-changed=src/ffi.cpp");
 		println!("cargo:rerun-if-changed=src/ffi.h");
 	}
-	// libc++ をリンクする feature(cxx+libcxx / cadrum=OCCT) は、libc++/OCCT の静的初期化
-	// (iostream・getenv 等) が引きずる wasi_snapshot_preview1 import を no-op スタブで潰す。
-	// 正常系では実 I/O しない。スタブシンボルは libc.a 処理時に初めて undefined になるので
-	// whole-archive で確実に取り込む。
-	let links_libcxx = std::env::var("CARGO_FEATURE_LIBCXX").is_ok()
-		|| std::env::var("CARGO_FEATURE_CADRUM").is_ok();
+	// libcxx 単独実験は、libc++ の静的初期化(iostream 等)が引きずる wasi_snapshot_preview1
+	// import を no-op スタブで潰す。正常系では実 I/O しない。スタブシンボルは libc.a 処理時に
+	// 初めて undefined になるので whole-archive で確実に取り込む。
+	// cadrum feature は cadrum 本体(cpp/wasi_stub.c)が同じスタブを自前で +whole-archive リンク
+	// するので、ここでは焼かない（焼くとシンボル二重定義でリンクエラー）。
+	let links_libcxx = std::env::var("CARGO_FEATURE_LIBCXX").is_ok();
 	if links_libcxx {
 		let out_dir = std::env::var("OUT_DIR").unwrap();
 		cc::Build::new()

--- a/sandbox-wasm/makefile
+++ b/sandbox-wasm/makefile
@@ -49,12 +49,12 @@ run-raw-%: # build wasm, and run it with node. hyphens in % become comma-separat
 	cargo build --target wasm32-unknown-unknown --features "$(subst -, ,$*)"
 	../out/bin/wasm-pack build . -d ./target --features "$(subst -, ,$*)"
 	node -e "import('./target/wasm_experiment.js').then(m=>console.log(m.print_volume()))"
-check-cadrum: download # build the cadrum wasm sample against ../target's extracted prebuilt OCCT (OCCT_ROOT, no re-source-build) and assert it runs under node (exnref EH)
+check-cadrum: download # build the cadrum wasm sample (--target web, like the browser) against ../target's prebuilt OCCT and run it under node; surfaces the WASI-import / EH-mix / __wasm_call_ctors errors
 	cargo clean
 	OCCT="$$(find $(CURDIR)/../target -maxdepth 1 -type d -name 'occt-*-wasm32_unknown_unknown' | head -1)"; \
 	test -n "$$OCCT" || { echo "no extracted wasm OCCT under ../target — run 'make cadrum-occt-wasm32-unknown-unknown-check' first"; exit 1; }; \
-	OCCT_ROOT="$$OCCT" ../out/bin/wasm-pack build . -d ./target --features cadrum
-	node --experimental-wasm-exnref -e "import('./target/wasm_experiment.js').then(m=>{const v=m.print_volume();console.log(v);if(!/Solid volume:\s*[0-9]/.test(v))process.exit(1)}).catch(e=>{console.error(e);process.exit(1)})"
+	OCCT_ROOT="$$OCCT" ../out/bin/wasm-pack build . -d ./target --target web --features cadrum
+	node --experimental-wasm-exnref run_node.mjs
 download: # download wasi-sdk (clang + prebuilt sysroot with libc / libc++).
 	cargo install --root ../out wasm-pack
 	cd ../out && ( ls $(call stem,$(WASI_SDK))/bin/clang.exe || ( curl -L -O $(WASI_SDK) && tar xf $(notdir $(WASI_SDK)) --transform="s,^[^/]+,$(call stem,$(WASI_SDK)),x" ) )

--- a/sandbox-wasm/run_node.mjs
+++ b/sandbox-wasm/run_node.mjs
@@ -1,0 +1,15 @@
+// CLI validation of the --target web path the browser (cadrum-wasm-example) uses.
+// node cannot fetch file: URLs, so we hand the raw .wasm bytes to the wasm-bindgen init.
+import { readFile } from "node:fs/promises";
+import init, { print_volume } from "./target/wasm_experiment.js";
+
+const wasmBytes = await readFile(new URL("./target/wasm_experiment_bg.wasm", import.meta.url));
+
+// `cadrum::wasm_start!()` in the consumer emits a #[wasm_bindgen(start)] shim, which
+// wasm-bindgen's init() calls — so OCCT's C++ global constructors run here automatically,
+// with no manual __wasm_call_ctors() call from JS.
+await init({ module_or_path: wasmBytes });
+
+const v = print_volume();
+console.log(v);
+if (!/Solid volume:\s*[0-9]/.test(v)) process.exit(1);

--- a/sandbox-wasm/src/lib.rs
+++ b/sandbox-wasm/src/lib.rs
@@ -1,6 +1,5 @@
 use wasm_bindgen::prelude::*;
 
-
 #[cfg(feature = "pure")]
 pub fn volume() -> f64 {
 	1.0
@@ -45,3 +44,7 @@ pub fn volume() -> f64 {
 pub fn print_volume() -> String {
 	format!("Solid volume: {}", volume())
 }
+
+// Run OCCT's C++ global constructors at init (wasm-bindgen start shim). See cadrum::wasm_start!.
+#[cfg(feature = "cadrum")]
+cadrum::wasm_start!();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,3 +304,32 @@ impl_solid_boolean_ops!(Solid, Solid, Boolean<Solid>);
 impl_solid_boolean_ops!(Solid, &Solid, Solid);
 impl_solid_boolean_ops!(Solid, &Solid, &Solid);
 impl_solid_boolean_ops!(Solid, &Solid, Boolean<Solid>);
+
+/// For wasm32 consumers built with `wasm-bindgen`: emit a `#[wasm_bindgen(start)]` shim that
+/// runs the C++ global constructors (OCCT type registration) once during init.
+///
+/// `wasm32-unknown-unknown` cdylibs link with `--no-entry`, so LLD emits no start section and
+/// `__wasm_call_ctors` is never called automatically — the first OCCT call then hits
+/// uninitialized type tables ("null function or function signature mismatch"). wasm-bindgen
+/// lifts a start function into `__wbindgen_start`, which its generated `init()` calls, so this
+/// shim makes the ctors run with no manual call from JS. Invoke once at the consumer crate root:
+///
+/// ```ignore
+/// cadrum::wasm_start!();
+/// ```
+///
+/// Lives in the consumer (not cadrum) because the start function is a single per-module concern
+/// owned by the final wasm-bindgen binary, and cadrum has no `wasm-bindgen` dependency.
+#[macro_export]
+macro_rules! wasm_start {
+	() => {
+		#[cfg(target_arch = "wasm32")]
+		#[::wasm_bindgen::prelude::wasm_bindgen(start)]
+		fn __cadrum_wasm_start() {
+			unsafe extern "C" {
+				fn __wasm_call_ctors();
+			}
+			unsafe { __wasm_call_ctors() };
+		}
+	};
+}


### PR DESCRIPTION
## Summary

Make cadrum's `wasm32-unknown-unknown` output run **self-contained and end-to-end** (browser / `--target web`), and validate it from the CLI under node. Together with the EH-encoding work in #204, this resolves all three wasm runtime errors.

| # | Error | Fix |
|---|-------|-----|
| 1 | unresolved `wasi_snapshot_preview1` imports | `cpp/wasi_stub.c` (no-op stubs), compiled + `+whole-archive` for wasm32 in `build.rs` |
| 2 | mix of legacy/new exception handling | exnref unification (#204, merged) |
| 3 | `__wasm_call_ctors` never called → "null function or function signature mismatch" | `cadrum::wasm_start!()` macro |

### `cpp/wasi_stub.c` (#1)
No-op definitions for the `__imported_wasi_snapshot_preview1_*` symbols (+ `setjmp`/`longjmp`) that libc++ `<iostream>` static init and OCCT (getenv / STEP I/O / `Standard_ErrorHandler`) drag in. Compiled separately and linked `+whole-archive` (the stubs only become undefined when `libc.a` is processed). `sandbox-wasm` no longer emits its own stub for the `cadrum` feature. `__cxa_atexit` is intentionally **not** stubbed — libc owns it, and re-defining it duplicates the symbol on the wasm link; cadrum is a cdylib so end-of-run destructors are not auto-run anyway.

### `cadrum::wasm_start!()` (#3)
`wasm32-unknown-unknown` cdylibs link with `--no-entry`, so LLD emits no `start` section and `__wasm_call_ctors` (OCCT's C++ global ctors) is never run — the first OCCT call hits uninitialized type tables. The macro emits a `#[wasm_bindgen(start)]` shim in the **consumer** that calls `__wasm_call_ctors()`; wasm-bindgen lifts it into `__wbindgen_start`, which its generated `init()` calls. No `--export` and no manual JS call, and — since the start function is a single per-module concern owned by the final binary — no clash with other C++ libraries' ctors. Consumers add one line: `cadrum::wasm_start!();`.

### Checker upgraded to `--target web` (validation)
`sandbox-wasm`'s `check-cadrum` now builds with `wasm-pack --target web` (the browser surface, where ctors are *not* auto-run) and runs `run_node.mjs` under `node --experimental-wasm-exnref`. The old bundler-target check masked #3; the new one exercises it.

（cadrum の wasm 出力を自己完結・end-to-end で動かし、node(CLI) で検証する。#204 の exnref と併せて #199 の3エラーを全解決：#1 WASI import → `cpp/wasi_stub.c`、#2 EH mix → exnref(#204)、#3 `__wasm_call_ctors` 未呼び出し → `cadrum::wasm_start!()` マクロ。`__cxa_atexit` は libc と重複するため stub しない。`wasm_start!` は消費側に1行で、export も手動 JS 呼び出しも不要・モジュール global シンボル衝突も無し。チェッカーは `--target web` + `run_node.mjs` に強化し #3 を検出可能に。）

## Verification

`make cadrum-occt-wasm32-unknown-unknown-check` (docker OCCT build → extract → `wasm-pack --target web` → node) prints:

```
node --experimental-wasm-exnref run_node.mjs
Solid volume: 6000      # OCCT cube → in-memory STEP round-trip → volume, exit 0
```

`cargo fmt` clean; native `cargo build` / `cargo test` unaffected (all wasm logic is gated on `wasm32`).

（`make cadrum-occt-wasm32-unknown-unknown-check` が `Solid volume: 6000` exit 0。native は wasm32 ゲートにより無影響。）
