### PR TITLE
Slim cross-build toolchain images (wasm32 on debian-slim, drop unused git)

### DIFF
--- a/docker/Dockerfile_wasm32-unknown-unknown
+++ b/docker/Dockerfile_wasm32-unknown-unknown
@@ -1,20 +1,27 @@
 # Prebuild OCCT for wasm32-unknown-unknown via the Linux wasi-sdk (clang + wasi-sysroot).
 #
-# manylinux_2_28 ships gcc (C++17 capable), cmake, make, curl, and git out of the
-# box. Rust is NOT bundled, so we install it via rustup.
-#
 # The wasm output is produced by the wasi-sdk clang, so the host image is
-# irrelevant to the result. HOST build-dependencies use the image's gcc; the
-# wasm TARGET (OCCT cmake + cxx-build) uses the wasi-sdk clang found first on PATH.
+# irrelevant to the result: nothing built against the host glibc is shipped (only
+# the .wasm / OCCT static libraries are), so we use the small debian-slim base
+# rather than manylinux. HOST build-dependencies use the image's gcc; the wasm
+# TARGET (OCCT cmake + cxx-build) uses the wasi-sdk clang found first on PATH.
 # The example .wasm cannot run here; the `occt` make target tolerates that via `... | tee`,
 # then tarballs the OCCT static libraries.
-FROM quay.io/pypa/manylinux_2_28_x86_64
+FROM debian:bookworm-slim
+
+# Tools manylinux used to bundle (gcc/g++ C++17 capable, cmake, make, curl) and
+# that this build needs; find/xargs/tar/sed/bash already ship in the base image.
+# ca-certificates is required for the https downloads below (wasi-sdk, rustup,
+# and the OCCT source tarball fetched by build.rs). git is intentionally omitted:
+# there are no git dependencies and OCCT sources arrive as a tarball.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl ca-certificates make cmake \
+    gcc g++ \
+    && rm -rf /var/lib/apt/lists/*
 
 # wasi-sdk (Linux): clang + prebuilt wasi-sysroot (libc / libc++, eh & noeh variants).
 # Rename the tarball's top dir to /wasi-sdk. The S/H flags keep the transform from
 # also rewriting sym/hardlink targets (e.g. bin/clang -> clang-22), which would break them.
-# NOTE: manylinux already ships a non-wasm clang at /opt/clang/bin, so /wasi-sdk/bin must
-# come first on PATH AND resolve correctly.
 RUN curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-33.0-x86_64-linux.tar.gz | tar xzv --transform="s,^[^/]+,/wasi-sdk,xSH"
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal

--- a/docker/Dockerfile_x86_64-pc-windows-gnu
+++ b/docker/Dockerfile_x86_64-pc-windows-gnu
@@ -8,7 +8,7 @@ FROM debian:bookworm-slim
 # gcc/g++: HOST compiler for build-dependencies (aws-lc-rs, ring, etc.)
 # gcc-mingw-w64-*: TARGET cross-compiler for OCCT and cxx-build
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl ca-certificates git make cmake \
+    curl ca-certificates make cmake \
     gcc g++ \
     gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 \
     && update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix \


### PR DESCRIPTION
## What

クロスビルド用ツールチェインイメージ（`docker/`、wasm-clang を除く）の軽量化。

### `Dockerfile_wasm32-unknown-unknown`: ベースを manylinux → `debian:bookworm-slim`
- このイメージが出荷するのは wasi-sdk の clang が生成する `.wasm` / OCCT 静的ライブラリのみで、**ホスト glibc に対してビルドされた成果物は出荷されない**。よって manylinux の glibc 2.28 ポータビリティはこのターゲットには不要。
- 唯一 ghcr.io に push される公開イメージのため、ベース縮小の効果が最も大きい。
- manylinux が同梱していた gcc/g++・cmake・make・curl を apt で明示インストール（`find`/`xargs`/`tar`/`sed`/`bash` は base 同梱）。
- 副次効果として、manylinux 同梱 `/opt/clang` と wasi-sdk の PATH 競合ハザードが構造的に消滅。

### `Dockerfile_x86_64-pc-windows-gnu`: 未使用の `git` を削除
- git 依存はゼロ、OCCT ソースは tarball で取得されるため `git` は不要。

`aarch64` / `x86_64-unknown-linux-gnu` は出荷静的ライブラリの glibc 2.28 ポータビリティ保証に manylinux が必要なため**変更なし**。

## Image size (実測)

`docker images` のローカル非圧縮サイズで新旧を実ビルドして比較:

| | base | 完成イメージ |
|---|---|---|
| 旧 (`quay.io/pypa/manylinux_2_28_x86_64`) | 2.16 GB | **4.02 GB** |
| 新 (`debian:bookworm-slim` + apt) | 0.12 GB | **2.44 GB** |
| 差分 | -2.04 GB | **-1.58 GB (-39%)** |

wasi-sdk(33) と Rust toolchain がイメージの大半を占めるため削減の上限はそこで頭打ちだが、ベース層だけで 1.58 GB 縮小した。

## Verification
- `make check-wasm32-unknown-unknown` … 新ベースでイメージビルド → OCCT クロスビルド → node で wasm 実行 `Solid volume: 6000`（exit 0）
- `make cross-x86_64-pc-windows-gnu GOAL=occt` … git 削除後も OCCT クロスビルド成功、tar.gz 生成（exit 0）