### PR TITLE
Drop unreferenced setjmp/longjmp stubs and dead OCC_CONVERT_SIGNALS patch

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -499,20 +499,6 @@ mod source {
 			// ため空ファイル化（Windows 以外ではコンパイルされず無害）。
 			"OSD_WNT.cxx" => Some(stub_content(path, false)),
 
-			// OCC_CONVERT_SIGNALS(signal→例外変換) を全 target で無効化。OSD_signal スタブ化と整合。
-			"occt_defs_flags.cmake" => {
-				let content = std::fs::read_to_string(path).ok()?;
-				let needle = "add_definitions(-DOCC_CONVERT_SIGNALS)";
-				let replacement = "# add_definitions(-DOCC_CONVERT_SIGNALS)  # patched out by cadrum build.rs";
-				if content.contains(needle) {
-					Some(content.replace(needle, replacement))
-				} else if content.contains(replacement) {
-					Some(content) // already patched — keep as-is
-				} else {
-					None
-				}
-			}
-
 			_ => None,
 		}
 	}

--- a/src/wasi_stub.rs
+++ b/src/wasi_stub.rs
@@ -1,10 +1,10 @@
 //! No-op import shims for the `wasm32-unknown-unknown` build.
 //!
-//! libc++'s `<iostream>` static initialization and OCCT (getenv / STEP I/O /
-//! `Standard_ErrorHandler`'s setjmp) drag in imports from `wasi_snapshot_preview1`
-//! (and `env` for setjmp/longjmp) that have no runtime on `wasm32-unknown-unknown`.
-//! Defining those symbols here as no-ops makes cadrum's wasm output self-contained
-//! (no downstream WASI shim). Signatures match the WASI ABI (i32/i64/pointers).
+//! libc++'s `<iostream>` static initialization, libc's startup environ init, and OCCT
+//! (STEP I/O / timing) drag in imports from `wasi_snapshot_preview1` that have no
+//! runtime on `wasm32-unknown-unknown`. Defining those symbols here as no-ops makes
+//! cadrum's wasm output self-contained (no downstream WASI shim). Signatures match the
+//! WASI ABI (i32/i64/pointers).
 //!
 //! These replace the former `cpp/wasi_stub.c` (compiled via `cc` and linked
 //! `+whole-archive`). In Rust the symbols live in cadrum's rlib, so they would be
@@ -13,9 +13,16 @@
 //! `__cxa_atexit` is intentionally NOT defined: libc owns its real definition and a
 //! second one would be a duplicate symbol (cadrum is a cdylib, so static dtors do
 //! not auto-run anyway).
+//!
+//! Why these specific symbols stay (none are eliminable via OCCT-source patching):
+//! - `environ_*` — libc's startup environ init, not OCCT getenv (verified: removing all
+//!   OCCT getenv via build.rs leaves these imports). `setjmp`/`longjmp` are absent
+//!   because `OCC_CONVERT_SIGNALS` is off in OCCT 8.0.0, so they are never referenced.
+//! - `path_*` / `fd_fdstat_set_flags` — file ops referenced (not called) from OCCT TUs
+//!   that cadrum links but does not exercise (`OSD_OpenFile`, `BRepAlgoAPI_*`).
+//! - `clock_time_get` — OCCT timing (`OSD_Timer`/`OSD_Thread`); `OSD_Thread` can't be
+//!   stubbed without breaking native threading. `fd_fdstat_get` — libc++ `<iostream>`.
 #![allow(clippy::missing_safety_doc)]
-
-use core::ffi::c_void;
 
 // --- WASI ABI errno values used by the called-at-runtime stubs ---
 const ERRNO_BADF: i32 = 8; // invalid file descriptor
