### PR TITLE
Bundle wasm libc++ into prebuilt; add rename flag to bundle_runtime_libs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -62,11 +62,14 @@ fn main() {
 	#[cfg(feature = "source")]
 	if env::var("CADRUM_BUNDLE_RUNTIME").is_ok() {
 		if target.ends_with("windows-gnu") || target.contains("linux-gnu") {
-			bundle_runtime_libs(&occt_lib_dir, &["libstdc++.a", "libgcc.a", "libgcc_eh.a"]);
+			bundle_runtime_libs(&occt_lib_dir, &["libstdc++.a", "libgcc.a", "libgcc_eh.a"], true);
 		} else if target.starts_with("wasm32") {
-			// -fwasm-exceptions ビルドの OCCT/libc++ が要求する eh 版ランタイム。最終リンク(rustc)で
-			// 必要と実測で確定済み（c++abi/unwind/c のいずれを欠いても env import 未解決で失敗）。
-			bundle_runtime_libs(&occt_lib_dir, &["libc++abi.a", "libunwind.a", "libc.a"]);
+			// -fwasm-exceptions ビルドの OCCT/libc++ が要求する eh 版ランタイムを同梱し prebuilt を
+			// 自己完結化する（実測: 4 つ同梱すれば RUSTFLAGS 無しでリンク・実行できる）。
+			// c++abi/unwind/c は外部 -l が出ないので prefix=true で walkdir に明示リンクさせる。
+			// libc++ は link-cplusplus の `-l c++` が実名を要求するので prefix=false で実名のまま置く。
+			bundle_runtime_libs(&occt_lib_dir, &["libc++abi.a", "libunwind.a", "libc.a"], true);
+			bundle_runtime_libs(&occt_lib_dir, &["libc++.a"], false);
 		}
 	}
 
@@ -288,13 +291,22 @@ fn fetch_bytes(url: &str) -> Result<Vec<u8>, String> {
 	}
 }
 
-/// Bundle host toolchain runtime archives (`libs`) into the OCCT lib dir as
-/// `libcadrum_*.a`. Triggered by `CADRUM_BUNDLE_RUNTIME` only — used by the
-/// prebuilt-tarball makefile recipe so end users running source don't get their
-/// host runtime silently bundled. Current policy bundles GCC runtime
-/// (libstdc++.a / libgcc.a / libgcc_eh.a) for GNU targets; see the call site in `main`.
+/// Bundle host toolchain runtime archives (`libs`) into the OCCT lib dir.
+/// Triggered by `CADRUM_BUNDLE_RUNTIME` only — used by the prebuilt-tarball makefile
+/// recipe so end users running source don't get their host runtime silently bundled.
+/// See the call sites in `main`.
+///
+/// `prefix` controls the destination name:
+/// - `true`  → copy as `libcadrum_*.a` so `link_occt_libraries`'s walkdir links it
+///   explicitly (`-l cadrum_*`). This both avoids the linker auto-grabbing the host
+///   runtime (#89) and is the *only* thing that links the archive in a clean
+///   prebuilt-consumer build. Required for anything no external `-l` already requests
+///   (GCC runtime, wasm libc++abi/unwind/c).
+/// - `false` → copy under the real name so an externally-emitted `-l <name>` resolves it
+///   via the occt lib-dir search path. Used for wasm `libc++.a`: cxx's link-cplusplus
+///   unconditionally emits `-l c++`, which needs the real file name (renaming breaks it).
 #[cfg(feature = "source")]
