### PR TITLE
docs: approach 2 (wasm clang) spike notes — memory cleared, clang.wasm acquisition is the blocker (#215)

### DIFF
--- a/notes/20260617-wasm-clangスパイクwrapperコンパイルのメモリ実測.md
+++ b/notes/20260617-wasm-clangスパイクwrapperコンパイルのメモリ実測.md
@@ -1,0 +1,48 @@
+# wasm-clang spike: wrapper.cpp コンパイルのメモリ/時間実測（#207 approach 2）
+
+## 背景
+
+#207「rustc だけで wasm を通す」の approach 2 = **wasm 製 clang を配布し、user 側で
+`cpp/wrapper.cpp` をコンパイル（compile only → `.o`、リンクは host の rust-lld）→ `.a` 化**。
+最大の不確実性は **wasm32 の 4GB 線形メモリ上限内で OCCT 多用の `wrapper.cpp` を
+コンパイルできるか**。これを実証する spike。
+
+## 方法（Tier 1: native clang のピーク RSS を proxy 計測）
+
+wasm 上 clang のメモリは native clang のピーク RSS と同オーダー（やや増）になるため、
+まず手元の wasi-sdk-33 **native** clang で `wrapper.cpp` を wasm 向けにコンパイルし、
+ピーク working set を実測。clang.wasm 不要で即判定できる主ゲート。
+
+- コンパイラ: `out/wasi-sdk-33/bin/clang++`（native exe、target=wasm32-wasip1）
+- フラグ: build.rs/Dockerfile 準拠
+  `--target=wasm32-wasip1 --sysroot=… -fwasm-exceptions -fexceptions -mllvm -wasm-use-legacy-eh=false -std=c++17 -D_USE_MATH_DEFINES -DCADRUM_COLOR -D_WASI_EMULATED_*`
+- include: `target/cxxbridge`（cxx 生成 ffi.rs.h / rust/cxx.h）, `..`（実 `cadrum/cpp/wrapper.h`）,
+  `target/occt-8_0_0_rev2-wasm32_unknown_unknown/include/opencascade`
+- 計測: PowerShell `Start-Process -PassThru` → `PeakWorkingSet64` をポーリング（単調増加なので真のピーク）, `Stopwatch` で時間
+- `-fsyntax-only` 事前検証 → exit 0（include 構成・パース OK）
+
+## 結果
+
+| 最適化 | ピーク RSS | 時間 | 生成 .o |
+|---|---|---|---|
+| `-O1` | **163.1 MB** | 4.6 s | 346 KB |
+| `-O0` | **160.8 MB** | 2.7 s | 978 KB |
+
+## 結論
+
+- **メモリ関門は明確にクリア。** ピーク ~163 MB は wasm32 の 4GB 上限に対し **約25倍の余裕**。
+  `wrapper.cpp` は OCCT を呼ぶだけの薄い glue TU で、OCCT 本体は prebuilt のため、
+  ヘッダを多数 include してもコンパイル時フットプリントは小さい。
+- wasm 上 clang のオーバーヘッド（経験的に native の <2倍程度）を見ても <1GB に収まる見込み。
+- よって **approach 2 はメモリ面で成立** = go。
+
+## 残課題（feasibility ではなくロジ/エンジニアリング）
+
+- **Tier 2 未実施**: 実 clang.wasm を wasm ランタイム（wasmtime 等）で実走させ、
+  (a) exnref EH 付きコンパイルの成功 (b) wasm インスタンス内メモリ (c) 時間 を確認する段は未了。
+  ローカルに wasm ランタイムも clang.wasm も無いため。これは「clang.wasm の入手/自前ビルド」という
+  ロジ課題で、メモリ可否の主判断は Tier 1 で確定済み。
+- approach 2 本実装に進む場合の構成（別計画）: clang.wasm 配布（LLVM 版ごと、低頻度）＋
+  compile-time ヘッダ同梱＋`build.rs` を cxx-gen（glue 生成のみ）＋`wasmtime` build-dep で
+  clang.wasm 実行＋`ar` クレートで `.a` 化。consumer は rustc のみ。
+- approach 1（PR #208 の prebuilt `cadrum_cpp.a`）は既に低リスクで成立済み。当面のデフォルト維持。

--- a/notes/20260617-wasm-clang実走スパイクGATE1ブロック.md
+++ b/notes/20260617-wasm-clang実走スパイクGATE1ブロック.md
@@ -1,0 +1,44 @@
+# approach 2 実走スパイク: GATE 1（clang.wasm 入手）でブロック
+
+#215 approach 2（wasm 化 clang で user 側コンパイル）を実走しようとした記録。
+メモリ関門は別ノートで実証済み(~163MB)。本回は **clang.wasm の入手**で停止。
+
+## 試したこと
+
+1. **wasmer 7.1.0** を導入（Windows 公式インストーラ、`~/.wasmer/bin`）。`--volume HOST:GUEST` で
+   ホストディレクトリをマップ（Windows のドライブコロン回避のため PowerShell からリポジトリ root を
+   `--volume ".:/src"` でマップ＝MSYS のパス変換も回避）。
+2. `wasmer run clang/clang -- --version` → **clang 16.0.0 / target wasm32-unknown-wasi**。
+3. ヘッダ不要の最小 `throw.cpp`（`try{throw 1;}catch(int){}`）を exnref フラグ
+   `-fwasm-exceptions -fexceptions -mllvm -wasm-use-legacy-eh=false -c` で wasm `.o` 化を試行。
+
+## 結果（2つの致命的ブロッカー）
+
+- **(A) clang 16 は exnref 非対応。** 新 wasm EH（try_table/throw_ref, `-wasm-use-legacy-eh=false`）は
+  LLVM 19+ 以降。OCCT prebuilt は wasi-sdk-33（LLVM 22）の **exnref** でビルドされており(#204)、
+  16 が出す legacy EH とは混在不可。
+- **(B) `clang/clang` package は WASI 上で `-c` コンパイルできない。**
+  `error: unknown integrated tool '-cc1'` ―clang driver が cc1 を別プロセスで起動しようとするが
+  WASI に exec/spawn が無く失敗。この package は実質コンパイラとして駆動できない。
+
+## 他候補も不適
+
+- **wasix-clang**（wasix-org/wasix-clang v0.0.15）: `wasix-llvm.tar.xz` の `bin/clang` を
+  **ネイティブ実行**で検証している＝**ネイティブ cross toolchain（clang.wasm ではない）**。
+  我々は既に native cross（wasi-sdk-33）を持つので approach 2 の目的（clang を wasm として動かす）に
+  寄与しない。
+
+## 結論
+
+「recent-LLVM(exnref対応) ＋ wasm ランタイムで cc1 まで動く ＋ wasi-sdk-33 と ABI 整合」を満たす
+**prebuilt な clang.wasm は現状入手できない**。approach 2 を実走するには **wasi-sdk-33 の LLVM(22) から
+clang を wasm32-wasi 向けに自前ビルド**する必要があり（数時間・CI 行き、cc1 を in-process で動く構成に
+する必要あり）、ローカルでの即時実証は不可。
+
+= 承認済み計画の「不成立時は GATE で停止＋報告」に該当。メモリ関門(別ノート)は clear 済みなので、
+approach 2 の残る本質的ハードルは **適切な clang.wasm の生成（CI）** に集約される。
+
+## 環境メモ
+- wasmer: `C:\Users\smith\.wasmer\bin\wasmer.exe`（7.1.0）。`--volume ".:/src"` を PowerShell から。
+- 再現コマンド例（PowerShell, repo root）:
+  `& wasmer run --volume ".:/src" clang/clang -- --target=wasm32-wasip1 -fwasm-exceptions -fexceptions -mllvm -wasm-use-legacy-eh=false -std=c++17 -O1 -c /src/<path>/throw.cpp -o /src/<path>/throw.o`

--- a/notes/20260618-clang-wasm自前ビルドの進捗と停止地点.md
+++ b/notes/20260618-clang-wasm自前ビルドの進捗と停止地点.md
@@ -1,0 +1,51 @@
+# clang.wasm 自前ビルド（LLVM→wasm クロス）: 進捗と停止地点
+
+#215 approach 2 を実走するため、wasi-sdk-33 の llvm-project を **wasm ホストへクロスビルド**して
+clang.wasm を得る試み。**クロス configure まで成功**し、LLVMSupport を ~55/2811 までコンパイル
+した時点で、**wasi-libc が POSIX を欠く（sigaction/fork/execve 等）**ため mainline LLVM の
+多ファイル移植が必要と判明し、ユーザ判断で一旦停止。
+
+## 環境 / 再現手順
+
+- ソース: `git clone --recursive https://github.com/WebAssembly/wasi-sdk` → checkout
+  `c10c0507deb3e5aad506f1f9f32084e49a21834b`（submodule: config, wasi-libc, llvm-project=**LLVM 22.1.0**）。
+  ローカル配置: `C:\Users\smith\wasi-sdk-build\wasi-sdk`（cadrum レポ外。再開用に残置）。
+- ビルド: docker `ubuntu:24.04`、`/work`=上記ソース mount。ビルドコンパイラは
+  **wasi-sdk-33(Linux) の clang-22**（`/work/wasi-sdk-linux`、builtins・sysroot・cmake toolchain 同梱）。
+- 2 段構成:
+  1. **native tablegen**: `cmake -S llvm -B build-native -DLLVM_ENABLE_PROJECTS=clang -DLLVM_TARGETS_TO_BUILD=WebAssembly` → `ninja llvm-tblgen clang-tblgen`。
+  2. **wasm クロス**: `CMAKE_TOOLCHAIN_FILE`=wasi-sdk の `wasi-sdk-p1.cmake`（`WASI_SDK_PREFIX` 指定、`Platform/WASI.cmake` を module path に）、
+     `CMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY`、`LLVM_HOST_TRIPLE=wasm32-wasip1`、
+     `LLVM_TABLEGEN/CLANG_TABLEGEN`=native、`LLVM_ENABLE_THREADS=OFF`、`CLANG_SPAWN_CC1=OFF`
+     （WASI に exec 無 → cc1 を in-process 化）、`LLVM_TARGETS_TO_BUILD=WebAssembly`、
+     `_WASI_EMULATED_{SIGNAL,MMAN,PROCESS_CLOCKS,GETPID}` を CXXFLAGS、対応 emulated lib をリンク。
+
+## 必要だったパッチ（クロス成立のため）
+
+1. **`cmake/Platform/WASI.cmake` に `set(UNIX 1)`**: LLVM `HandleLLVMOptions.cmake` が
+   WIN32/UNIX/CYGWIN/Generic 以外を "Unable to determine platform" で拒否。WASI は POSIX 風なので UNIX 扱い。
+2. **`llvm/include/llvm/ADT/bit.h`**: endianness 分岐の最初の `#if` に `|| defined(__wasi__)` を追加。
+   未対応だと `#else` で不在の `<machine/endian.h>` を引く（wasi-libc は `<endian.h>` を持つ）。
+
+## 到達点
+
+- ✅ **クロス configure 成功**（`CONFIGURE_OK`、Clang 22.1.0 / Targeting WebAssembly）。
+- ✅ `bit.h` パッチ後、LLVMSupport を **~55/2811** までコンパイル。
+- ❌ `lib/Support/CrashRecoveryContext.cpp` で停止: `struct sigaction` 不完全 + `sigaction()` 未提供。
+  wasi-sysroot の `signal.h` で **`sigaction()` は `#ifdef __wasilibc_unmodified_upstream /* WASI has no signals */` 内**
+  ＝ **wasi-libc は sigaction を提供しない**。`_WASI_EMULATED_SIGNAL` でも `signal()`/`raise()` のみ。
+
+## 結論 / 推奨
+
+- mainline LLVM 22 の Unix サポート層（`CrashRecoveryContext`・`Signals.inc`・`Program.inc` の fork/execve・
+  `Process.inc`・`Path.inc`・`Memory.inc`・`DynamicLibrary` 等）は wasi-libc に無い POSIX API を多用。
+  **wasm ホスト化には多数のソースパッチ＝ mainline LLVM の wasi 移植**が必要（Wasmer が fork で維持する規模）。
+  emulated shim（signal/mman/getpid/clocks）では sigaction/fork/exec は埋まらない。
+- 推奨: ①既存の **LLVM-WASI fork/パッチ群（Wasmer 等）** を採用して clang.wasm を得る、または
+  ②本移植を独立した大規模タスクとして計画・実施。**メモリ関門と consumer 経路（cxx_build skip + prebuilt FFI link）
+  は別途実証/設計済み**なので、適切な clang.wasm さえ得られれば approach 2 は完成可能。
+
+## 状態
+- ビルドツリー `C:\Users\smith\wasi-sdk-build`（数 GB）は再開用に残置。スクリプト:
+  `wasi-sdk/cross-configure.sh`, `wasi-sdk/reconfig-and-build.sh`, `wasi-sdk/build-clang.sh`。
+- 関連: 別ノート（メモリ実測 ~163MB / GATE1 ブロック）、#215, PR #216。


### PR DESCRIPTION
#215（approach 2: wasm 化 clang を配布し consumer 側で wrapper をコンパイル）の **feasibility spike** の記録 notes 2 枚。コード変更なし。

## 要点

- **メモリ関門は clear**: `cpp/wrapper.cpp` を wasm 向けにコンパイルしたピーク RSS は **~163 MB**（-O1）。wasm32 の 4GB 上限に対し約25倍の余裕。wrapper は OCCT を呼ぶだけの薄い glue TU で OCCT 本体は prebuilt のため小さい。→ メモリは非ブロッカー。
- **実行関門（GATE 1 = clang.wasm 入手）でブロック**:
  - wasmer `clang/clang` = **clang 16**（exnref EH 非対応）＋ WASI 上で **`-cc1` を起動できず `-c` 不可**。
  - **wasix-clang** = `bin/clang` を**ネイティブ実行**＝ネイティブ cross toolchain（clang.wasm ではない）。
  - → 「recent-LLVM(exnref) ＋ wasm ランタイムで動く ＋ wasi-sdk-33 と ABI 整合」の prebuilt clang.wasm は入手不可。**自前ビルド（LLVM→wasm, CI）が必要**。

## ファイル
- `notes/20260617-wasm-clangスパイクwrapperコンパイルのメモリ実測.md`
- `notes/20260617-wasm-clang実走スパイクGATE1ブロック.md`

次段: wasi-sdk-33 を指定コミットから `--recursive` clone し wasm ターゲットで clang.wasm を自前ビルド → それで FFI をビルドして `make check-wasm32-unknown-unknown` を通す（別作業）。
