### PR TITLE
Bind-mount source into cross Docker images instead of COPY

### DIFF
--- a/docker/Dockerfile_aarch64-unknown-linux-gnu
+++ b/docker/Dockerfile_aarch64-unknown-linux-gnu
@@ -24,6 +24,5 @@ ENV CARGO_BUILD_TARGET=aarch64-unknown-linux-gnu
 # add cargo target
 RUN rustup target add ${CARGO_BUILD_TARGET}
 
-# copy source and build OCCT prebuilt
-WORKDIR /src
-COPY . /src
+# No COPY: source is bind-mounted at `docker run` time (see makefile `cross-%`),
+# keeping this a project-agnostic toolchain image.

--- a/docker/Dockerfile_wasm32-unknown-unknown
+++ b/docker/Dockerfile_wasm32-unknown-unknown
@@ -42,6 +42,5 @@ ENV CXXFLAGS_wasm32_unknown_unknown="--target=wasm32-wasip1 --sysroot=${SYSROOT}
 # Final link (rustc) pulls the eh libc++ / libc++abi / libunwind and libc.
 ENV CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS="-L native=${SYSROOT}/lib/wasm32-wasip1/eh -L native=${SYSROOT}/lib/wasm32-wasip1 -l static=c++abi -l static=unwind -l static=c"
 
-# copy source and build OCCT prebuilt
-WORKDIR /src
-COPY . /src
+# No COPY: source is bind-mounted at `docker run` time (see makefile `cross-%`),
+# keeping this a project-agnostic toolchain image.

--- a/docker/Dockerfile_x86_64-pc-windows-gnu
+++ b/docker/Dockerfile_x86_64-pc-windows-gnu
@@ -35,6 +35,5 @@ ENV CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER=x86_64-w64-mingw32-gcc
 # add cargo target
 RUN rustup target add ${CARGO_BUILD_TARGET}
 
-# copy source and build OCCT prebuilt
-WORKDIR /src
-COPY . /src
+# No COPY: source is bind-mounted at `docker run` time (see makefile `cross-%`),
+# keeping this a project-agnostic toolchain image.

--- a/docker/Dockerfile_x86_64-unknown-linux-gnu
+++ b/docker/Dockerfile_x86_64-unknown-linux-gnu
@@ -22,6 +22,5 @@ ENV CARGO_BUILD_TARGET=x86_64-unknown-linux-gnu
 # add cargo target
 RUN rustup target add ${CARGO_BUILD_TARGET}
 
-# copy source and build OCCT prebuilt
-WORKDIR /src
-COPY . /src
+# No COPY: source is bind-mounted at `docker run` time (see makefile `cross-%`),
+# keeping this a project-agnostic toolchain image.

--- a/makefile
+++ b/makefile
@@ -1,8 +1,4 @@
 PATH_DOCS=out/markdown
-# Cargo's build dir. Defaults to `target`; the `cross-%` Docker recipe overrides it
-# (via `docker run -e`) to an in-container path so a bind-mounted source tree's build
-# stays isolated from the host `target/`. Recipes that locate build outputs use this var.
-CARGO_TARGET_DIR ?= target
 generate: # prepare for deploy
 	mkdir -p out
 	find . -maxdepth 1 -name .gitignore | xargs -IX sed '/^#\s*EOF_DOCKERIGNORE.*/q' X > .dockerignore
@@ -35,7 +31,7 @@ occt: generate # output out/occt-<rev>-<target>.tar.gz from source natively
 	# CADRUM_BUNDLE_RUNTIME=1 で OCCT lib dir に libstdc++.a / libgcc.a / libgcc_eh.a を libcadrum_* として同梱し、ホスト側 GCC との ABI 不整合を回避する (#89 / #147 対策)。
 	# pipefail is required so tee's exit code does not mask a cargo build failure
 	bash -c "set -o pipefail && CADRUM_BUNDLE_RUNTIME=1 cargo build --example 01_primitives --release --features source 2>&1 | tee out/log.txt"