-fn bundle_runtime_libs(occt_lib_dir: &Path, libs: &[&str]) {
+fn bundle_runtime_libs(occt_lib_dir: &Path, libs: &[&str], prefix: bool) {
 	let compiler = cc::Build::new().get_compiler();
 	// `to_command()` で target/sysroot 等のフラグごと probe する。wasm は --target/--sysroot 無しだと
 	// -print-file-name が wasi-sysroot を解決できない（GNU は素の probe でも絶対パスが返る）。
@@ -312,7 +324,7 @@ fn bundle_runtime_libs(occt_lib_dir: &Path, libs: &[&str]) {
 		let src = eh_dir.as_ref().map(|d| d.join(lib)).filter(|p| p.exists()).unwrap_or_else(|| probe(lib));
 		// `-print-file-name=` は名前が見つからない時に lib 名そのものを返すので存在チェック必須
 		if src.is_absolute() && src.exists() {
-			let dst_name = lib.replace("lib", "libcadrum_");
+			let dst_name = if prefix { lib.replace("lib", "libcadrum_") } else { lib.to_string() };
 			std::fs::copy(&src, occt_lib_dir.join(&dst_name)).unwrap();
 		} else {
 			eprintln!("cargo:warning=runtime lib not found: {}", lib);


### PR DESCRIPTION
## Summary

Follow-up to #214. Bundle the eh-variant **`libc++.a`** into the wasm prebuilt OCCT so the tarball is self-contained at link time, and parameterize `bundle_runtime_libs` with a `prefix: bool` to control the rename instead of a hardcoded special case.

### Background

#214 bundled `libc++abi.a` / `libunwind.a` / `libc.a` (as `libcadrum_*.a`) so the eh-variant runtime travels with the prebuilt. But `libc++.a` itself was not bundled, so a prebuilt consumer still had to pass `-L <wasi-sysroot>/lib/wasm32-wasip1/eh` in `RUSTFLAGS` to satisfy the `-l c++` that cxx's `link-cplusplus` emits unconditionally.

### What changed

- `bundle_runtime_libs(occt_lib_dir, libs, prefix)` — new `prefix` flag:
  - `prefix = true` → copy as `libcadrum_*.a`. `link_occt_libraries`'s walkdir links these explicitly (`-l cadrum_*`); this is the only thing that links an archive no external `-l` already requests (GCC runtime; wasm `c++abi`/`unwind`/`c`).
  - `prefix = false` → copy under the real name so an externally-emitted `-l <name>` resolves it via the occt lib-dir search path.
- wasm now bundles libc++ too, split by mechanism:
  - `["libc++abi.a", "libunwind.a", "libc.a"]` with `prefix = true` (no external `-l`, need the walkdir)
  - `["libc++.a"]` with `prefix = false` (`link-cplusplus` already emits `-l c++`, which needs the real file name — renaming it to `libcadrum_c++.a` leaves `-l c++` unresolved)
- GNU call passes `prefix = true` (unchanged behavior).

### Why not bundle all four with `prefix = false`

The rename is not only #89 host-ABI safety (irrelevant for wasm — no host execution); for `c++abi`/`unwind`/`c` it is also the *only* link mechanism. With real names the walkdir skips them (it matches `cadrum` in the name) and nothing else emits their `-l`, so they regress to unresolved `env` imports. Only `libc++` has an external `-l` (`link-cplusplus`), so only it can use `prefix = false`.

### Verification

Locally confirmed (manual simulation against the #214 prebuilt): with the real-named `libc++.a` in the occt lib dir, the sandbox links and runs with **empty `RUSTFLAGS`** — `Solid volume: 6000`, zero wasm imports. The full `make check-wasm32-unknown-unknown` gate on this exact change is running; if it fails this PR can simply be rejected.

## 概要（日本語）

#214 の続き。wasm prebuilt に eh 版 **`libc++.a`** も同梱してリンク時に自己完結化し、`bundle_runtime_libs` に `prefix: bool` を足して改名の有無を制御する（libc++ だけハードコード特例にしない）。

- `prefix=true` → `libcadrum_*.a` に改名。`link_occt_libraries` の walkdir が `-l cadrum_*` で明示リンク。外部 `-l` が出ない物（GCC runtime、wasm の c++abi/unwind/c）に必須。
- `prefix=false` → 実名のまま。外部の `-l <name>`（cxx の link-cplusplus が出す `-l c++` 等）が search path 経由で解決。
- 「4 つ一括 prefix=false」は不可: c++abi/unwind/c は walkdir に拾われず未解決の env import に逆戻りするため、libc++ だけ `prefix=false` に分ける。

検証: 実名 libc++.a を置くと **空 RUSTFLAGS** で sandbox がリンク・実行でき `Solid volume: 6000`・wasm import 0 を確認済み。フルゲートは実行中で、失敗したら本 PR はリジェクトすればよい。