@@ -47,7 +54,7 @@ pub extern "C" fn __imported_wasi_snapshot_preview1_fd_prestat_get(_fd: i32, _bu
 pub extern "C" fn __imported_wasi_snapshot_preview1_fd_prestat_dir_name(_fd: i32, _path: i32, _path_len: i32) -> i32 {
 	ERRNO_BADF
 }
-// environment imports dragged in by OCCT's getenv. Treat the environment as empty.
+// libc startup environ init. Report an empty environment.
 #[no_mangle]
 pub extern "C" fn __imported_wasi_snapshot_preview1_environ_sizes_get(count: *mut u32, buf_size: *mut u32) -> i32 {
 	unsafe {
@@ -60,7 +67,7 @@ pub extern "C" fn __imported_wasi_snapshot_preview1_environ_sizes_get(count: *mu
 pub extern "C" fn __imported_wasi_snapshot_preview1_environ_get(_environ: i32, _buf: i32) -> i32 {
 	0
 }
-// stdio init's isatty etc. Return BADF to treat the fd as invalid.
+// stdio init's isatty etc. Return BADF to treat the fd as invalid (libc++ iostream).
 #[no_mangle]
 pub extern "C" fn __imported_wasi_snapshot_preview1_fd_fdstat_get(_fd: i32, _stat: i32) -> i32 {
 	ERRNO_BADF
@@ -73,8 +80,7 @@ pub extern "C" fn __imported_wasi_snapshot_preview1_fd_read(_fd: i32, _iovs: i32
 	}
 	0
 }
-// STEP write/read time + file imports. Time is 0; path lookups return NOENT so OCCT
-// falls back to its built-in defaults.
+// OCCT timing (OSD_Timer/OSD_Thread). Referenced, not called by cadrum. time=0.
 #[no_mangle]
 pub extern "C" fn __imported_wasi_snapshot_preview1_clock_time_get(_id: i32, _precision: i64, time: *mut u64) -> i32 {
 	unsafe {
@@ -86,6 +92,8 @@ pub extern "C" fn __imported_wasi_snapshot_preview1_clock_time_get(_id: i32, _pr
 pub extern "C" fn __imported_wasi_snapshot_preview1_fd_fdstat_set_flags(_fd: i32, _flags: i32) -> i32 {
 	0
 }
+// File-stat / open referenced (not called) from OCCT TUs cadrum links but never
+// exercises (OSD_OpenFile, BRepAlgoAPI_*). Return NOENT.
 #[no_mangle]
 pub extern "C" fn __imported_wasi_snapshot_preview1_path_filestat_get(_fd: i32, _flags: i32, _path: i32, _path_len: i32, _buf: i32) -> i32 {
 	ERRNO_NOENT
@@ -94,18 +102,6 @@ pub extern "C" fn __imported_wasi_snapshot_preview1_path_filestat_get(_fd: i32, 
 #[allow(clippy::too_many_arguments)]
 pub extern "C" fn __imported_wasi_snapshot_preview1_path_open(_fd: i32, _dirflags: i32, _path: i32, _path_len: i32, _oflags: i32, _rights_base: i64, _rights_inheriting: i64, _fdflags: i32, _opened_fd: i32) -> i32 {
 	ERRNO_NOENT
-}
-
-// OCCT's `Standard_ErrorHandler` references setjmp/longjmp; on wasm these become `env`
-// imports. cadrum uses C++ exceptions (not signal-based unwinding), so setjmp just
-// returns 0 (fall through the protected block) and longjmp is never reached (trap if it is).
-#[no_mangle]
-pub extern "C" fn setjmp(_env: *mut c_void) -> i32 {
-	0
-}
-#[no_mangle]
-pub extern "C" fn longjmp(_env: *mut c_void, _val: i32) {
-	core::arch::wasm32::unreachable()
 }
 
 /// Force every stub above into the final wasm module.
@@ -135,7 +131,5 @@ pub fn anchor() {
 		let _ = __imported_wasi_snapshot_preview1_fd_fdstat_set_flags(0, 0);
 		let _ = __imported_wasi_snapshot_preview1_path_filestat_get(0, 0, 0, 0, 0);
 		let _ = __imported_wasi_snapshot_preview1_path_open(0, 0, 0, 0, 0, 0, 0, 0, 0);
-		let _ = setjmp(core::ptr::null_mut());
-		longjmp(core::ptr::null_mut(), 0);
 	}
 }


### PR DESCRIPTION
## What

Two dead-code removals, both rooted in the same fact: **`OCC_CONVERT_SIGNALS` is no longer defined in OCCT 8.0.0**.

- **`src/wasi_stub.rs`** — remove the `setjmp` / `longjmp` no-op shims. With `OCC_CONVERT_SIGNALS` off, `OCC_CATCH_SIGNALS` expands to nothing, so OCCT never references setjmp/longjmp.
- **`build.rs`** — remove the `patch_or_none` arm for `occt_defs_flags.cmake`. That file does not exist anywhere in OCCT 8.0.0, so the arm can never fire.

## Why this is removable now (7.x → 8.0.0)

This isn't an accident of 8.0.0 — it's a build-system change:

- **OCCT 7.x** (`adm/cmake/occt_defs_flags.cmake`) added `-DOCC_CONVERT_SIGNALS` for **every non-MSVC build** (the `else()` branch of `if (MSVC)`). So GCC/Clang/mingw/wasi-clang builds had signal→exception conversion (setjmp/longjmp) **on by default**. cadrum therefore needed both the no-op stubs *and* a build.rs patch to comment that `add_definitions` out.
- **OCCT 8.0.0** reworked its CMake build system and reorganized sources to `src/Module/Toolkit/Package/File`. In the process `occt_defs_flags.cmake` was removed and `OCC_CONVERT_SIGNALS` is no longer defined by the default build (reverting to its documented opt-in behavior).

Net effect: `OCC_CATCH_SIGNALS` now expands empty → setjmp/longjmp unreferenced, **and** the file the patch targeted is gone → both the stubs and the patch arm are dead.

Refs: [7.9.0 `occt_defs_flags.cmake`](https://raw.githubusercontent.com/Open-Cascade-SAS/OCCT/V7_9_0/adm/cmake/occt_defs_flags.cmake) · [V8_0_0 release (CMake rework / source reorg)](https://github.com/Open-Cascade-SAS/OCCT/releases/tag/V8_0_0) · [Standard_ErrorHandler.hxx](https://dev.opencascade.org/doc/refman/html/_standard___error_handler_8hxx.html)

> Note on signals: `OCC_CONVERT_SIGNALS`/SjLj was OCCT's mechanism to turn CPU signals (e.g. SIGFPE from integer `1/0`, SIGSEGV) into catchable `Standard_Failure` exceptions on non-MSVC. cadrum never enabled it (`OSD::SetSignal` is not called), and wasm has no signals at all — integer div-by-zero is a hard wasm trap, float div-by-zero is IEEE `inf`/`NaN`. So removing these stubs does not change div-by-zero behavior; that path was never caught.

## Verification

- **wasm (empirical)**: rebuilt the `wasm32-unknown-unknown` output and confirmed `setjmp`/`longjmp` do **not** reappear as imports after removal; the final wasm has **zero** `wasi_snapshot_preview1`/`env` imports and the STEP→GLB Node smoke test passes (`NODETEST:OK`).
- **native**: `cargo test --features source` (OCCT built from source with patches on mingw) — all suites green.
- `cargo build` / `cargo fmt --check` clean.

## Why the other stubs stay

The remaining `wasi_stub.rs` entries are referenced-but-not-removable via OCCT-source patching:
- `environ_*` — libc **startup** environ init (not OCCT getenv; verified by removing all OCCT getenv and seeing the import persist).
- `fd_fdstat_get` — libc++ `<iostream>` static init.
- `path_*` / `fd_fdstat_set_flags` — OCCT TUs cadrum links but never calls (`OSD_OpenFile`, `BRepAlgoAPI_*`).
- `clock_time_get` — OCCT timing (`OSD_Timer`/`OSD_Thread`); `OSD_Thread` can't be stubbed without breaking native threading.

This is documented in the `wasi_stub.rs` module comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)