### PR TITLE
Bump BUILD_REVISION to rev3

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 const OCCT_VERSION: &str = "V8_0_0";
 
 /// Build revision for prebuilt tarballs. Update this when making non-OCCT-breaking changes that require cache invalidation (e.g. patch updates, build script changes, EH encoding changes, etc).
-const BUILD_REVISION: &str = "rev2";
+const BUILD_REVISION: &str = "rev3";
 
 /// Release tag / tarball / cache-dir name (#203). Fields are separated by `-` and
 /// characters within a field by `_`, so the name parses by splitting on `-` (the


### PR DESCRIPTION
Bumps `BUILD_REVISION` from `rev2` to `rev3` to invalidate the prebuilt tarball cache.