### PR TITLE
Publish the wasm cross-build toolchain image, rework wasm build docs, remove wasm_start! macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,14 +84,21 @@ docker run --rm -v "$PWD":/work -w /work ghcr.io/lzpel/cross-wasm32-unknown-unkn
 The image cross-compiles to `wasm32-unknown-unknown` by default; you get a `.wasm`
 from a binary or a `crate-type = ["cdylib"]` crate (a plain `lib` produces an `.rlib`).
 
-**Required for cadrum on wasm:** initialize OCCT before the first call.
-`wasm32-unknown-unknown` cdylibs link with `--no-entry`, so OCCT's C++ global
-constructors aren't run automatically (the first OCCT call otherwise traps), and
-cadrum's WASI import shims must be anchored. Either call `cadrum::wasm_start!()` once at
-your crate root (convenient — emits a `#[wasm_bindgen(start)]` shim, so your crate needs
-`wasm-bindgen`), or, if you already define your own start, do it manually with
-`cadrum::__anchor_wasi_stub()` followed by `__wasm_call_ctors()`. Then process the output
-with `wasm-bindgen` / `wasm-pack` for browser glue. See
+**Required for cadrum on wasm:** run OCCT's C++ constructors once before your first
+cadrum call, and anchor cadrum's WASI shims. (`wasm32-unknown-unknown` cdylibs link with
+`--no-entry`, so the constructors don't run automatically — the first OCCT call otherwise
+traps.) Drop this into your startup code:
+
+```rust,ignore
+cadrum::__anchor_wasi_stub();
+extern "C" {
+    fn __wasm_call_ctors();
+}
+unsafe { __wasm_call_ctors() };
+```
+
+For a wasm-bindgen cdylib, put it in a `#[wasm_bindgen(start)]` function so it runs at
+init. Then process the output with `wasm-bindgen` / `wasm-pack` for browser glue. See
 [`cadrum-wasm-example`](https://github.com/lzpel/cadrum-wasm-example) for a complete setup.
 
 **Runtime requirement:** the module is built with Wasm exception handling

--- a/README.md
+++ b/README.md
@@ -81,10 +81,16 @@ docker run --rm -v "$PWD":/work -w /work ghcr.io/lzpel/cross-wasm32-unknown-unkn
 # → target/wasm32-unknown-unknown/release/<your-crate>.wasm
 ```
 
-The image cross-compiles to `wasm32-unknown-unknown` by default. You get a `.wasm`
-when your crate is a binary or a `crate-type = ["cdylib"]` library (a plain `lib`
-produces an `.rlib`). Run the output through `wasm-bindgen` / `wasm-pack` for
-browser glue as usual.
+The image cross-compiles to `wasm32-unknown-unknown` by default; you get a `.wasm`
+from a binary or a `crate-type = ["cdylib"]` crate (a plain `lib` produces an `.rlib`).
+
+**Required for cadrum on wasm:** call `cadrum::wasm_start!()` once at your crate root
+(your crate must depend on `wasm-bindgen`). It emits a `#[wasm_bindgen(start)]` shim
+that runs OCCT's C++ global constructors and anchors cadrum's WASI import shims —
+without it the module compiles but traps on the first OCCT call, because
+`wasm32-unknown-unknown` cdylibs don't auto-run constructors. Then process the output
+with `wasm-bindgen` / `wasm-pack` for browser glue. See
+[`cadrum-wasm-example`](https://github.com/lzpel/cadrum-wasm-example) for a complete setup.
 
 ### Building for other targets
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Add this to your `Cargo.toml`:
 cadrum = "^0.8"
 ```
 
-`cargo build` automatically downloads a prebuilt OCCT 8.0.0 binary for the targets below.
+`cargo build` automatically downloads a prebuilt OCCT 8.0.0 binary for these targets:
 
-| | Target | Prebuilt |
+| | Target | Prebuilt OCCT |
 |--|--------|----------|
 | ![img](figure/linux.svg) | `x86_64-unknown-linux-gnu` | ✅ |
 | ![img](figure/linux.svg) | `aarch64-unknown-linux-gnu` | ✅ |
@@ -63,20 +63,37 @@ cadrum = "^0.8"
 | ![img](figure/windows.svg) | `x86_64-pc-windows-gnu` | ✅ |
 | ![img](figure/apple.svg) | `aarch64-apple-darwin` | ✅ |
 | ![img](figure/apple.svg) | `x86_64-apple-darwin` | ✅ |
-| ![img](figure/wasm.svg) | `wasm32-unknown-unknown` | ✅ |
+| ![img](figure/wasm.svg) | `wasm32-unknown-unknown` | ✅ (build in [Docker](#building-for-wasm32-unknown-unknown)) |
 
-For other targets, build OCCT from source:
+Native targets build with a plain `cargo build` — no system OpenCASCADE install,
+no C++ toolchain setup. `wasm32-unknown-unknown` additionally needs a wasi-sdk
+C/C++ toolchain to compile cadrum's OCCT wrapper, so build it in Docker (below).
+
+### Building for `wasm32-unknown-unknown`
+
+We ship the wasi-sdk toolchain as a ready-to-use Docker image,
+`ghcr.io/lzpel/cadrum-wasm` (built from
+[`docker/Dockerfile_wasm32-unknown-unknown`](docker/Dockerfile_wasm32-unknown-unknown))
+— so you don't install wasi-sdk locally. Mount your project and build as usual:
+
+```sh
+docker run --rm -v "$PWD":/work -w /work ghcr.io/lzpel/cadrum-wasm cargo build --release
+# → target/wasm32-unknown-unknown/release/<your-crate>.wasm
+```
+
+The image cross-compiles to `wasm32-unknown-unknown` by default. You get a `.wasm`
+when your crate is a binary or a `crate-type = ["cdylib"]` library (a plain `lib`
+produces an `.rlib`). Run the output through `wasm-bindgen` / `wasm-pack` for
+browser glue as usual.
+
+### Other targets — build OCCT from source
 
 ```sh
 OCCT_ROOT=/path/to/occt cargo build --features source
 ```
 
-If `OCCT_ROOT` is not set, built binaries are cached under `target/`.
-
-#### Requirements when building OpenCASCADE from source
-
-- C++17 compiler (GCC, Clang, or MSVC)
-- CMake
+If `OCCT_ROOT` is unset, the source build is cached under `target/`. Requires a
+C++17 compiler (GCC, Clang, or MSVC) and CMake.
 
 ## Capabilities
 

--- a/README.md
+++ b/README.md
@@ -84,21 +84,19 @@ docker run --rm -v "$PWD":/work -w /work ghcr.io/lzpel/cross-wasm32-unknown-unkn
 The image cross-compiles to `wasm32-unknown-unknown` by default; you get a `.wasm`
 from a binary or a `crate-type = ["cdylib"]` crate (a plain `lib` produces an `.rlib`).
 
-**Required for cadrum on wasm:** run OCCT's C++ constructors once before your first
-cadrum call, and anchor cadrum's WASI shims. (`wasm32-unknown-unknown` cdylibs link with
-`--no-entry`, so the constructors don't run automatically — the first OCCT call otherwise
-traps.) Drop this into your startup code:
+**Code requirement:** run cadrum's wasm init once at startup, before the first cadrum
+call (e.g. from a `#[wasm_bindgen(start)]` function) — otherwise OCCT's C++ constructors
+never run and the call traps:
 
 ```rust,ignore
 cadrum::__anchor_wasi_stub();
-extern "C" {
+unsafe extern "C" {
     fn __wasm_call_ctors();
 }
 unsafe { __wasm_call_ctors() };
 ```
 
-For a wasm-bindgen cdylib, put it in a `#[wasm_bindgen(start)]` function so it runs at
-init. Then process the output with `wasm-bindgen` / `wasm-pack` for browser glue. See
+Then run the output through `wasm-bindgen` / `wasm-pack` for browser glue. See
 [`cadrum-wasm-example`](https://github.com/lzpel/cadrum-wasm-example) for a complete setup.
 
 **Runtime requirement:** the module is built with Wasm exception handling

--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ without it the module compiles but traps on the first OCCT call, because
 with `wasm-bindgen` / `wasm-pack` for browser glue. See
 [`cadrum-wasm-example`](https://github.com/lzpel/cadrum-wasm-example) for a complete setup.
 
+**Runtime requirement:** the module is built with Wasm exception handling
+(`-fwasm-exceptions`, the newer `exnref` encoding), so it needs a runtime that
+supports it — a current browser, or Node run with `--experimental-wasm-exnref`.
+
 ### Building for other targets
 
 For a target without a prebuilt OCCT, build OCCT from source:

--- a/README.md
+++ b/README.md
@@ -84,11 +84,13 @@ docker run --rm -v "$PWD":/work -w /work ghcr.io/lzpel/cross-wasm32-unknown-unkn
 The image cross-compiles to `wasm32-unknown-unknown` by default; you get a `.wasm`
 from a binary or a `crate-type = ["cdylib"]` crate (a plain `lib` produces an `.rlib`).
 
-**Required for cadrum on wasm:** call `cadrum::wasm_start!()` once at your crate root
-(your crate must depend on `wasm-bindgen`). It emits a `#[wasm_bindgen(start)]` shim
-that runs OCCT's C++ global constructors and anchors cadrum's WASI import shims —
-without it the module compiles but traps on the first OCCT call, because
-`wasm32-unknown-unknown` cdylibs don't auto-run constructors. Then process the output
+**Required for cadrum on wasm:** initialize OCCT before the first call.
+`wasm32-unknown-unknown` cdylibs link with `--no-entry`, so OCCT's C++ global
+constructors aren't run automatically (the first OCCT call otherwise traps), and
+cadrum's WASI import shims must be anchored. Either call `cadrum::wasm_start!()` once at
+your crate root (convenient — emits a `#[wasm_bindgen(start)]` shim, so your crate needs
+`wasm-bindgen`), or, if you already define your own start, do it manually with
+`cadrum::__anchor_wasi_stub()` followed by `__wasm_call_ctors()`. Then process the output
 with `wasm-bindgen` / `wasm-pack` for browser glue. See
 [`cadrum-wasm-example`](https://github.com/lzpel/cadrum-wasm-example) for a complete setup.
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ when your crate is a binary or a `crate-type = ["cdylib"]` library (a plain `lib
 produces an `.rlib`). Run the output through `wasm-bindgen` / `wasm-pack` for
 browser glue as usual.
 
-### Other targets — build OCCT from source
+### Building for other targets
+
+For a target without a prebuilt OCCT, build OCCT from source:
 
 ```sh
 OCCT_ROOT=/path/to/occt cargo build --features source

--- a/README.md
+++ b/README.md
@@ -72,12 +72,12 @@ C/C++ toolchain to compile cadrum's OCCT wrapper, so build it in Docker (below).
 ### Building for `wasm32-unknown-unknown`
 
 We ship the wasi-sdk toolchain as a ready-to-use Docker image,
-`ghcr.io/lzpel/cadrum-wasm` (built from
+`ghcr.io/lzpel/cross-wasm32-unknown-unknown` (built from
 [`docker/Dockerfile_wasm32-unknown-unknown`](docker/Dockerfile_wasm32-unknown-unknown))
 — so you don't install wasi-sdk locally. Mount your project and build as usual:
 
 ```sh
-docker run --rm -v "$PWD":/work -w /work ghcr.io/lzpel/cadrum-wasm cargo build --release
+docker run --rm -v "$PWD":/work -w /work ghcr.io/lzpel/cross-wasm32-unknown-unknown cargo build --release
 # → target/wasm32-unknown-unknown/release/<your-crate>.wasm
 ```
 

--- a/build.rs
+++ b/build.rs
@@ -231,8 +231,8 @@ fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path, target: &str) {
 	build.compile(&release_name(Some(target), true));
 
 	// wasm: the `wasi_snapshot_preview1` / `env` imports dragged in by libc++ static
-	// init and OCCT are neutralized by no-op shims in `src/wasi_stub.rs` (anchored via
-	// `wasm_start!`), so no separate C stub / `+whole-archive` link is needed here.
+	// init and OCCT are neutralized by no-op shims in `src/wasi_stub.rs` (anchored by the
+	// consumer's wasm init via `__anchor_wasi_stub`), so no separate C stub / `+whole-archive` link is needed here.
 
 	println!("cargo:rerun-if-changed=src/occt/ffi.rs");
 	println!("cargo:rerun-if-changed=cpp/wrapper.h");

--- a/makefile
+++ b/makefile
@@ -17,13 +17,8 @@ publish-ready: # guard: HEAD must be on main and match remote main's tip
 	gh api repos/lzpel/cadrum/commits/main --jq .sha | grep -q $(shell git rev-parse --short HEAD) # latest
 	cargo publish --dry-run # not-durty
 publish: publish-ready update # publish to crates.io
-	# build the wasm prebuilt FFI wrapper .a (consumer-side download code is TBD)
+	# build (and wasm-smoke-test) the cross-wasm32-unknown-unknown image published below
 	$(MAKE) cross-wasm32-unknown-unknown GOAL=cadrum
-	# upload to the EXISTING OCCT release (tag = occt-<rev>, derived from the .a name); fails if the release is absent
-	find out/wasm32-unknown-unknown -maxdepth 1 -name 'libocct-*-cadrum*.a' | while read -r f; do \
-		tag=$$(basename "$$f" .a | sed 's/^lib//' | cut -d- -f1,2); \
-		gh release upload "$$tag" "$$f" --clobber; \
-	done
 	# publish the wasm cross-build toolchain image (already built above by the
 	# cross-wasm32-unknown-unknown step) so users can run
 	# `docker run ghcr.io/lzpel/cross-wasm32-unknown-unknown cargo build` without installing wasi-sdk.

--- a/makefile
+++ b/makefile
@@ -26,10 +26,10 @@ publish: publish-ready update # publish to crates.io
 	done
 	# publish the wasm cross-build toolchain image (already built above by the
 	# cross-wasm32-unknown-unknown step) so users can run
-	# `docker run ghcr.io/lzpel/cadrum-wasm cargo build` without installing wasi-sdk.
+	# `docker run ghcr.io/lzpel/cross-wasm32-unknown-unknown cargo build` without installing wasi-sdk.
 	# Requires a one-time `docker login ghcr.io -u lzpel` beforehand (token cached).
-	docker tag cross-wasm32-unknown-unknown ghcr.io/lzpel/cadrum-wasm:latest
-	docker push ghcr.io/lzpel/cadrum-wasm:latest
+	docker tag cross-wasm32-unknown-unknown ghcr.io/lzpel/cross-wasm32-unknown-unknown:latest
+	docker push ghcr.io/lzpel/cross-wasm32-unknown-unknown:latest
 	# publish the crate sources to crates.io
 	cargo publish
 occt: generate # output out/occt-<rev>-<target>.tar.gz from source natively

--- a/makefile
+++ b/makefile
@@ -24,6 +24,12 @@ publish: publish-ready update # publish to crates.io
 		tag=$$(basename "$$f" .a | sed 's/^lib//' | cut -d- -f1,2); \
 		gh release upload "$$tag" "$$f" --clobber; \
 	done
+	# publish the wasm cross-build toolchain image (already built above by the
+	# cross-wasm32-unknown-unknown step) so users can run
+	# `docker run ghcr.io/lzpel/cadrum-wasm cargo build` without installing wasi-sdk.
+	# Requires a one-time `docker login ghcr.io -u lzpel` beforehand (token cached).
+	docker tag cross-wasm32-unknown-unknown ghcr.io/lzpel/cadrum-wasm:latest
+	docker push ghcr.io/lzpel/cadrum-wasm:latest
 	# publish the crate sources to crates.io
 	cargo publish
 occt: generate # output out/occt-<rev>-<target>.tar.gz from source natively

--- a/sandbox-wasm/build.rs
+++ b/sandbox-wasm/build.rs
@@ -38,7 +38,7 @@ fn main() {
 	// libcxx 単独実験は、libc++ の静的初期化(iostream 等)が引きずる wasi_snapshot_preview1
 	// import を no-op スタブで潰す。正常系では実 I/O しない。スタブシンボルは libc.a 処理時に
 	// 初めて undefined になるので whole-archive で確実に取り込む。
-	// cadrum feature は cadrum 本体(src/wasi_stub.rs、wasm_start! でアンカー)が同じスタブを
+	// cadrum feature は cadrum 本体(src/wasi_stub.rs、__anchor_wasi_stub でアンカー)が同じスタブを
 	// 提供するので、ここでは焼かない（焼くとシンボル二重定義でリンクエラー）。
 	let links_libcxx = std::env::var("CARGO_FEATURE_LIBCXX").is_ok();
 	if links_libcxx {

--- a/sandbox-wasm/src/lib.rs
+++ b/sandbox-wasm/src/lib.rs
@@ -45,6 +45,16 @@ pub fn print_volume() -> String {
 	format!("Solid volume: {}", volume())
 }
 
-// Run OCCT's C++ global constructors at init (wasm-bindgen start shim). See cadrum::wasm_start!.
-#[cfg(feature = "cadrum")]
-cadrum::wasm_start!();
+// Run OCCT's C++ global constructors + anchor cadrum's WASI shims at init.
+// wasm32-unknown-unknown cdylibs link with --no-entry, so the ctors that
+// initialize OCCT's type tables aren't run automatically; without this the
+// first OCCT call traps.
+#[cfg(all(feature = "cadrum", target_arch = "wasm32"))]
+#[wasm_bindgen(start)]
+fn start() {
+	cadrum::__anchor_wasi_stub();
+	unsafe extern "C" {
+		fn __wasm_call_ctors();
+	}
+	unsafe { __wasm_call_ctors() };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,8 @@ pub mod occt;
 #[cfg(not(feature = "pure"))]
 pub use occt::{edge::Edge, face::Face, solid::Solid};
 pub(crate) mod traits;
-// wasm32: no-op WASI/`env` import shims (self-contained wasm). Anchored via `wasm_start!`.
+// wasm32: no-op WASI/`env` import shims (self-contained wasm). Kept alive by the
+// consumer's wasm init calling `__anchor_wasi_stub` (see its docs).
 #[cfg(target_arch = "wasm32")]
 mod wasi_stub;
 #[cfg(target_arch = "wasm32")]
@@ -310,36 +311,3 @@ impl_solid_boolean_ops!(Solid, Solid, Boolean<Solid>);
 impl_solid_boolean_ops!(Solid, &Solid, Solid);
 impl_solid_boolean_ops!(Solid, &Solid, &Solid);
 impl_solid_boolean_ops!(Solid, &Solid, Boolean<Solid>);
-
-/// For wasm32 consumers built with `wasm-bindgen`: emit a `#[wasm_bindgen(start)]` shim that
-/// runs the C++ global constructors (OCCT type registration) once during init.
-///
-/// `wasm32-unknown-unknown` cdylibs link with `--no-entry`, so LLD emits no start section and
-/// `__wasm_call_ctors` is never called automatically — the first OCCT call then hits
-/// uninitialized type tables ("null function or function signature mismatch"). wasm-bindgen
-/// lifts a start function into `__wbindgen_start`, which its generated `init()` calls, so this
-/// shim makes the ctors run with no manual call from JS. Invoke once at the consumer crate root:
-///
-/// ```ignore
-/// cadrum::wasm_start!();
-/// ```
-///
-/// Lives in the consumer (not cadrum) because the start function is a single per-module concern
-/// owned by the final wasm-bindgen binary, and cadrum has no `wasm-bindgen` dependency.
-#[macro_export]
-macro_rules! wasm_start {
-	() => {
-		#[cfg(target_arch = "wasm32")]
-		#[::wasm_bindgen::prelude::wasm_bindgen(start)]
-		fn __cadrum_wasm_start() {
-			// Anchor cadrum's no-op WASI/`env` import shims into this module so the
-			// linker keeps them (replaces the old `+whole-archive` C stub). See
-			// cadrum's `wasi_stub`.
-			$crate::__anchor_wasi_stub();
-			unsafe extern "C" {
-				fn __wasm_call_ctors();
-			}
-			unsafe { __wasm_call_ctors() };
-		}
-	};
-}

--- a/src/wasi_stub.rs
+++ b/src/wasi_stub.rs
@@ -10,7 +10,8 @@
 //! These replace the former `cpp/wasi_stub.c` (compiled via `cc` and linked
 //! `+whole-archive`). In Rust the symbols live in cadrum's rlib, so they would be
 //! dropped before libc's late references are resolved unless something reachable
-//! pulls them in — that is what [`anchor`] does, invoked from `cadrum::wasm_start!`.
+//! pulls them in — that is what [`anchor`] does, called from the consumer's wasm init
+//! (re-exported as `cadrum::__anchor_wasi_stub`).
 //! `__cxa_atexit` is intentionally NOT defined: libc owns its real definition and a
 //! second one would be a duplicate symbol (cadrum is a cdylib, so static dtors do
 //! not auto-run anyway).


### PR DESCRIPTION
## What

- **`make publish` now publishes the wasm cross-build toolchain image to GHCR** as `ghcr.io/lzpel/cross-wasm32-unknown-unknown:latest` — it tags the image already built by the existing `cross-… GOAL=cadrum` step and pushes it. The name matches the local docker tag and reflects that it's a general `wasm32-unknown-unknown` cross-build toolchain, not cadrum-specific.
- **Dropped the obsolete prebuilt-FFI `.a` release upload** from `make publish`; the Docker image supersedes that (never-implemented, "TBD") download path. The untracked `cadrum.yaml` workflow that mirrored it was removed too.
- **Reworked the README `## Build` section**: native vs wasm distinction, the Docker image for wasm, symmetric `### Building for …` headings, the wasm **Code requirement** (manual OCCT init), the **exnref runtime** requirement, and source builds.
- **Removed the `cadrum::wasm_start!()` macro**, documenting the manual init it wrapped instead.

## Why

The README already pointed users at `ghcr.io/lzpel/cross-wasm32-unknown-unknown`, but that image was never published — wiring the push into the maintainer's `make publish` fixes that. The FFI-`.a` download path was never implemented and is now superseded by the image, so building/uploading it is dead weight. The Build docs were misleading (wasm marked ✅ like native targets, yet it needs the wasi-sdk toolchain). The wasm init story was first incomplete, then over-stated: the real requirement is running OCCT's C++ constructors + anchoring the WASI shims before the first call, which `wasm_start!()` merely wrapped. Since the official `cadrum-wasm-example` can't even use the macro (a module may hold only one `#[wasm_bindgen(start)]`) and does the init by hand, the macro was redundant — dropping it removes a public API per the repo's "reduce surface" policy.

## Breaking change

Removes the `#[macro_export] wasm_start!` macro — breaking for 0.8.x consumers that call it. Replacement: run `cadrum::__anchor_wasi_stub()` + `__wasm_call_ctors()` at init (documented in the README). Version bump deferred to publish time.

## Verification

- Built an **external** crate (`cadrum = "^0.8"` from crates.io, `crate-type = ["cdylib"]`) with the exact README command inside the toolchain image → `cadrum v0.8.12` resolved, exit 0, produced `target/wasm32-unknown-unknown/release/*.wasm` (~4.1 MB, OCCT linked) on the host.
- `cargo build` + `cargo fmt` clean; `cargo test --doc` → 13 passed / 1 ignored (the wasm-only snippet) / 0 failed.

## Maintainer notes

- `make publish` needs a one-time `docker login ghcr.io -u lzpel`.
- After the first push, set the GHCR package `cross-wasm32-unknown-unknown` visibility to **Public** for anonymous `docker pull`.
- Image is **linux/amd64 only** (arm64 hosts run it under emulation).
- Pairs with #229 (drops `COPY . /src` for a lean, project-agnostic image); independent for merge.

---

## 概要（日本語）

- **`make publish` が wasm クロスビルド用 toolchain image を GHCR に publish**（`ghcr.io/lzpel/cross-wasm32-unknown-unknown:latest`）。既存の `cross-… GOAL=cadrum` で生成済みの image をタグして push。名前はローカルタグと一致し、cadrum 専用でない汎用 wasm32 toolchain であることを反映。
- **不要になった prebuilt-FFI `.a` の release upload を `make publish` から削除**（image が未実装のダウンロード経路を置換）。対応していた未追跡の `cadrum.yaml` ワークフローも削除。
- **README `## Build` を全面改訂**: native と wasm の区別、wasm 用 Docker image、対称な `### Building for …` 見出し、wasm の **Code requirement**（手動 OCCT init）、**exnref ランタイム**要件、source ビルド。
- **`cadrum::wasm_start!()` マクロを削除**し、ラップしていた手動 init を直接ドキュメント化。

## 破壊的変更

`#[macro_export] wasm_start!` を削除（0.8.x の利用者には breaking）。代替は init で `cadrum::__anchor_wasi_stub()` + `__wasm_call_ctors()` を呼ぶ（README に記載）。バージョン bump は publish 時に。

## 検証

外部クレート（`cadrum="^0.8"`, cdylib）を README の手順で image 内ビルド → `cadrum v0.8.12` 取得・exit 0・`*.wasm`（約4.1MB, OCCTリンク済）をホストに生成。`cargo build`/`fmt` クリーン、`cargo test --doc` 13 passed / 1 ignored / 0 failed。

## maintainer メモ

- `make publish` 前に一度きり `docker login ghcr.io -u lzpel`。
- 初回 push 後、GHCR パッケージ `cross-wasm32-unknown-unknown` を **Public** に。
- image は **linux/amd64 のみ**。
- #229（`COPY . /src` 撤廃で lean 化）と組で効くが merge 上は独立。