### PR TITLE
Bundle wasm eh-variant runtime libs into prebuilt OCCT

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -60,8 +60,14 @@ fn main() {
 	// gate を切らないと source user 全員のホストランタイムが静的取り込みされてしまう。
 	// 現 policy: mingw / Linux GNU で GCC runtime を対象 (Windows MSVC は MSVC ランタイム、Mac は別系統)。
 	#[cfg(feature = "source")]
-	if env::var("CADRUM_BUNDLE_RUNTIME").is_ok() && (target.ends_with("windows-gnu") || target.contains("linux-gnu")) {
-		bundle_runtime_libs(&occt_lib_dir, &["libstdc++.a", "libgcc.a", "libgcc_eh.a"]);
+	if env::var("CADRUM_BUNDLE_RUNTIME").is_ok() {
+		if target.ends_with("windows-gnu") || target.contains("linux-gnu") {
+			bundle_runtime_libs(&occt_lib_dir, &["libstdc++.a", "libgcc.a", "libgcc_eh.a"]);
+		} else if target.starts_with("wasm32") {
+			// -fwasm-exceptions ビルドの OCCT/libc++ が要求する eh 版ランタイム。最終リンク(rustc)で
+			// 必要と実測で確定済み（c++abi/unwind/c のいずれを欠いても env import 未解決で失敗）。
+			bundle_runtime_libs(&occt_lib_dir, &["libc++abi.a", "libunwind.a", "libc.a"]);
+		}
 	}
 
 	link_occt_libraries(&occt_include, &occt_lib_dir, &target);
@@ -290,9 +296,20 @@ fn fetch_bytes(url: &str) -> Result<Vec<u8>, String> {
 #[cfg(feature = "source")]
 fn bundle_runtime_libs(occt_lib_dir: &Path, libs: &[&str]) {
 	let compiler = cc::Build::new().get_compiler();
+	// `to_command()` で target/sysroot 等のフラグごと probe する。wasm は --target/--sysroot 無しだと
+	// -print-file-name が wasi-sysroot を解決できない（GNU は素の probe でも絶対パスが返る）。
+	let probe = |lib: &str| -> PathBuf {
+		let out = compiler.to_command().arg(format!("-print-file-name={}", lib)).output().expect("compiler probe failed");
+		PathBuf::from(std::str::from_utf8(&out.stdout).unwrap().trim())
+	};
+	// wasm の wasi-sysroot は C++ ランタイムを lib/<triple>/{noeh,eh}/ に分け、-print-file-name は
+	// noeh を返す（libunwind は解決すらできない）。OCCT は -fwasm-exceptions ビルドなので eh 版が要る。
+	// triple 直下にあり確実に引ける libc.a から eh ディレクトリを導出し、各 lib は eh を優先する。
+	// GNU 系は eh サブディレクトリが無いので probe 結果（従来通り）にフォールバックする。
+	let libc = probe("libc.a");
+	let eh_dir = libc.parent().map(|d| d.join("eh")).filter(|d| d.is_dir());
 	for &lib in libs {
-		let out = std::process::Command::new(compiler.path()).arg(format!("-print-file-name={}", lib)).output().expect("compiler probe failed");
-		let src = PathBuf::from(std::str::from_utf8(&out.stdout).unwrap().trim());
+		let src = eh_dir.as_ref().map(|d| d.join(lib)).filter(|p| p.exists()).unwrap_or_else(|| probe(lib));
 		// `-print-file-name=` は名前が見つからない時に lib 名そのものを返すので存在チェック必須
 		if src.is_absolute() && src.exists() {
 			let dst_name = lib.replace("lib", "libcadrum_");

--- a/src/wasi_stub.rs
+++ b/src/wasi_stub.rs
@@ -1,10 +1,11 @@
 //! No-op import shims for the `wasm32-unknown-unknown` build.
 //!
 //! libc++'s `<iostream>` static initialization, libc's startup environ init, and OCCT
-//! (STEP I/O / timing) drag in imports from `wasi_snapshot_preview1` that have no
-//! runtime on `wasm32-unknown-unknown`. Defining those symbols here as no-ops makes
-//! cadrum's wasm output self-contained (no downstream WASI shim). Signatures match the
-//! WASI ABI (i32/i64/pointers).
+//! (STEP I/O / timing / `Standard_ErrorHandler`'s setjmp) drag in imports from
+//! `wasi_snapshot_preview1` (and `env` for setjmp/longjmp) that have no runtime on
+//! `wasm32-unknown-unknown`. Defining those symbols here as no-ops makes cadrum's wasm
+//! output self-contained (no downstream WASI shim). Signatures match the WASI ABI
+//! (i32/i64/pointers).
 //!
 //! These replace the former `cpp/wasi_stub.c` (compiled via `cc` and linked
 //! `+whole-archive`). In Rust the symbols live in cadrum's rlib, so they would be
@@ -16,13 +17,19 @@
 //!
 //! Why these specific symbols stay (none are eliminable via OCCT-source patching):
 //! - `environ_*` — libc's startup environ init, not OCCT getenv (verified: removing all
-//!   OCCT getenv via build.rs leaves these imports). `setjmp`/`longjmp` are absent
-//!   because `OCC_CONVERT_SIGNALS` is off in OCCT 8.0.0, so they are never referenced.
+//!   OCCT getenv via build.rs leaves these imports).
+//! - `setjmp`/`longjmp` — referenced by OCCT's `Standard_ErrorHandler` and surface as
+//!   the `env.setjmp` import. Many OCCT TUs carry `U setjmp` even with
+//!   `OCC_CONVERT_SIGNALS` off (verified by `llvm-nm` on the wasm OCCT libs and by the
+//!   `env.setjmp` import on the final wasm). cadrum unwinds via C++ exceptions, so
+//!   setjmp falls through (returns 0) and longjmp is never reached (traps if it is).
 //! - `path_*` / `fd_fdstat_set_flags` — file ops referenced (not called) from OCCT TUs
 //!   that cadrum links but does not exercise (`OSD_OpenFile`, `BRepAlgoAPI_*`).
 //! - `clock_time_get` — OCCT timing (`OSD_Timer`/`OSD_Thread`); `OSD_Thread` can't be
 //!   stubbed without breaking native threading. `fd_fdstat_get` — libc++ `<iostream>`.
 #![allow(clippy::missing_safety_doc)]
+
+use core::ffi::c_void;
 
 // --- WASI ABI errno values used by the called-at-runtime stubs ---
 const ERRNO_BADF: i32 = 8; // invalid file descriptor
@@ -104,6 +111,18 @@ pub extern "C" fn __imported_wasi_snapshot_preview1_path_open(_fd: i32, _dirflag
 	ERRNO_NOENT
 }
 
+// OCCT's `Standard_ErrorHandler` references setjmp/longjmp; on wasm these become `env`
+// imports. cadrum uses C++ exceptions (not signal-based unwinding), so setjmp just
+// returns 0 (fall through the protected block) and longjmp is never reached (trap if it is).
+#[no_mangle]
+pub extern "C" fn setjmp(_env: *mut c_void) -> i32 {
+	0
+}
+#[no_mangle]
+pub extern "C" fn longjmp(_env: *mut c_void, _val: i32) {
+	core::arch::wasm32::unreachable()
+}
+
 /// Force every stub above into the final wasm module.
 ///
 /// In Rust the stubs sit in cadrum's rlib; rustc only links that object — and only
@@ -131,5 +150,7 @@ pub fn anchor() {
 		let _ = __imported_wasi_snapshot_preview1_fd_fdstat_set_flags(0, 0);
 		let _ = __imported_wasi_snapshot_preview1_path_filestat_get(0, 0, 0, 0, 0);
 		let _ = __imported_wasi_snapshot_preview1_path_open(0, 0, 0, 0, 0, 0, 0, 0, 0);
+		let _ = setjmp(core::ptr::null_mut());
+		longjmp(core::ptr::null_mut(), 0);
 	}
 }


### PR DESCRIPTION
## Summary

For `wasm32-unknown-unknown`, the final rustc link of OCCT needs the `-fwasm-exceptions` (eh) variants of `libc++abi` / `libunwind` plus `libc`. These were only supplied via the Dockerfile / sandbox `RUSTFLAGS`, so they did not travel with the prebuilt tarball.

This change bundles them into the prebuilt OCCT as `libcadrum_*.a` (picked up automatically by the existing `cadrum`-named-lib walkdir in `link_occt_libraries`), mirroring the existing GNU runtime bundling (#89 / #147). The result is the exact matching eh-variant runtime travels with the prebuilt.

### What was verified
- **Necessity (Phase A):** dropping any one of `-L eh`, `-L base`, `-l c++abi`, `-l unwind`, `-l c` from `RUSTFLAGS` and running the sandbox cadrum sample fails (missing search path, or unresolved `env` imports at runtime). All five are required, so `RUSTFLAGS` is already minimal and is left unchanged.
- **Bundling (Phase B):** a real `--features source` wasm build produces byte-correct eh-variant `libcadrum_{c++abi,unwind,c}.a`, and the sandbox sample links against them and prints `Solid volume: 6000` even with the explicit `-l` flags removed from `RUSTFLAGS`.

### Implementation notes
`bundle_runtime_libs` is fixed for the wasm sysroot layout:
- It now probes the compiler with its full target/sysroot flags (`-print-file-name` resolves nothing for wasm without `--target/--sysroot`).
- It prefers the `eh/` sysroot subdir: the default probe returns the **noeh** `libc++abi` and cannot locate `libunwind` at all. The `eh/` dir is derived from the always-resolvable base `libc.a`.
- GNU targets have no `eh/` subdir and fall back to the previous behavior unchanged.

> Note: the full `make check-wasm32-unknown-unknown` docker pipeline (CI/release gate) was not run locally; every component was validated locally instead.

---

## 概要（日本語）

`wasm32-unknown-unknown` の OCCT 最終リンクには `-fwasm-exceptions`(eh)版の `libc++abi` / `libunwind` と `libc` が必要だが、従来は Dockerfile / sandbox の `RUSTFLAGS` でのみ供給され、prebuilt tarball には同梱されていなかった。

本変更はこれらを `libcadrum_*.a` として prebuilt OCCT に同梱し（`link_occt_libraries` の既存 walkdir が自動リンク）、GNU ランタイム同梱(#89 / #147)と同じ方式で、OCCT がビルドされたのと同一の eh 版ランタイムを prebuilt に持たせる。

### 検証
- **必要性(Phase A):** `RUSTFLAGS` から `-L eh` / `-L base` / `-l c++abi` / `-l unwind` / `-l c` を1つずつ落とすといずれも失敗（探索パス欠落、または実行時の `env` import 未解決）。5要素すべて必要なため `RUSTFLAGS` は既に最小で、変更しない。
- **同梱(Phase B):** 実際の `--features source` wasm ビルドが eh 版の `libcadrum_{c++abi,unwind,c}.a` をバイト一致で生成し、`RUSTFLAGS` から明示 `-l` を外しても sandbox サンプルがリンクでき `Solid volume: 6000` を出力。

### 実装メモ
`bundle_runtime_libs` を wasm の wasi-sysroot 構成に対応：
- compiler を target/sysroot フラグごと probe（wasm では `--target/--sysroot` 無しだと `-print-file-name` が解決できない）。
- `eh/` サブディレクトリを優先（既定 probe は **noeh** の `libc++abi` を返し、`libunwind` は解決すらできない）。`eh/` は確実に引ける base `libc.a` から導出。
- GNU 系は `eh/` が無いため従来動作にフォールバック。