### PR TITLE
Link prebuilt FFI archive from release to skip wrapper compile (wasm: no full wasi-sdk)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -213,22 +213,29 @@ fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path, target: &str) {
 		println!("cargo:rustc-link-arg=-static");
 	}
 
-	let mut build = cxx_build::bridge("src/occt/ffi.rs");
-	build.file("cpp/wrapper.cpp").include(occt_include).std("c++17").define("_USE_MATH_DEFINES", None);
+	// If a prebuilt FFI archive matching this target + crate version is published on the
+	// release, link it instead of compiling the wrapper. The archive bundles the cxx glue
+	// (`ffi.rs.o`) and `wrapper.o`, so the consumer needs no C++ toolchain — in particular
+	// wasm builds need no wasi-sdk/clang (the final link is rust-lld). Falls back to a local
+	// compile when the asset is absent (e.g. native targets ship no FFI .a) or under `source`.
+	if !link_prebuilt_ffi(target) {
+		let mut build = cxx_build::bridge("src/occt/ffi.rs");
+		build.file("cpp/wrapper.cpp").include(occt_include).std("c++17").define("_USE_MATH_DEFINES", None);
 
-	apply_compiler_flags(|s| {
-		build.flag(s);
-	});
+		apply_compiler_flags(|s| {
+			build.flag(s);
+		});
 
-	#[cfg(feature = "color")]
-	build.define("CADRUM_COLOR", None);
+		#[cfg(feature = "color")]
+		build.define("CADRUM_COLOR", None);
 
-	// Name the FFI archive after `release_name(target, true)` so the produced
-	// `lib<release_name>.a` is uniquely identifiable in the target dir (the makefile
-	// `cadrum` recipe locates it for the GitHub Release upload) and shares one
-	// naming authority with the download URL. cc auto-emits the matching
-	// `rustc-link-lib=static=<name>`, so local linking stays consistent.
-	build.compile(&release_name(Some(target), true));
+		// Name the FFI archive after `release_name(target, true)` so the produced
+		// `lib<release_name>.a` is uniquely identifiable in the target dir (the makefile
+		// `cadrum` recipe locates it for the GitHub Release upload) and shares one
+		// naming authority with the download URL. cc auto-emits the matching
+		// `rustc-link-lib=static=<name>`, so local linking stays consistent.
+		build.compile(&release_name(Some(target), true));
+	}
 
 	// wasm: the `wasi_snapshot_preview1` / `env` imports dragged in by libc++ static
 	// init and OCCT are neutralized by no-op shims in `src/wasi_stub.rs` (anchored via
@@ -237,6 +244,54 @@ fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path, target: &str) {
 	println!("cargo:rerun-if-changed=src/occt/ffi.rs");
 	println!("cargo:rerun-if-changed=cpp/wrapper.h");
 	println!("cargo:rerun-if-changed=cpp/wrapper.cpp");
+	println!("cargo:rerun-if-env-changed=CADRUM_FFI_URL");
+}
+
+/// Try to download and link the prebuilt FFI archive `lib<release_name(target,true)>.a`
+/// from the GitHub release. Returns `true` if it was linked (so the caller skips compiling
+/// the wrapper), `false` to fall back to a local cxx-build.
+///
+/// The archive name carries the crate version, so it only matches when the published asset
+/// was built from this exact cadrum version (keeping the cxx-bridge ABI consistent). A 404
+/// returns GitHub's HTML error page, which fails the `ar` magic check below — that is the
+/// "does the release asset exist?" test (no per-target guard needed). The OCCT static libs
+/// are still provided separately by `resolve_occt`; this only replaces the wrapper compile.
+#[cfg(feature = "source")]
+fn link_prebuilt_ffi(_target: &str) -> bool {
+	// `source` means "build everything from upstream sources" — always compile the wrapper.
+	false
+}
+
+#[cfg(not(feature = "source"))]
+fn link_prebuilt_ffi(target: &str) -> bool {
+	let archive = format!("lib{}.a", release_name(Some(target), true));
+	let url = env::var("CADRUM_FFI_URL").unwrap_or_else(|_| format!("https://github.com/lzpel/cadrum/releases/download/{}/{}", release_name(None, false), archive));
+
+	let bytes = match fetch_bytes(&url) {
+		Ok(b) => b,
+		Err(e) => {
+			eprintln!("cargo:warning=prebuilt FFI unavailable ({}); compiling wrapper locally: {}", archive, e);
+			return false;
+		}
+	};
+
+	// GitHub serves an HTML page for a missing asset; a real archive starts with the ar magic.
+	if !bytes.starts_with(b"!<arch>\n") {
+		eprintln!("cargo:warning=prebuilt FFI {} not found on release; compiling wrapper locally", archive);
+		return false;
+	}
+
+	let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+	let dest = out_dir.join(&archive);
+	if let Err(e) = std::fs::write(&dest, &bytes) {
+		eprintln!("cargo:warning=failed to write prebuilt FFI to {}: {}; compiling wrapper locally", dest.display(), e);
+		return false;
+	}
+
+	eprintln!("cargo:warning=Using prebuilt FFI archive {}", url);
+	println!("cargo:rustc-link-search=native={}", out_dir.display());
+	println!("cargo:rustc-link-lib=static={}", release_name(Some(target), true));
+	true
 }
 
 /// Provide OCCT into `effective_root` by downloading a prebuilt tarball for `target`.