-	find $(CARGO_TARGET_DIR) -maxdepth 1 -type d -name 'occt*' | xargs -IX sh -c 'tar -czf out/$$(basename X).tar.gz -C $$(dirname X) $$(basename X)'
+	find $(or $(CARGO_TARGET_DIR),target) -maxdepth 1 -type d -name 'occt*' | xargs -IX sh -c 'tar -czf out/$$(basename X).tar.gz -C $$(dirname X) $$(basename X)'
 cadrum: generate # output out/libocct-<rev>-<target>-cadrum-<version>.a (wrapper compiled against the RELEASED prebuilt OCCT)
 	# cargo clean wipes any source-built OCCT cache (from `make occt`) so build.rs is
 	# forced down the prebuilt path: it downloads the RELEASED prebuilt OCCT and compiles
@@ -44,7 +40,7 @@ cadrum: generate # output out/libocct-<rev>-<target>-cadrum-<version>.a (wrapper
 	# so does this recipe -- never silently build/stage an archive against a missing/stale OCCT.
 	cargo clean
 	cargo build --example 01_primitives --release
-	find $(CARGO_TARGET_DIR) -name 'libocct-*-cadrum*.a' -exec cp {} out/ \;
+	find $(or $(CARGO_TARGET_DIR),target) -name 'libocct-*-cadrum*.a' -exec cp {} out/ \;
 cross-%: # run `make $(GOAL)` for target % inside its Docker cross env. GOAL is required. Source is bind-mounted at run time (image is a project-agnostic toolchain); CARGO_TARGET_DIR is redirected into the container (/tmp/target) so the build never touches/pollutes the host target/, and outputs still land in out/<target>/.
 	@test -n "$(GOAL)" || { echo "GOAL is required: make cross-$* GOAL=occt|cadrum"; exit 1; }
 	docker build -f docker/Dockerfile_$(*) -t cross-$(*) .

--- a/makefile
+++ b/makefile
@@ -1,4 +1,8 @@
 PATH_DOCS=out/markdown
+# Cargo's build dir. Defaults to `target`; the `cross-%` Docker recipe overrides it
+# (via `docker run -e`) to an in-container path so a bind-mounted source tree's build
+# stays isolated from the host `target/`. Recipes that locate build outputs use this var.
+CARGO_TARGET_DIR ?= target
 generate: # prepare for deploy
 	mkdir -p out
 	find . -maxdepth 1 -name .gitignore | xargs -IX sed '/^#\s*EOF_DOCKERIGNORE.*/q' X > .dockerignore
@@ -31,7 +35,7 @@ occt: generate # output out/occt-<rev>-<target>.tar.gz from source natively
 	# CADRUM_BUNDLE_RUNTIME=1 で OCCT lib dir に libstdc++.a / libgcc.a / libgcc_eh.a を libcadrum_* として同梱し、ホスト側 GCC との ABI 不整合を回避する (#89 / #147 対策)。
 	# pipefail is required so tee's exit code does not mask a cargo build failure
 	bash -c "set -o pipefail && CADRUM_BUNDLE_RUNTIME=1 cargo build --example 01_primitives --release --features source 2>&1 | tee out/log.txt"
-	find target -maxdepth 1 -type d -name 'occt*' | xargs -IX sh -c 'tar -czf out/$$(basename X).tar.gz -C $$(dirname X) $$(basename X)'
+	find $(CARGO_TARGET_DIR) -maxdepth 1 -type d -name 'occt*' | xargs -IX sh -c 'tar -czf out/$$(basename X).tar.gz -C $$(dirname X) $$(basename X)'
 cadrum: generate # output out/libocct-<rev>-<target>-cadrum-<version>.a (wrapper compiled against the RELEASED prebuilt OCCT)
 	# cargo clean wipes any source-built OCCT cache (from `make occt`) so build.rs is
 	# forced down the prebuilt path: it downloads the RELEASED prebuilt OCCT and compiles
@@ -40,11 +44,11 @@ cadrum: generate # output out/libocct-<rev>-<target>-cadrum-<version>.a (wrapper
 	# so does this recipe -- never silently build/stage an archive against a missing/stale OCCT.
 	cargo clean
 	cargo build --example 01_primitives --release
