### PR TITLE
Restructure make build pipeline + name FFI archive by release_name

### DIFF
--- a/.github/workflows/prebuilt.yaml
+++ b/.github/workflows/prebuilt.yaml
@@ -6,11 +6,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  # The following prebuilt tarballs are cross-built via Docker:
-  #   - cadrum-occt-x86_64-unknown-linux-gnu
-  #   - cadrum-occt-aarch64-unknown-linux-gnu
-  #   - cadrum-occt-x86_64-pc-windows-gnu
-  #   - cadrum-occt-wasm32-unknown-unknown
+  # The following prebuilt OCCT tarballs are cross-built via Docker (make cross-<target> GOAL=occt):
+  #   - x86_64-unknown-linux-gnu
+  #   - aarch64-unknown-linux-gnu
+  #   - x86_64-pc-windows-gnu
+  #   - wasm32-unknown-unknown
   # This is because the cross toolchain for these targets is mature on the Linux
   # side (cross-gcc / mingw-w64 / wasi-sdk clang), so Docker gives a reproducible
   # build host.
@@ -32,16 +32,16 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: build
-        run: make cadrum-occt-${{ matrix.target }}
+        run: make cross-${{ matrix.target }} GOAL=occt
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cadrum-occt-${{ matrix.target }}
+          name: occt-${{ matrix.target }}
           path: out/${{ matrix.target }}/occt-*.tar.gz
 
-  # The following prebuilt tarball is built on a native Windows runner with
-  # native cl.exe:
-  #   - cadrum-occt-x86_64-pc-windows-msvc
+  # The following prebuilt OCCT tarball is built on a native Windows runner with
+  # native cl.exe (make occt):
+  #   - x86_64-pc-windows-msvc
   # This is because prebuilding via cargo-xwin/clang-cl makes COMDAT emission
   # decisions for MSVC STL templates that disagree with native cl.exe, producing
   # `std::_Variant_storage_<...>` unresolved symbols at the user's link step
@@ -72,17 +72,17 @@ jobs:
         shell: bash
         env:
           CARGO_BUILD_TARGET: x86_64-pc-windows-msvc
-        run: make cadrum-occt
+        run: make occt
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cadrum-occt-x86_64-pc-windows-msvc
+          name: occt-x86_64-pc-windows-msvc
           path: out/occt-*.tar.gz
 
-  # The following prebuilt tarballs are built on native macOS runners with Apple
-  # clang/libc++:
-  #   - cadrum-occt-aarch64-apple-darwin
-  #   - cadrum-occt-x86_64-apple-darwin
+  # The following prebuilt OCCT tarballs are built on native macOS runners with Apple
+  # clang/libc++ (make occt):
+  #   - aarch64-apple-darwin
+  #   - x86_64-apple-darwin
   # This is because this repo has no Docker/osxcross apple-darwin toolchain, and
   # Apple's SDK + clang are simplest (and license-clean) on real Apple hardware,
   # which GitHub provides as free runners. macOS libc++ has a stable ABI, so this
@@ -91,7 +91,7 @@ jobs:
   # NOTE: macos-13 (the old Intel label) was retired on 2025-12-04, so we use its
   #       successor macos-15-intel. https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/
   # cmake / make / clang are preinstalled on the GitHub macOS runner.
-  # CADRUM_BUNDLE_RUNTIME=1 inside `make cadrum-occt` is a no-op on Darwin
+  # CADRUM_BUNDLE_RUNTIME=1 inside `make occt` is a no-op on Darwin
   # (build.rs bundles libstdc++/libgcc only for *-windows-gnu / *-linux-gnu).
   build-macos:
     strategy:
@@ -113,11 +113,11 @@ jobs:
       - name: build
         env:
           CARGO_BUILD_TARGET: ${{ matrix.target }}
-        run: make cadrum-occt
+        run: make occt
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cadrum-occt-${{ matrix.target }}
+          name: occt-${{ matrix.target }}
           path: out/occt-*.tar.gz
 
   release:

--- a/build.rs
+++ b/build.rs
@@ -64,7 +64,7 @@ fn main() {
 		bundle_runtime_libs(&occt_lib_dir, &["libstdc++.a", "libgcc.a", "libgcc_eh.a"]);
 	}
 
-	link_occt_libraries(&occt_include, &occt_lib_dir);
+	link_occt_libraries(&occt_include, &occt_lib_dir, &target);
 }
 
 /// Derive the cargo target directory from `OUT_DIR`.