### PR DESCRIPTION
## 概要

`build.rs` の `link_occt_libraries` に「`release_name(target, true)` が示す **prebuilt FFI アーカイブ** `lib<name>.a` が GitHub release にあれば、それをリンクして `cpp/wrapper.cpp` のコンパイル（cxx-build）をスキップする」経路を追加する。

これにより wasm 消費者にとって **cadrum 自身の wasm 向け C++ コンパイルが不要**になり、残るのは `cxx` クレートの `cxx.cc` のみ。結果、フル wasi-sdk ワークフロー無し（**clang≥19 + wasm sysroot ヘッダ**）で wasm をビルドできる。

## 変更

- `build.rs`: `link_prebuilt_ffi(target) -> bool` を追加。
  - URL: `CADRUM_FFI_URL` env、無ければ `releases/download/{release_name(None,false)}/lib{release_name(Some(target),true)}.a`（`occt_from_prebuilt` の `CADRUM_PREBUILT_URL` と同流儀。`file://` 対応）。
  - 取得バイト列を **`ar` マジック `!<arch>\n`** で検証（GitHub の 404 は HTML を返すため、これが「アセット実在」の判定）。
  - 妥当なら `OUT_DIR` に書き出し、`rustc-link-search` + `rustc-link-lib=static=<name>` を emit して `true`。失敗時は `false`。
  - **target ガード無し**: アセットがある target は使い、無ければ（native 等）従来通りラッパーをコンパイル。
  - `#[cfg(not(feature = \"source\"))]`（`source` は全部ソースから）。
  - 既存 `fetch_bytes` を再利用、新規依存なし。

## 検証

wasm32-unknown-unknown（clang≥19 として wasi-sdk 同梱 clang22 + sysroot ヘッダ使用）:
- cadrum の wasm build dir `out/` は DL した `libocct-8_0_0_rev3-wasm32_unknown_unknown-cadrum-0_8_12.a` のみ＝**ラッパー compile スキップ**（`wrapper.o` 無し）。
- 最小 cdylib 消費者を `cargo build --target wasm32-unknown-unknown` → `wasmtest.wasm`（17.9MB）生成。**RUSTFLAGS で wasi-sysroot lib を指す必要なし**（OCCT prebuilt 同梱ランタイムで解決）。
- ネイティブ（x86_64-pc-windows-gnu）: アセット 404 → 従来パスでビルド成功（退行なし）。

## 注意 / 既知の制約（詳細は #225）

- **cxx クレートの `cxx.cc`** は依然 wasm 向けにコンパイルされる（cadrum からは止められない）。よって wasm は **clang≥19 + wasm sysroot ヘッダ**が必要（ホスト clang18 は libc++ の `__builtin_clzg` 要求で不可）。
- prebuilt FFI と消費側 `cxx` の **ABI 整合**が前提（同一 cadrum バージョン + pin された cxx で担保。不一致時は 404 フォールバック）。
- **バージョン結合**: その rev+target+crate バージョンの FFI `.a` が公開済みの時のみ有効。
- wasm sysroot ヘッダの配布手段・完全 toolchain-free 化（cxxbridge1 同梱 + `.cargo/config`）は別タスク。

Refs #225（調査・方針 Option B の build.rs 部分。ヘッダ配布等の残課題は #225 に残す）。