-	find target -name 'libocct-*-cadrum*.a' -exec cp {} out/ \;
-cross-%: # run `make $(GOAL)` for target % inside its Docker cross env (out/<target>/ is the mount). GOAL is required.
+	find $(CARGO_TARGET_DIR) -name 'libocct-*-cadrum*.a' -exec cp {} out/ \;
+cross-%: # run `make $(GOAL)` for target % inside its Docker cross env. GOAL is required. Source is bind-mounted at run time (image is a project-agnostic toolchain); CARGO_TARGET_DIR is redirected into the container (/tmp/target) so the build never touches/pollutes the host target/, and outputs still land in out/<target>/.
 	@test -n "$(GOAL)" || { echo "GOAL is required: make cross-$* GOAL=occt|cadrum"; exit 1; }
 	docker build -f docker/Dockerfile_$(*) -t cross-$(*) .
-	docker run --rm -v $(PWD)/out/$(*):/src/out cross-$(*) make $(GOAL)
+	docker run --rm -v $(PWD):/src -w /src -e CARGO_TARGET_DIR=/tmp/target -v $(PWD)/out/$(*):/src/out cross-$(*) make $(GOAL)
 check-%: # validate the cross-built prebuilt OCCT runs on the host (extract -> run example / wasm check)
 	$(MAKE) cross-$* GOAL=occt
 	mkdir -p target


### PR DESCRIPTION
## What

Switch the four cross-build Docker images (`docker/Dockerfile_{aarch64-unknown-linux-gnu,wasm32-unknown-unknown,x86_64-pc-windows-gnu,x86_64-unknown-linux-gnu}`) from baking the repo in with `COPY . /src` to **bind-mounting the source at `docker run` time**, and isolate the cargo `target/` from the host tree.

## Why

These Dockerfiles never compile anything at image-build time — the real build runs at `docker run` via `make $(GOAL)`. So `COPY . /src` only existed to expose the source to the run-time `make`. Replacing it with a runtime bind mount makes each image a **project-agnostic toolchain**: source changes no longer rebuild the image (the ~361 MB context transfer + COPY layer disappear), and the same image can later be published for end users to wasm-compile their own projects (`docker run -v $PWD:/work ...`).

## How

- Drop `WORKDIR /src` + `COPY . /src` from all four cross Dockerfiles.
- `makefile cross-%`: mount the repo (`-v $(PWD):/src -w /src`) and redirect `CARGO_TARGET_DIR=/tmp/target` (via `docker run -e`) so the container's build writes to its own overlayfs, never touching/colliding with the host `target/`. Recipes (`occt`, `cadrum`) locate build outputs through `$(CARGO_TARGET_DIR)` (defaults to `target` for local runs). Outputs still land in `out/<target>/`.

> Note: an anonymous volume over `/src/target` was tried first but `cargo clean` cannot remove a mount-point directory (EBUSY); the `CARGO_TARGET_DIR` redirect avoids that entirely.

## Verification

`make cross-wasm32-unknown-unknown GOAL=cadrum`:
- ✅ `out/wasm32-unknown-unknown/libocct-8_0_0_rev3-wasm32_unknown_unknown-cadrum-0_8_12.a` regenerated (442,928 bytes, same as before), exit 0, no warnings.
- ✅ host `target/` untouched (container used `/tmp/target`).
- ✅ `docker build` fully CACHED — no source-dependent layer remains.

`Dockerfile_wasm-clang` is unaffected (already has no `COPY`).

---

## 概要（日本語）

cross ビルド用4 Dockerfile を `COPY . /src` から **実行時 bind マウント**へ切り替え、cargo の `target/` をホストツリーから隔離する。

これらの Dockerfile はイメージビルド時にコンパイルしない（実ビルドは `docker run` 時の `make`）ため、`COPY` は「実行時 `make` にソースを見せる」だけの役割だった。bind マウント化でイメージが**プロジェクト非依存のツールチェイン**になり、ソース変更でイメージ再ビルドが不要になる（将来エンドユーザーが自分のプロジェクトを wasm 化するための公開イメージにも転用できる）。

`makefile cross-%` でリポジトリをマウントしつつ `CARGO_TARGET_DIR=/tmp/target` をコンテナへ注入し、ホスト `target/` と衝突・汚染しないようにした。出力は従来どおり `out/<target>/`。（匿名ボリューム案は `cargo clean` がマウントポイントを消せず EBUSY になるため不採用。）