@@ -176,7 +176,7 @@ fn apply_compiler_flags(mut apply: impl FnMut(&str)) {
 	}
 }
 
-fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path) {
+fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path, target: &str) {
 	println!("cargo:rustc-link-search=native={}", occt_lib_dir.display());
 	for lib in OCC_LIBS {
 		println!("cargo:rustc-link-lib=static={}", lib);
@@ -214,7 +214,12 @@ fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path) {
 	#[cfg(feature = "color")]
 	build.define("CADRUM_COLOR", None);
 
-	build.compile("cadrum_cpp");
+	// Name the FFI archive after `release_name(target, true)` so the produced
+	// `lib<release_name>.a` is uniquely identifiable in the target dir (the makefile
+	// `cadrum` recipe locates it for the GitHub Release upload) and shares one
+	// naming authority with the download URL. cc auto-emits the matching
+	// `rustc-link-lib=static=<name>`, so local linking stays consistent.
+	build.compile(&release_name(Some(target), true));
 
 	// wasm: the `wasi_snapshot_preview1` / `env` imports dragged in by libc++ static
 	// init and OCCT are neutralized by no-op shims in `src/wasi_stub.rs` (anchored via

--- a/docker/Dockerfile_wasm32-unknown-unknown
+++ b/docker/Dockerfile_wasm32-unknown-unknown
@@ -6,7 +6,7 @@
 # The wasm output is produced by the wasi-sdk clang, so the host image is
 # irrelevant to the result. HOST build-dependencies use the image's gcc; the
 # wasm TARGET (OCCT cmake + cxx-build) uses the wasi-sdk clang found first on PATH.
-# The example .wasm cannot run here; `cadrum-occt` tolerates that via `... | tee`,
+# The example .wasm cannot run here; the `occt` make target tolerates that via `... | tee`,
 # then tarballs the OCCT static libraries.
 FROM quay.io/pypa/manylinux_2_28_x86_64
 

--- a/docker/Dockerfile_x86_64-pc-windows-gnu
+++ b/docker/Dockerfile_x86_64-pc-windows-gnu
@@ -2,7 +2,7 @@
 #
 # Cross-compiles OCCT into static libraries (.a) from a Linux host.
 # The resulting Windows .exe cannot execute inside this container;
-# `cadrum-occt` tolerates the execution failure via `|| true`.
+# the `occt` make target tolerates the execution failure via `|| true`.
 FROM debian:bookworm-slim
 
 # gcc/g++: HOST compiler for build-dependencies (aws-lc-rs, ring, etc.)

--- a/makefile
+++ b/makefile
@@ -13,17 +13,27 @@ deploy: generate # generate out/markdown from examples, then build out/html
 	./out/bin/mdbook build
 publish: deploy # publish to crates.io
 	cargo publish
-cadrum-occt: generate # build occt from source natively
+occt: generate # output out/occt-<rev>-<target>.tar.gz from source natively
 	cargo clean
 	# CADRUM_BUNDLE_RUNTIME=1 で OCCT lib dir に libstdc++.a / libgcc.a / libgcc_eh.a を libcadrum_* として同梱し、ホスト側 GCC との ABI 不整合を回避する (#89 / #147 対策)。
 	# pipefail is required so tee's exit code does not mask a cargo build failure
 	bash -c "set -o pipefail && CADRUM_BUNDLE_RUNTIME=1 cargo build --example 01_primitives --release --features source 2>&1 | tee out/log.txt"
 	find target -maxdepth 1 -type d -name 'occt*' | xargs -IX sh -c 'tar -czf out/$$(basename X).tar.gz -C $$(dirname X) $$(basename X)'
-cadrum-occt-%: # build occt from source in cross ( = native build in container ) cadrum-occt-aarch64-unknown-linux-gnu cadrum-occt-x86_64-pc-windows-gnu cadrum-occt-x86_64-unknown-linux-gnu
-	docker build -f docker/Dockerfile_$(*) -t cadrum-occt-$(*) .
-	docker run --rm -v $(PWD)/out/$(*):/src/out cadrum-occt-$(*) make cadrum-occt
-cadrum-occt-%-check: # validate the built occt: link+run a host binary, or for wasm build+run sandbox-wasm under node
-	$(MAKE) cadrum-occt-$*
+cadrum: generate # output out/libocct-<rev>-<target>-cadrum-<version>.a (wrapper compiled against the RELEASED prebuilt OCCT)
+	# cargo clean wipes any source-built OCCT cache (from `make occt`) so build.rs is
+	# forced down the prebuilt path: it downloads the RELEASED prebuilt OCCT and compiles
+	# the wrapper against exactly that. --release without --features source selects the
+	# prebuilt path; if that target's prebuilt is not released yet the download fails and
+	# so does this recipe -- never silently build/stage an archive against a missing/stale OCCT.
+	cargo clean
+	cargo build --example 01_primitives --release
+	find target -name 'libocct-*-cadrum*.a' -exec cp {} out/ \;
+cross-%: # run `make $(GOAL)` for target % inside its Docker cross env (out/<target>/ is the mount). GOAL is required.
+	@test -n "$(GOAL)" || { echo "GOAL is required: make cross-$* GOAL=occt|cadrum"; exit 1; }
+	docker build -f docker/Dockerfile_$(*) -t cross-$(*) .
+	docker run --rm -v $(PWD)/out/$(*):/src/out cross-$(*) make $(GOAL)
+check-%: # validate the cross-built prebuilt OCCT runs on the host (extract -> run example / wasm check)
+	$(MAKE) cross-$* GOAL=occt
 	mkdir -p target
 	find out -maxdepth 2 -type f -name '*.tar.gz' | xargs -IX tar -xzf X -C target
 	if [ "$*" = "wasm32-unknown-unknown" ]; then \

--- a/notes/20260617-build_rsの各関数とOCCT_ROOTへの影響.md
+++ b/notes/20260617-build_rsの各関数とOCCT_ROOTへの影響.md
@@ -52,8 +52,8 @@
   - ミス時: 下流（`occt_from_source` / `occt_from_prebuilt`）経由で `effective_root` に**生成・展開する**。
   - 同梱 (`bundle_runtime_libs`) はここではなく `main` に移動済み（`resolve_occt` は dirs を返すだけ）。
 
-### `link_occt_libraries(occt_include, occt_lib_dir)`
-- **責任**: `rustc-link-search` / `rustc-link-lib` の出力、lib ディレクトリ内の `cadrum` を含む static lib の追加リンク、mingw 向けリンクフラグ、`cxx_build` による `cpp/wrapper.cpp` のコンパイル（`cadrum_cpp`）。
+### `link_occt_libraries(occt_include, occt_lib_dir, target)`
+- **責任**: `rustc-link-search` / `rustc-link-lib` の出力、lib ディレクトリ内の `cadrum` を含む static lib の追加リンク、mingw 向けリンクフラグ、`cxx_build` による `cpp/wrapper.cpp` のコンパイル。成果物アーカイブ名は `release_name(target, true)`（`lib<release_name>.a`）で、makefile の `find_cadrum` が target 内を一意に拾えるようにし、download URL と命名権を共有する。cc が一致する `rustc-link-lib=static=<name>` を自動発行するのでローカルリンクは整合。
 - **OCCT_ROOT への影響**: **なし（読み取りのみ）**。`occt_lib_dir` は `WalkDir` で**走査して読むだけ**。wrapper のコンパイル成果物は `OUT_DIR` 側に出るので OCCT_ROOT は汚さない。
 
 ### `occt_from_prebuilt(effective_root, target)`  〔`not(feature = "source")`〕

--- a/sandbox-wasm/makefile
+++ b/sandbox-wasm/makefile
@@ -52,7 +52,7 @@ run-raw-%: # build wasm, and run it with node. hyphens in % become comma-separat
 check-cadrum: download # build the cadrum wasm sample (--target web, like the browser) against ../target's prebuilt OCCT and run it under node; surfaces the WASI-import / EH-mix / __wasm_call_ctors errors
 	cargo clean
 	OCCT="$$(find $(CURDIR)/../target -maxdepth 1 -type d -name 'occt-*-wasm32_unknown_unknown' | head -1)"; \
-	test -n "$$OCCT" || { echo "no extracted wasm OCCT under ../target — run 'make cadrum-occt-wasm32-unknown-unknown-check' first"; exit 1; }; \
+	test -n "$$OCCT" || { echo "no extracted wasm OCCT under ../target — run 'make check-wasm32-unknown-unknown' first"; exit 1; }; \
 	OCCT_ROOT="$$OCCT" ../out/bin/wasm-pack build . -d ./target --target web --features cadrum
 	node --experimental-wasm-exnref run_node.mjs
 download: # download wasi-sdk (clang + prebuilt sysroot with libc / libc++).


### PR DESCRIPTION
## What

Two related build-pipeline changes. No library behavior change.

### 1. Name the cxx FFI archive after `release_name(target, true)`
`build.compile()` now emits `lib<release_name(target,true)>.a` (e.g. `libocct-8_0_0_rev2-<target>-cadrum-<version>.a`) instead of `libcadrum_cpp.a`. This makes the archive uniquely identifiable in the target dir and shares a single naming authority (`release_name`) with the future download URL. `cc` auto-emits the matching `rustc-link-lib=static=<name>`, so local linking stays consistent. `target` is threaded into `link_occt_libraries` for the `release_name` call.

### 2. Restructure make targets into single-purpose ones
- `occt` — build OCCT from source → `out/occt-<rev>-<target>.tar.gz`
- `cadrum` — `cargo clean` + build against the **released prebuilt** OCCT, then stage `out/libocct-*-cadrum-*.a`. Fails if that target's prebuilt is missing (never stages an archive built against a missing/stale OCCT).
- `cross-%` — generic "run `make $(GOAL)` in target %'s Docker cross env" (`GOAL` required), replacing the occt-specific cross recipe.
- `check-%` — renamed from `occt-%-check`; validates the prebuilt on the host.

Drops the redundant `cadrum-` prefix from the old target names and updates all callers: `prebuilt.yaml` (`make cross-<target> GOAL=occt`), the `sandbox-wasm/makefile` error hint, and the two Dockerfile comments.

## Out of scope
- The `cadrum` FFI release workflow (`.github/workflows/cadrum.yaml`) is intentionally **not** included. Its artifact-identity design (content-hash vs crate-version keying) is still under discussion — tracked in a separate issue.

## Verification
- `cargo build` / `cargo build --features source` ✅
- `cargo build --release --example 01_primitives` links the renamed archive ✅
- `make -n` dry-runs of `occt` / `cadrum` / `cross-% GOAL=occt|cadrum` / `check-%` match intent; `cross-%` with no `GOAL` errors out.

---

# （日本語）

## 概要

ビルドパイプライン関連の2変更。ライブラリの挙動変更なし。

### 1. cxx FFI アーカイブを `release_name(target, true)` で命名
`build.compile()` が `libcadrum_cpp.a` ではなく `lib<release_name(target,true)>.a`（例 `libocct-8_0_0_rev2-<target>-cadrum-<version>.a`）を出力する。target ディレクトリ内で一意に特定でき、将来の download URL と命名権限（`release_name`）を一元化できる。`cc` が一致する `rustc-link-lib=static=<name>` を自動発行するためローカルリンクは整合。`release_name` 呼び出しのため `target` を `link_occt_libraries` に渡す。

### 2. make ターゲットを単一責務に再構成
- `occt` — OCCT をソースからビルド → `out/occt-<rev>-<target>.tar.gz`
- `cadrum` — `cargo clean` 後、**リリース済み prebuilt** OCCT に対してビルドし `out/libocct-*-cadrum-*.a` をステージ。prebuilt が無ければ失敗（欠落/古い OCCT に対するアーカイブを作らない）。
- `cross-%` — 「target % の Docker クロス環境で `make $(GOAL)` を実行」する汎用ランナー（`GOAL` 必須）。occt 専用クロス recipe を置換。
- `check-%` — `occt-%-check` を改名。ホストで prebuilt を検証。

旧ターゲット名から冗長な `cadrum-` prefix を除去し、呼び出し元（`prebuilt.yaml` の `make cross-<target> GOAL=occt`、`sandbox-wasm/makefile` のエラーヒント、Dockerfile コメント2箇所）を更新。

## 対象外
- `cadrum` FFI リリースワークフロー（`.github/workflows/cadrum.yaml`）は**意図的に含めない**。アーティファクト識別の設計（内容ハッシュ vs crate バージョン）が議論中のため、別 issue で追跡。

## 検証
- `cargo build` / `cargo build --features source` ✅
- `cargo build --release --example 01_primitives` でリネーム後アーカイブがリンク ✅
- `make -n` で `occt` / `cadrum` / `cross-% GOAL=occt|cadrum` / `check-%` の展開を確認。`cross-%` の `GOAL` 未指定はエラー。