### PR TITLE
Drop the cxx dependency: hand-written extern "C" OCCT FFI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,12 +30,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "anstyle"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
-
-[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,8 +65,6 @@ version = "0.8.13"
 dependencies = [
  "cc",
  "cmake",
- "cxx",
- "cxx-build",
  "glam",
  "libflate",
  "minreq",
@@ -99,32 +91,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "clap"
-version = "4.5.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
-dependencies = [
- "clap_builder",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
-dependencies = [
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_lex"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
-
-[[package]]
 name = "cmake"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,85 +100,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "codespan-reporting"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
-dependencies = [
- "serde",
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "cxx"
-version = "1.0.194"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747d8437319e3a2f43d93b341c137927ca70c0f5dabeea7a005a73665e247c7e"
-dependencies = [
- "cc",
- "cxx-build",
- "cxxbridge-cmd",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "foldhash",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.194"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f4697d190a142477b16aef7da8a99bfdc41e7e8b1687583c0d23a79c7afc1e"
-dependencies = [
- "cc",
- "codespan-reporting",
- "indexmap",
- "proc-macro2",
- "quote",
- "scratch",
- "syn",
-]
-
-[[package]]
-name = "cxxbridge-cmd"
-version = "1.0.194"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0956799fa8678d4c50eed028f2de1c0552ae183c76e976cf7ca8c4e36a7c328"
-dependencies = [
- "clap",
- "codespan-reporting",
- "indexmap",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.194"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23384a836ab4f0ad98ace7e3955ad2de39de42378ab487dc28d3990392cb283a"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.194"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6acc6b5822b9526adfb4fc377b67128fdd60aac757cc4a741a6278603f763cf"
-dependencies = [
- "indexmap",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -308,16 +201,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
-dependencies = [
- "equivalent",
- "hashbrown",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,15 +240,6 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall",
-]
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f78c730aaa7d0b9336a299029ea49f9ee53b0ed06e9202e8cb7db9bae7b8c82"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -433,24 +307,6 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "1.0.106"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "quote"
-version = "1.0.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
-dependencies = [
- "proc-macro2",
 ]
 
 [[package]]
@@ -556,12 +412,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scratch"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
-
-[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,36 +419,6 @@ checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "serde"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
-dependencies = [
- "serde_core",
- "serde_derive",
-]
-
-[[package]]
-name = "serde_core"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -620,23 +440,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "syn"
-version = "2.0.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
 name = "tar"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,15 +448,6 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -681,18 +475,6 @@ dependencies = [
  "bytemuck",
  "strict-num",
 ]
-
-[[package]]
-name = "unicode-ident"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ png = ["dep:tiny-skia"]
 pure = []
 
 [dependencies]
-cxx = "1"
 glam = { version = ">=0.29", features = ["std"] }
 # Pure-Rust 2D rasterizer used by Scene2D::write_png. Pulled in only with
 # the `png` feature; tiny-skia bundles its own PNG encoder so no separate
@@ -33,7 +32,6 @@ tiny-skia = { version = "0.11", optional = true }
 
 
 [build-dependencies]
-cxx-build = "1"
 # download and extract prebuilt OCCT tarball
 minreq = { version = "2", features = ["https-rustls"] }
 libflate = "2"

--- a/build.rs
+++ b/build.rs
@@ -213,8 +213,8 @@ fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path, target: &str) {
 		println!("cargo:rustc-link-arg=-static");
 	}
 
-	let mut build = cxx_build::bridge("src/occt/ffi.rs");
-	build.file("cpp/wrapper.cpp").include(occt_include).std("c++17").define("_USE_MATH_DEFINES", None);
+	let mut build = cc::Build::new();
+	build.cpp(true).file("cpp/wrapper.cpp").include(occt_include).std("c++17").define("_USE_MATH_DEFINES", None);
 
 	apply_compiler_flags(|s| {
 		build.flag(s);
@@ -234,7 +234,7 @@ fn link_occt_libraries(occt_include: &Path, occt_lib_dir: &Path, target: &str) {
 	// init and OCCT are neutralized by no-op shims in `src/wasi_stub.rs` (anchored by the
 	// consumer's wasm init via `__anchor_wasi_stub`), so no separate C stub / `+whole-archive` link is needed here.
 
-	println!("cargo:rerun-if-changed=src/occt/ffi.rs");
+	println!("cargo:rerun-if-changed=cpp/ffi.h");
 	println!("cargo:rerun-if-changed=cpp/wrapper.h");
 	println!("cargo:rerun-if-changed=cpp/wrapper.cpp");
 }

--- a/cpp/ffi.h
+++ b/cpp/ffi.h
@@ -1,0 +1,172 @@
+#pragma once
+
+// Hand-written C ABI for the cadrum OCCT wrapper.
+//
+// This replaces the cxx-generated bridge: `wrapper.cpp` keeps its OCCT logic in
+// `namespace cadrum` (using `std::unique_ptr` / `std::vector`), and a thin
+// `extern "C"` shim layer (defined at the bottom of wrapper.cpp) marshals
+// between those C++ types and the raw pointer/length ABI declared here. The Rust
+// side declares matching `extern "C"` signatures in `src/occt/ffi.rs`.
+//
+// Ownership conventions:
+//   - `TopoDS_*` returned by value are heap objects owned by Rust; free with the
+//     matching `cadrum_*_free` (delete).
+//   - `T**` arrays and POD (`double*`/`uint32_t*`/`uint64_t*`/`float*`) buffers
+//     are allocated with `malloc`; Rust copies out then frees with `cadrum_free`.
+//     For `T**` arrays each element is an owned `TopoDS_*` (free individually).
+
+#include <cstdint>
+#include <cstddef>
+
+// OCCT topology types — only used behind pointers across the ABI, so incomplete
+// forward declarations suffice (avoids pulling heavy OCCT headers into the ABI).
+class TopoDS_Shape;
+class TopoDS_Face;
+class TopoDS_Edge;
+
+extern "C" {
+
+// ==================== Stream callbacks ====================
+// Bridge a Rust `dyn Read`/`dyn Write` into a C++ std::streambuf. `ctx` is an
+// opaque pointer to the Rust-side reader/writer; `read`/`write` is a Rust
+// trampoline with C linkage.
+typedef size_t (*cadrum_read_fn)(void* ctx, uint8_t* buf, size_t len);
+typedef size_t (*cadrum_write_fn)(void* ctx, const uint8_t* buf, size_t len);
+
+struct CReader {
+	void* ctx;
+	cadrum_read_fn read;
+};
+struct CWriter {
+	void* ctx;
+	cadrum_write_fn write;
+};
+
+// ==================== Mesh result ====================
+// POD arrays allocated with malloc (free each with cadrum_free).
+struct CMeshData {
+	double* vertices;
+	size_t vertices_len;
+	double* uvs;
+	size_t uvs_len;
+	uint32_t* indices;
+	size_t indices_len;
+	uint64_t* face_ids;
+	size_t face_ids_len;
+	bool success;
+};
+
+// ==================== Deallocators ====================
+void cadrum_free(void* p);              // free()  — POD arrays / T** arrays
+void cadrum_shape_free(TopoDS_Shape* p); // delete — owned shape
+void cadrum_face_free(TopoDS_Face* p);   // delete — owned face
+void cadrum_edge_free(TopoDS_Edge* p);   // delete — owned edge
+
+// ==================== Shape I/O (streambuf callback) ====================
+#ifndef CADRUM_COLOR
+TopoDS_Shape* read_step_stream(const CReader* reader);
+bool write_step_stream(const TopoDS_Shape* shape, const CWriter* writer);
+#endif
+TopoDS_Shape* read_brep_bin_stream(const CReader* reader);
+bool write_brep_bin_stream(const TopoDS_Shape* shape, const CWriter* writer);
+TopoDS_Shape* read_brep_text_stream(const CReader* reader);
+bool write_brep_text_stream(const TopoDS_Shape* shape, const CWriter* writer);
+
+// ==================== Shape Constructors ====================
+TopoDS_Shape* make_half_space(double ox, double oy, double oz, double nx, double ny, double nz);
+TopoDS_Shape* make_box(double x1, double y1, double z1, double x2, double y2, double z2);
+TopoDS_Shape* make_cylinder(double px, double py, double pz, double dx, double dy, double dz, double radius, double height);
+TopoDS_Shape* make_sphere(double cx, double cy, double cz, double radius);
+TopoDS_Shape* make_cone(double px, double py, double pz, double dx, double dy, double dz, double r1, double r2, double height);
+TopoDS_Shape* make_torus(double px, double py, double pz, double dx, double dy, double dz, double r1, double r2);
+TopoDS_Shape* make_empty();
+TopoDS_Shape* deep_copy(const TopoDS_Shape* shape);
+
+// ==================== Builders (solid -> solid with history) ====================
+// `out_history`/`out_history_len` receive a malloc'd flat [post_id, src_id, ...]
+// buffer (free with cadrum_free).
+TopoDS_Shape* builder_cells(const TopoDS_Shape* const* solids, size_t n_solids, const int64_t* clauses, size_t n_clauses, uint64_t** out_history, size_t* out_history_len);
+TopoDS_Shape* builder_clean(const TopoDS_Shape* shape, uint64_t** out_history, size_t* out_history_len);
+TopoDS_Shape* builder_thick_solid(const TopoDS_Shape* solid, const TopoDS_Face* const* open_faces, size_t n_faces, double thickness, uint64_t** out_history, size_t* out_history_len);
+TopoDS_Shape* builder_fillet(const TopoDS_Shape* solid, const TopoDS_Edge* const* edges, size_t n_edges, double radius, uint64_t** out_history, size_t* out_history_len);
+TopoDS_Shape* builder_chamfer(const TopoDS_Shape* solid, const TopoDS_Edge* const* edges, size_t n_edges, double distance, uint64_t** out_history, size_t* out_history_len);
+
+// ==================== Transforms (solid -> solid, no history) ====================
+TopoDS_Shape* transform_translate(const TopoDS_Shape* shape, double tx, double ty, double tz);
+TopoDS_Shape* transform_rotate(const TopoDS_Shape* shape, double ox, double oy, double oz, double dx, double dy, double dz, double angle);
+TopoDS_Shape* transform_scale(const TopoDS_Shape* shape, double cx, double cy, double cz, double factor);
+TopoDS_Shape* transform_mirror(const TopoDS_Shape* shape, double ox, double oy, double oz, double nx, double ny, double nz);
+
+// ==================== Shape Queries ====================
+bool shape_is_null(const TopoDS_Shape* shape);
+bool shape_is_solid(const TopoDS_Shape* shape);
+double shape_volume(const TopoDS_Shape* shape);
+double shape_surface_area(const TopoDS_Shape* shape);
+void shape_center_of_mass(const TopoDS_Shape* shape, double* x, double* y, double* z);
+void shape_inertia_tensor(const TopoDS_Shape* shape, double* m00, double* m01, double* m02, double* m10, double* m11, double* m12, double* m20, double* m21, double* m22);
+bool shape_contains_point(const TopoDS_Shape* shape, double x, double y, double z);
+void shape_bounding_box(const TopoDS_Shape* shape, double* xmin, double* ymin, double* zmin, double* xmax, double* ymax, double* zmax);
+
+// ==================== Compound Decompose/Compose ====================
+// Returns a malloc'd array of owned TopoDS_Shape* (free array with cadrum_free,
+// each element with cadrum_shape_free).
+TopoDS_Shape** decompose_into_solids(const TopoDS_Shape* shape, size_t* out_len);
+void compound_add(TopoDS_Shape* compound, const TopoDS_Shape* child);
+
+// ==================== Meshing ====================
+CMeshData mesh_shape(const TopoDS_Shape* shape, double linear, double angular, bool relative);
+
+// ==================== Topology enumeration ====================
+// Each returns a malloc'd array of owned handles (free array with cadrum_free,
+// each element with the matching cadrum_*_free).
+TopoDS_Edge** shape_edges(const TopoDS_Shape* shape, size_t* out_len);
+TopoDS_Face** shape_faces(const TopoDS_Shape* shape, size_t* out_len);
+TopoDS_Edge** face_edges(const TopoDS_Face* face, size_t* out_len);
+
+TopoDS_Shape* clone_shape_handle(const TopoDS_Shape* shape);
+
+// ==================== Face Methods ====================
+uint64_t face_tshape_id(const TopoDS_Face* face);
+uint64_t shape_tshape_id(const TopoDS_Shape* shape);
+uint64_t edge_tshape_id(const TopoDS_Edge* edge);
+bool face_project_point(const TopoDS_Face* face, double px, double py, double pz, double* cpx, double* cpy, double* cpz, double* nx, double* ny, double* nz);
+
+// ==================== Edge Methods ====================
+// Returns a malloc'd flat xyz buffer (free with cadrum_free).
+double* edge_approximation_segments(const TopoDS_Edge* edge, double linear, double angular, bool relative, size_t* out_len);
+
+TopoDS_Edge* make_helix_edge(double ax, double ay, double az, double xrx, double xry, double xrz, double radius, double pitch, double height);
+TopoDS_Edge** make_polygon_edges(const double* coords, size_t n_coords, size_t* out_len);
+TopoDS_Edge* make_circle_edge(double ax, double ay, double az, double radius);
+TopoDS_Edge* make_line_edge(double ax, double ay, double az, double bx, double by, double bz);
+TopoDS_Edge* make_arc_edge(double sx, double sy, double sz, double mx, double my, double mz, double ex, double ey, double ez);
+TopoDS_Edge* make_bspline_edge(const double* coords, size_t n_coords, uint32_t end_kind, double sx, double sy, double sz, double ex, double ey, double ez);
+
+void edge_endpoints(const TopoDS_Edge* edge, double* sx, double* sy, double* sz, double* ex, double* ey, double* ez);
+void edge_tangents(const TopoDS_Edge* edge, double* sx, double* sy, double* sz, double* ex, double* ey, double* ez);
+bool edge_is_closed(const TopoDS_Edge* edge);
+bool edge_project_point(const TopoDS_Edge* edge, double px, double py, double pz, double* cpx, double* cpy, double* cpz, double* tx, double* ty, double* tz);
+
+TopoDS_Edge* deep_copy_edge(const TopoDS_Edge* edge);
+TopoDS_Edge* translate_edge(const TopoDS_Edge* edge, double tx, double ty, double tz);
+TopoDS_Edge* rotate_edge(const TopoDS_Edge* edge, double ox, double oy, double oz, double dx, double dy, double dz, double angle);
+TopoDS_Edge* scale_edge(const TopoDS_Edge* edge, double cx, double cy, double cz, double factor);
+TopoDS_Edge* mirror_edge(const TopoDS_Edge* edge, double ox, double oy, double oz, double nx, double ny, double nz);
+
+// Edge collections passed in as pointer arrays; a null entry is a section
+// separator (replaces the cxx null-edge sentinel) for pipe_shell / loft.
+TopoDS_Shape* make_extrude(const TopoDS_Edge* const* profile_edges, size_t n_profile, double dx, double dy, double dz);
+TopoDS_Shape* make_pipe_shell(const TopoDS_Edge* const* all_edges, size_t n_all, const TopoDS_Edge* const* spine_edges, size_t n_spine, uint32_t orient, double ux, double uy, double uz, const TopoDS_Edge* const* aux_spine_edges, size_t n_aux);
+TopoDS_Shape* make_loft(const TopoDS_Edge* const* all_edges, size_t n_all, bool ruled);
+TopoDS_Shape* make_sewn_solid(const TopoDS_Face* const* faces, size_t n_faces, double tolerance);
+TopoDS_Shape* make_offset_shape(const TopoDS_Shape* shape, double offset, double tolerance);
+TopoDS_Shape* make_bspline_solid(const double* coords, size_t n_coords, uint32_t nu, uint32_t nv, bool u_periodic);
+
+// ==================== Colored STEP I/O (color feature only) ====================
+#ifdef CADRUM_COLOR
+// out_ids / out_rgb receive malloc'd POD buffers (free with cadrum_free).
+TopoDS_Shape* read_step_color_stream(const CReader* reader, uint64_t** out_ids, size_t* out_ids_len, float** out_rgb, size_t* out_rgb_len);
+bool write_step_color_stream(const TopoDS_Shape* shape, const uint64_t* ids, size_t n_ids, const float* rgb, size_t n_rgb, const CWriter* writer);
+#endif
+
+} // extern "C"

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -1,4 +1,4 @@
-#include "cadrum/src/occt/ffi.rs.h"
+#include "wrapper.h"
 
 // ==================== OCCT headers (impl only — not exposed via wrapper.h) ====================
 //
@@ -109,6 +109,7 @@
 #include <cmath>
 #include <cstring>
 #include <cstdint>
+#include <cstdlib>
 #include <algorithm>
 #include <unordered_map>
 #include <unordered_set>
@@ -134,9 +135,7 @@ static const int _silence_occt_default_printer = []() {
 // ==================== RustReadStreambuf ====================
 
 std::streambuf::int_type RustReadStreambuf::underflow() {
-    rust::Slice<uint8_t> slice(
-        reinterpret_cast<uint8_t*>(buf_), sizeof(buf_));
-    size_t n = rust_reader_read(reader_, slice);
+    size_t n = reader_.read(reader_.ctx, reinterpret_cast<uint8_t*>(buf_), sizeof(buf_));
     if (n == 0) return traits_type::eof();
     setg(buf_, buf_, buf_ + n);
     return traits_type::to_int_type(*gptr());
@@ -179,9 +178,7 @@ int RustWriteStreambuf::sync() {
 
 bool RustWriteStreambuf::flush_buf() {
     if (pos_ == 0) return true;
-    rust::Slice<const uint8_t> slice(
-        reinterpret_cast<const uint8_t*>(buf_), pos_);
-    size_t n = rust_writer_write(writer_, slice);
+    size_t n = writer_.write(writer_.ctx, reinterpret_cast<const uint8_t*>(buf_), pos_);
     if (n < pos_) return false;
     pos_ = 0;
     return true;
@@ -198,7 +195,7 @@ std::streambuf::pos_type RustWriteStreambuf::seekpos(pos_type, std::ios_base::op
 // With color, STEP routes through XCAF (`read_step_color_stream` /
 // `write_step_color_stream`) instead.
 
-std::unique_ptr<TopoDS_Shape> read_step_stream(RustReader& reader) {
+std::unique_ptr<TopoDS_Shape> read_step_stream(const CReader& reader) {
     RustReadStreambuf sbuf(reader);
     std::istream is(&sbuf);
 
@@ -220,7 +217,7 @@ std::unique_ptr<TopoDS_Shape> read_step_stream(RustReader& reader) {
         try_sew_orphan_faces(step_reader->OneShape(), nullptr));
 }
 
-bool write_step_stream(const TopoDS_Shape& shape, RustWriter& writer) {
+bool write_step_stream(const TopoDS_Shape& shape, const CWriter& writer) {
     RustWriteStreambuf sbuf(writer);
     std::ostream os(&sbuf);
     STEPControl_Writer step_writer;
@@ -231,7 +228,7 @@ bool write_step_stream(const TopoDS_Shape& shape, RustWriter& writer) {
 }
 #endif // !CADRUM_COLOR
 
-std::unique_ptr<TopoDS_Shape> read_brep_bin_stream(RustReader& reader) {
+std::unique_ptr<TopoDS_Shape> read_brep_bin_stream(const CReader& reader) {
     // BinTools::Read requires a seekable stream: the binary format stores
     // backward references (offsets) for shared sub-shapes and seeks to them.
     // Our RustReadStreambuf is sequential only, so buffer everything in
@@ -239,8 +236,7 @@ std::unique_ptr<TopoDS_Shape> read_brep_bin_stream(RustReader& reader) {
     std::string data;
     char buf[8192];
     for (;;) {
-        rust::Slice<uint8_t> slice(reinterpret_cast<uint8_t*>(buf), sizeof(buf));
-        size_t n = rust_reader_read(reader, slice);
+        size_t n = reader.read(reader.ctx, reinterpret_cast<uint8_t*>(buf), sizeof(buf));
         if (n == 0) break;
         data.append(buf, n);
     }
@@ -259,7 +255,7 @@ std::unique_ptr<TopoDS_Shape> read_brep_bin_stream(RustReader& reader) {
     return shape;
 }
 
-bool write_brep_bin_stream(const TopoDS_Shape& shape, RustWriter& writer) {
+bool write_brep_bin_stream(const TopoDS_Shape& shape, const CWriter& writer) {
     RustWriteStreambuf sbuf(writer);
     std::ostream os(&sbuf);
     try {
@@ -270,7 +266,7 @@ bool write_brep_bin_stream(const TopoDS_Shape& shape, RustWriter& writer) {
     return os.good();
 }
 
-std::unique_ptr<TopoDS_Shape> read_brep_text_stream(RustReader& reader) {
+std::unique_ptr<TopoDS_Shape> read_brep_text_stream(const CReader& reader) {
     RustReadStreambuf sbuf(reader);
     std::istream is(&sbuf);
 
@@ -288,7 +284,7 @@ std::unique_ptr<TopoDS_Shape> read_brep_text_stream(RustReader& reader) {
     return shape;
 }
 
-bool write_brep_text_stream(const TopoDS_Shape& shape, RustWriter& writer) {
+bool write_brep_text_stream(const TopoDS_Shape& shape, const CWriter& writer) {
     RustWriteStreambuf sbuf(writer);
     std::ostream os(&sbuf);
     try {
@@ -566,7 +562,7 @@ static void relay_from_pair(
 static void relay_into_history(
     const std::unordered_map<uint64_t, uint64_t>* relay1,
     const std::unordered_map<uint64_t, uint64_t>* relay2,
-    rust::Vec<uint64_t>& out)
+    std::vector<uint64_t>& out)
 {
     if (relay2 == nullptr) {
         for (const auto& kv : *relay1) {
@@ -587,8 +583,8 @@ static void relay_into_history(
 // 1 回の Perform() で全交差を計算し、clause ごとに AddToResult を呼ぶ。
 std::unique_ptr<TopoDS_Shape> builder_cells(
     const std::vector<TopoDS_Shape>& solids,
-    rust::Slice<const int64_t> clauses,
-    rust::Vec<uint64_t>& out_history)
+    const std::vector<int64_t>& clauses,
+    std::vector<uint64_t>& out_history)
 {
     try {
         if (solids.empty() || clauses.size() == 0) return nullptr;
@@ -652,7 +648,7 @@ std::unique_ptr<TopoDS_Shape> builder_cells(
 // `builder_boolean`'s history.
 std::unique_ptr<TopoDS_Shape> builder_clean(
     const TopoDS_Shape& shape,
-    rust::Vec<uint64_t>& out_history)
+    std::vector<uint64_t>& out_history)
 {
     try {
         ShapeUpgrade_UnifySameDomain unifier(shape, true, true, true);
@@ -945,14 +941,6 @@ std::unique_ptr<TopoDS_Shape> clone_shape_handle(const TopoDS_Shape& shape) {
     return std::make_unique<TopoDS_Shape>(shape);
 }
 
-std::unique_ptr<TopoDS_Edge> clone_edge_handle(const TopoDS_Edge& edge) {
-    return std::make_unique<TopoDS_Edge>(edge);
-}
-
-std::unique_ptr<TopoDS_Face> clone_face_handle(const TopoDS_Face& face) {
-    return std::make_unique<TopoDS_Face>(face);
-}
-
 // ==================== Face Methods ====================
 
 uint64_t face_tshape_id(const TopoDS_Face& face) {
@@ -1024,10 +1012,10 @@ bool face_project_point(const TopoDS_Face& face,
 
 // ==================== Edge Methods ====================
 
-rust::Vec<double> edge_approximation_segments(
+std::vector<double> edge_approximation_segments(
     const TopoDS_Edge& edge, double linear, double angular, bool relative)
 {
-    rust::Vec<double> out;
+    std::vector<double> out;
     try {
         // Mirror mesh_shape's relative semantics: when relative, scale the chord
         // by the edge's bounding-box max dimension (OCCT BRepMesh convention).
@@ -1096,7 +1084,7 @@ std::unique_ptr<TopoDS_Edge> make_helix_edge(
     }
 }
 
-std::unique_ptr<std::vector<TopoDS_Edge>> make_polygon_edges(rust::Slice<const double> coords) {
+std::unique_ptr<std::vector<TopoDS_Edge>> make_polygon_edges(const std::vector<double>& coords) {
     auto out = std::make_unique<std::vector<TopoDS_Edge>>();
     if (coords.size() < 9 || coords.size() % 3 != 0) return out;
     try {
@@ -1196,7 +1184,7 @@ std::unique_ptr<TopoDS_Edge> make_arc_edge(
 // Returns null on any failure (out-of-range end_kind, OCCT internal
 // failure, degenerate point distribution).
 std::unique_ptr<TopoDS_Edge> make_bspline_edge(
-    rust::Slice<const double> coords,
+    const std::vector<double>& coords,
     uint32_t end_kind,
     double sx, double sy, double sz,
     double ex, double ey, double ez)
@@ -1399,39 +1387,11 @@ std::unique_ptr<TopoDS_Edge> mirror_edge(
     }
 }
 
-std::unique_ptr<std::vector<TopoDS_Edge>> edge_vec_new() {
-    return std::make_unique<std::vector<TopoDS_Edge>>();
-}
-
-void edge_vec_push(std::vector<TopoDS_Edge>& v, const TopoDS_Edge& e) {
-    v.push_back(e);
-}
-
-void edge_vec_push_null(std::vector<TopoDS_Edge>& v) {
-    v.push_back(TopoDS_Edge());
-}
-
-std::unique_ptr<std::vector<TopoDS_Face>> face_vec_new() {
-    return std::make_unique<std::vector<TopoDS_Face>>();
-}
-
-void face_vec_push(std::vector<TopoDS_Face>& v, const TopoDS_Face& f) {
-    v.push_back(f);
-}
-
-std::unique_ptr<std::vector<TopoDS_Shape>> shape_vec_new() {
-    return std::make_unique<std::vector<TopoDS_Shape>>();
-}
-
-void shape_vec_push(std::vector<TopoDS_Shape>& v, const TopoDS_Shape& s) {
-    v.push_back(s);
-}
-
 std::unique_ptr<TopoDS_Shape> builder_thick_solid(
     const TopoDS_Shape& solid,
     const std::vector<TopoDS_Face>& open_faces,
     double thickness,
-    rust::Vec<uint64_t>& out_history)
+    std::vector<uint64_t>& out_history)
 {
     try {
         // Empty open_faces: MakeThickSolidByJoin degenerates to a plain offset
@@ -1515,7 +1475,7 @@ std::unique_ptr<TopoDS_Shape> builder_fillet(
     const TopoDS_Shape& solid,
     const std::vector<TopoDS_Edge>& edges,
     double radius,
-    rust::Vec<uint64_t>& out_history)
+    std::vector<uint64_t>& out_history)
 {
     try {
         if (edges.empty()) {
@@ -1555,7 +1515,7 @@ std::unique_ptr<TopoDS_Shape> builder_chamfer(
     const TopoDS_Shape& solid,
     const std::vector<TopoDS_Edge>& edges,
     double distance,
-    rust::Vec<uint64_t>& out_history)
+    std::vector<uint64_t>& out_history)
 {
     try {
         if (edges.empty()) {
@@ -1862,7 +1822,7 @@ std::unique_ptr<TopoDS_Shape> make_offset_shape(
 }
 
 std::unique_ptr<TopoDS_Shape> make_bspline_solid(
-    rust::Slice<const double> coords,
+    const std::vector<double>& coords,
     uint32_t nu, uint32_t nv,
     bool u_periodic)
 {
@@ -2086,9 +2046,9 @@ static void collect_face_colors(
 }
 
 std::unique_ptr<TopoDS_Shape> read_step_color_stream(
-    RustReader&          reader,
-    rust::Vec<uint64_t>& out_ids,
-    rust::Vec<float>&    out_rgb)
+    const CReader&        reader,
+    std::vector<uint64_t>& out_ids,
+    std::vector<float>&    out_rgb)
 {
     try {
         // Create XDE document directly — avoids XCAFApp_Application which
@@ -2151,10 +2111,10 @@ std::unique_ptr<TopoDS_Shape> read_step_color_stream(
 }
 
 bool write_step_color_stream(
-    const TopoDS_Shape&         shape,
-    rust::Slice<const uint64_t> ids,
-    rust::Slice<const float>    rgb,
-    RustWriter&                 writer)
+    const TopoDS_Shape&          shape,
+    const std::vector<uint64_t>& ids,
+    const std::vector<float>&    rgb,
+    const CWriter&               writer)
 {
     try {
         Handle(TDocStd_Document) doc = new TDocStd_Document("XmlXCAF");
@@ -2208,3 +2168,204 @@ bool write_step_color_stream(
 } // namespace cadrum
 
 #endif // CADRUM_COLOR
+
+// ==================== extern "C" shim layer ====================
+//
+// Thin marshaling between the raw C ABI (cpp/ffi.h, consumed by Rust) and the
+// `cadrum::` C++ functions above. Ownership: TopoDS_* returned by value are
+// `release()`d for Rust to own (freed via cadrum_*_free = delete); POD and
+// pointer arrays are malloc'd for Rust to copy out then free via cadrum_free.
+
+namespace {
+
+// Build a std::vector<T> from a pointer array; a null entry becomes a
+// default-constructed (null) element — the section separator for loft/pipe.
+template <class T>
+std::vector<T> ffi_vec_in(const T* const* p, size_t n) {
+	std::vector<T> v;
+	v.reserve(n);
+	for (size_t i = 0; i < n; ++i) v.push_back(p[i] ? *p[i] : T());
+	return v;
+}
+
+// malloc a T*[] where each element is an owned clone of v[i].
+template <class T>
+T** ffi_owned_array(const std::vector<T>& v, size_t* out_len) {
+	*out_len = v.size();
+	if (v.empty()) return nullptr;
+	T** arr = static_cast<T**>(std::malloc(sizeof(T*) * v.size()));
+	for (size_t i = 0; i < v.size(); ++i) arr[i] = new T(v[i]);
+	return arr;
+}
+
+// malloc a flat POD buffer copied from v.
+template <class T>
+T* ffi_pod_array(const std::vector<T>& v, size_t* out_len) {
+	*out_len = v.size();
+	if (v.empty()) return nullptr;
+	T* arr = static_cast<T*>(std::malloc(sizeof(T) * v.size()));
+	std::memcpy(arr, v.data(), sizeof(T) * v.size());
+	return arr;
+}
+
+} // anonymous namespace
+
+extern "C" {
+
+// ---- Deallocators ----
+void cadrum_free(void* p) { std::free(p); }
+void cadrum_shape_free(TopoDS_Shape* p) { delete p; }
+void cadrum_face_free(TopoDS_Face* p) { delete p; }
+void cadrum_edge_free(TopoDS_Edge* p) { delete p; }
+
+// ---- Shape I/O ----
+#ifndef CADRUM_COLOR
+TopoDS_Shape* read_step_stream(const CReader* reader) { return cadrum::read_step_stream(*reader).release(); }
+bool write_step_stream(const TopoDS_Shape* shape, const CWriter* writer) { return cadrum::write_step_stream(*shape, *writer); }
+#endif
+TopoDS_Shape* read_brep_bin_stream(const CReader* reader) { return cadrum::read_brep_bin_stream(*reader).release(); }
+bool write_brep_bin_stream(const TopoDS_Shape* shape, const CWriter* writer) { return cadrum::write_brep_bin_stream(*shape, *writer); }
+TopoDS_Shape* read_brep_text_stream(const CReader* reader) { return cadrum::read_brep_text_stream(*reader).release(); }
+bool write_brep_text_stream(const TopoDS_Shape* shape, const CWriter* writer) { return cadrum::write_brep_text_stream(*shape, *writer); }
+
+// ---- Constructors ----
+TopoDS_Shape* make_half_space(double ox, double oy, double oz, double nx, double ny, double nz) { return cadrum::make_half_space(ox, oy, oz, nx, ny, nz).release(); }
+TopoDS_Shape* make_box(double x1, double y1, double z1, double x2, double y2, double z2) { return cadrum::make_box(x1, y1, z1, x2, y2, z2).release(); }
+TopoDS_Shape* make_cylinder(double px, double py, double pz, double dx, double dy, double dz, double radius, double height) { return cadrum::make_cylinder(px, py, pz, dx, dy, dz, radius, height).release(); }
+TopoDS_Shape* make_sphere(double cx, double cy, double cz, double radius) { return cadrum::make_sphere(cx, cy, cz, radius).release(); }
+TopoDS_Shape* make_cone(double px, double py, double pz, double dx, double dy, double dz, double r1, double r2, double height) { return cadrum::make_cone(px, py, pz, dx, dy, dz, r1, r2, height).release(); }
+TopoDS_Shape* make_torus(double px, double py, double pz, double dx, double dy, double dz, double r1, double r2) { return cadrum::make_torus(px, py, pz, dx, dy, dz, r1, r2).release(); }
+TopoDS_Shape* make_empty() { return cadrum::make_empty().release(); }
+TopoDS_Shape* deep_copy(const TopoDS_Shape* shape) { return cadrum::deep_copy(*shape).release(); }
+
+// ---- Builders ----
+TopoDS_Shape* builder_cells(const TopoDS_Shape* const* solids, size_t n_solids, const int64_t* clauses, size_t n_clauses, uint64_t** out_history, size_t* out_history_len) {
+	std::vector<uint64_t> hist;
+	auto r = cadrum::builder_cells(ffi_vec_in(solids, n_solids), std::vector<int64_t>(clauses, clauses + n_clauses), hist);
+	*out_history = ffi_pod_array(hist, out_history_len);
+	return r.release();
+}
+TopoDS_Shape* builder_clean(const TopoDS_Shape* shape, uint64_t** out_history, size_t* out_history_len) {
+	std::vector<uint64_t> hist;
+	auto r = cadrum::builder_clean(*shape, hist);
+	*out_history = ffi_pod_array(hist, out_history_len);
+	return r.release();
+}
+TopoDS_Shape* builder_thick_solid(const TopoDS_Shape* solid, const TopoDS_Face* const* open_faces, size_t n_faces, double thickness, uint64_t** out_history, size_t* out_history_len) {
+	std::vector<uint64_t> hist;
+	auto r = cadrum::builder_thick_solid(*solid, ffi_vec_in(open_faces, n_faces), thickness, hist);
+	*out_history = ffi_pod_array(hist, out_history_len);
+	return r.release();
+}
+TopoDS_Shape* builder_fillet(const TopoDS_Shape* solid, const TopoDS_Edge* const* edges, size_t n_edges, double radius, uint64_t** out_history, size_t* out_history_len) {
+	std::vector<uint64_t> hist;
+	auto r = cadrum::builder_fillet(*solid, ffi_vec_in(edges, n_edges), radius, hist);
+	*out_history = ffi_pod_array(hist, out_history_len);
+	return r.release();
+}
+TopoDS_Shape* builder_chamfer(const TopoDS_Shape* solid, const TopoDS_Edge* const* edges, size_t n_edges, double distance, uint64_t** out_history, size_t* out_history_len) {
+	std::vector<uint64_t> hist;
+	auto r = cadrum::builder_chamfer(*solid, ffi_vec_in(edges, n_edges), distance, hist);
+	*out_history = ffi_pod_array(hist, out_history_len);
+	return r.release();
+}
+
+// ---- Transforms ----
+TopoDS_Shape* transform_translate(const TopoDS_Shape* shape, double tx, double ty, double tz) { return cadrum::transform_translate(*shape, tx, ty, tz).release(); }
+TopoDS_Shape* transform_rotate(const TopoDS_Shape* shape, double ox, double oy, double oz, double dx, double dy, double dz, double angle) { return cadrum::transform_rotate(*shape, ox, oy, oz, dx, dy, dz, angle).release(); }
+TopoDS_Shape* transform_scale(const TopoDS_Shape* shape, double cx, double cy, double cz, double factor) { return cadrum::transform_scale(*shape, cx, cy, cz, factor).release(); }
+TopoDS_Shape* transform_mirror(const TopoDS_Shape* shape, double ox, double oy, double oz, double nx, double ny, double nz) { return cadrum::transform_mirror(*shape, ox, oy, oz, nx, ny, nz).release(); }
+
+// ---- Queries ----
+bool shape_is_null(const TopoDS_Shape* shape) { return cadrum::shape_is_null(*shape); }
+bool shape_is_solid(const TopoDS_Shape* shape) { return cadrum::shape_is_solid(*shape); }
+double shape_volume(const TopoDS_Shape* shape) { return cadrum::shape_volume(*shape); }
+double shape_surface_area(const TopoDS_Shape* shape) { return cadrum::shape_surface_area(*shape); }
+void shape_center_of_mass(const TopoDS_Shape* shape, double* x, double* y, double* z) { cadrum::shape_center_of_mass(*shape, *x, *y, *z); }
+void shape_inertia_tensor(const TopoDS_Shape* shape, double* m00, double* m01, double* m02, double* m10, double* m11, double* m12, double* m20, double* m21, double* m22) { cadrum::shape_inertia_tensor(*shape, *m00, *m01, *m02, *m10, *m11, *m12, *m20, *m21, *m22); }
+bool shape_contains_point(const TopoDS_Shape* shape, double x, double y, double z) { return cadrum::shape_contains_point(*shape, x, y, z); }
+void shape_bounding_box(const TopoDS_Shape* shape, double* xmin, double* ymin, double* zmin, double* xmax, double* ymax, double* zmax) { cadrum::shape_bounding_box(*shape, *xmin, *ymin, *zmin, *xmax, *ymax, *zmax); }
+
+// ---- Compound ----
+TopoDS_Shape** decompose_into_solids(const TopoDS_Shape* shape, size_t* out_len) {
+	auto v = cadrum::decompose_into_solids(*shape);
+	return ffi_owned_array(*v, out_len);
+}
+void compound_add(TopoDS_Shape* compound, const TopoDS_Shape* child) { cadrum::compound_add(*compound, *child); }
+
+// ---- Meshing ----
+CMeshData mesh_shape(const TopoDS_Shape* shape, double linear, double angular, bool relative) {
+	cadrum::MeshData m = cadrum::mesh_shape(*shape, linear, angular, relative);
+	CMeshData out;
+	out.vertices = ffi_pod_array(m.vertices, &out.vertices_len);
+	out.uvs = ffi_pod_array(m.uvs, &out.uvs_len);
+	out.indices = ffi_pod_array(m.indices, &out.indices_len);
+	out.face_ids = ffi_pod_array(m.face_tshape_ids, &out.face_ids_len);
+	out.success = m.success;
+	return out;
+}
+
+// ---- Topology enumeration ----
+TopoDS_Edge** shape_edges(const TopoDS_Shape* shape, size_t* out_len) { auto v = cadrum::shape_edges(*shape); return ffi_owned_array(*v, out_len); }
+TopoDS_Face** shape_faces(const TopoDS_Shape* shape, size_t* out_len) { auto v = cadrum::shape_faces(*shape); return ffi_owned_array(*v, out_len); }
+TopoDS_Edge** face_edges(const TopoDS_Face* face, size_t* out_len) { auto v = cadrum::face_edges(*face); return ffi_owned_array(*v, out_len); }
+TopoDS_Shape* clone_shape_handle(const TopoDS_Shape* shape) { return cadrum::clone_shape_handle(*shape).release(); }
+
+// ---- Face / Edge ids ----
+uint64_t face_tshape_id(const TopoDS_Face* face) { return cadrum::face_tshape_id(*face); }
+uint64_t shape_tshape_id(const TopoDS_Shape* shape) { return cadrum::shape_tshape_id(*shape); }
+uint64_t edge_tshape_id(const TopoDS_Edge* edge) { return cadrum::edge_tshape_id(*edge); }
+bool face_project_point(const TopoDS_Face* face, double px, double py, double pz, double* cpx, double* cpy, double* cpz, double* nx, double* ny, double* nz) { return cadrum::face_project_point(*face, px, py, pz, *cpx, *cpy, *cpz, *nx, *ny, *nz); }
+
+// ---- Edge methods ----
+double* edge_approximation_segments(const TopoDS_Edge* edge, double linear, double angular, bool relative, size_t* out_len) {
+	std::vector<double> v = cadrum::edge_approximation_segments(*edge, linear, angular, relative);
+	return ffi_pod_array(v, out_len);
+}
+TopoDS_Edge* make_helix_edge(double ax, double ay, double az, double xrx, double xry, double xrz, double radius, double pitch, double height) { return cadrum::make_helix_edge(ax, ay, az, xrx, xry, xrz, radius, pitch, height).release(); }
+TopoDS_Edge** make_polygon_edges(const double* coords, size_t n_coords, size_t* out_len) {
+	auto v = cadrum::make_polygon_edges(std::vector<double>(coords, coords + n_coords));
+	return ffi_owned_array(*v, out_len);
+}
+TopoDS_Edge* make_circle_edge(double ax, double ay, double az, double radius) { return cadrum::make_circle_edge(ax, ay, az, radius).release(); }
+TopoDS_Edge* make_line_edge(double ax, double ay, double az, double bx, double by, double bz) { return cadrum::make_line_edge(ax, ay, az, bx, by, bz).release(); }
+TopoDS_Edge* make_arc_edge(double sx, double sy, double sz, double mx, double my, double mz, double ex, double ey, double ez) { return cadrum::make_arc_edge(sx, sy, sz, mx, my, mz, ex, ey, ez).release(); }
+TopoDS_Edge* make_bspline_edge(const double* coords, size_t n_coords, uint32_t end_kind, double sx, double sy, double sz, double ex, double ey, double ez) {
+	return cadrum::make_bspline_edge(std::vector<double>(coords, coords + n_coords), end_kind, sx, sy, sz, ex, ey, ez).release();
+}
+void edge_endpoints(const TopoDS_Edge* edge, double* sx, double* sy, double* sz, double* ex, double* ey, double* ez) { cadrum::edge_endpoints(*edge, *sx, *sy, *sz, *ex, *ey, *ez); }
+void edge_tangents(const TopoDS_Edge* edge, double* sx, double* sy, double* sz, double* ex, double* ey, double* ez) { cadrum::edge_tangents(*edge, *sx, *sy, *sz, *ex, *ey, *ez); }
+bool edge_is_closed(const TopoDS_Edge* edge) { return cadrum::edge_is_closed(*edge); }
+bool edge_project_point(const TopoDS_Edge* edge, double px, double py, double pz, double* cpx, double* cpy, double* cpz, double* tx, double* ty, double* tz) { return cadrum::edge_project_point(*edge, px, py, pz, *cpx, *cpy, *cpz, *tx, *ty, *tz); }
+TopoDS_Edge* deep_copy_edge(const TopoDS_Edge* edge) { return cadrum::deep_copy_edge(*edge).release(); }
+TopoDS_Edge* translate_edge(const TopoDS_Edge* edge, double tx, double ty, double tz) { return cadrum::translate_edge(*edge, tx, ty, tz).release(); }
+TopoDS_Edge* rotate_edge(const TopoDS_Edge* edge, double ox, double oy, double oz, double dx, double dy, double dz, double angle) { return cadrum::rotate_edge(*edge, ox, oy, oz, dx, dy, dz, angle).release(); }
+TopoDS_Edge* scale_edge(const TopoDS_Edge* edge, double cx, double cy, double cz, double factor) { return cadrum::scale_edge(*edge, cx, cy, cz, factor).release(); }
+TopoDS_Edge* mirror_edge(const TopoDS_Edge* edge, double ox, double oy, double oz, double nx, double ny, double nz) { return cadrum::mirror_edge(*edge, ox, oy, oz, nx, ny, nz).release(); }
+TopoDS_Shape* make_extrude(const TopoDS_Edge* const* profile_edges, size_t n_profile, double dx, double dy, double dz) { return cadrum::make_extrude(ffi_vec_in(profile_edges, n_profile), dx, dy, dz).release(); }
+TopoDS_Shape* make_pipe_shell(const TopoDS_Edge* const* all_edges, size_t n_all, const TopoDS_Edge* const* spine_edges, size_t n_spine, uint32_t orient, double ux, double uy, double uz, const TopoDS_Edge* const* aux_spine_edges, size_t n_aux) {
+	return cadrum::make_pipe_shell(ffi_vec_in(all_edges, n_all), ffi_vec_in(spine_edges, n_spine), orient, ux, uy, uz, ffi_vec_in(aux_spine_edges, n_aux)).release();
+}
+TopoDS_Shape* make_loft(const TopoDS_Edge* const* all_edges, size_t n_all, bool ruled) { return cadrum::make_loft(ffi_vec_in(all_edges, n_all), ruled).release(); }
+TopoDS_Shape* make_sewn_solid(const TopoDS_Face* const* faces, size_t n_faces, double tolerance) { return cadrum::make_sewn_solid(ffi_vec_in(faces, n_faces), tolerance).release(); }
+TopoDS_Shape* make_offset_shape(const TopoDS_Shape* shape, double offset, double tolerance) { return cadrum::make_offset_shape(*shape, offset, tolerance).release(); }
+TopoDS_Shape* make_bspline_solid(const double* coords, size_t n_coords, uint32_t nu, uint32_t nv, bool u_periodic) {
+	return cadrum::make_bspline_solid(std::vector<double>(coords, coords + n_coords), nu, nv, u_periodic).release();
+}
+
+// ---- Colored STEP I/O ----
+#ifdef CADRUM_COLOR
+TopoDS_Shape* read_step_color_stream(const CReader* reader, uint64_t** out_ids, size_t* out_ids_len, float** out_rgb, size_t* out_rgb_len) {
+	std::vector<uint64_t> ids;
+	std::vector<float> rgb;
+	auto r = cadrum::read_step_color_stream(*reader, ids, rgb);
+	*out_ids = ffi_pod_array(ids, out_ids_len);
+	*out_rgb = ffi_pod_array(rgb, out_rgb_len);
+	return r.release();
+}
+bool write_step_color_stream(const TopoDS_Shape* shape, const uint64_t* ids, size_t n_ids, const float* rgb, size_t n_rgb, const CWriter* writer) {
+	return cadrum::write_step_color_stream(*shape, std::vector<uint64_t>(ids, ids + n_ids), std::vector<float>(rgb, rgb + n_rgb), *writer);
+}
+#endif
+
+} // extern "C"

--- a/cpp/wrapper.h
+++ b/cpp/wrapper.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "rust/cxx.h"
+// Hand-written C ABI (CReader / CWriter / CMeshData / extern "C" prototypes).
+#include "ffi.h"
 
-// Types used directly in function signatures — keep minimal so that
-// the cxx-generated bridge objects do not compile heavy OCCT headers.
+// Types used directly in function signatures — keep minimal so that the wrapper
+// objects do not compile heavy OCCT headers.
 #include <TopoDS_Shape.hxx>
 #include <TopoDS_Face.hxx>
 #include <TopoDS_Edge.hxx>
@@ -16,23 +17,27 @@
 namespace cadrum {
 
 // Type aliases to bring OCCT global types into cadrum namespace.
-// Required because the cxx bridge uses namespace = "cadrum".
 using TopoDS_Shape = ::TopoDS_Shape;
 using TopoDS_Face = ::TopoDS_Face;
 using TopoDS_Edge = ::TopoDS_Edge;
 
-// Forward-declare the Rust opaque types (defined by cxx in ffi.rs.h)
-struct RustReader;
-struct RustWriter;
+// Mesh data assembled by `mesh_shape`. The extern "C" shim flattens this into
+// the POD `CMeshData` for Rust.
+struct MeshData {
+    std::vector<double> vertices;   // flat xyz
+    std::vector<double> uvs;        // flat uv
+    std::vector<uint32_t> indices;
+    std::vector<uint64_t> face_tshape_ids; // per-triangle TShape* address
+    bool success;
+};
 
-// Forward-declare shared structs (defined by cxx in ffi.rs.h)
-struct MeshData;
 // ==================== Streambuf bridges ====================
 
-// std::streambuf subclass that reads from a Rust `dyn Read` via FFI callback
+// std::streambuf subclass that reads from a Rust `dyn Read` via the CReader
+// callback (function pointer + opaque ctx).
 class RustReadStreambuf : public std::streambuf {
 public:
-    explicit RustReadStreambuf(RustReader& reader) : reader_(reader) {}
+    explicit RustReadStreambuf(const CReader& reader) : reader_(reader) {}
 
 protected:
     int_type underflow() override;
@@ -45,14 +50,15 @@ protected:
     pos_type seekpos(pos_type sp, std::ios_base::openmode which = std::ios_base::in | std::ios_base::out) override;
 
 private:
-    RustReader& reader_;
+    const CReader& reader_;
     char buf_[8192];
 };
 
-// std::streambuf subclass that writes to a Rust `dyn Write` via FFI callback
+// std::streambuf subclass that writes to a Rust `dyn Write` via the CWriter
+// callback (function pointer + opaque ctx).
 class RustWriteStreambuf : public std::streambuf {
 public:
-    explicit RustWriteStreambuf(RustWriter& writer) : writer_(writer) {}
+    explicit RustWriteStreambuf(const CWriter& writer) : writer_(writer) {}
 
     ~RustWriteStreambuf() override {
         sync();
@@ -68,7 +74,7 @@ protected:
 private:
     bool flush_buf();
 
-    RustWriter& writer_;
+    const CWriter& writer_;
     char buf_[8192];
     size_t pos_ = 0;
 };
@@ -78,13 +84,13 @@ private:
 // Plain STEP I/O — only built without CADRUM_COLOR; with color, STEP goes
 // through XCAF (`read_step_color_stream` etc.) instead.
 #ifndef CADRUM_COLOR
-std::unique_ptr<TopoDS_Shape> read_step_stream(RustReader& reader);
-bool write_step_stream(const TopoDS_Shape& shape, RustWriter& writer);
+std::unique_ptr<TopoDS_Shape> read_step_stream(const CReader& reader);
+bool write_step_stream(const TopoDS_Shape& shape, const CWriter& writer);
 #endif
-std::unique_ptr<TopoDS_Shape> read_brep_bin_stream(RustReader& reader);
-bool write_brep_bin_stream(const TopoDS_Shape& shape, RustWriter& writer);
-std::unique_ptr<TopoDS_Shape> read_brep_text_stream(RustReader& reader);
-bool write_brep_text_stream(const TopoDS_Shape& shape, RustWriter& writer);
+std::unique_ptr<TopoDS_Shape> read_brep_bin_stream(const CReader& reader);
+bool write_brep_bin_stream(const TopoDS_Shape& shape, const CWriter& writer);
+std::unique_ptr<TopoDS_Shape> read_brep_text_stream(const CReader& reader);
+bool write_brep_text_stream(const TopoDS_Shape& shape, const CWriter& writer);
 
 // ==================== Shape Constructors ====================
 
@@ -134,15 +140,15 @@ std::unique_ptr<TopoDS_Shape> deep_copy(const TopoDS_Shape& shape);
 // `out_history` の形式は builder_boolean と同じ。
 std::unique_ptr<TopoDS_Shape> builder_cells(
     const std::vector<TopoDS_Shape>& solids,
-    rust::Slice<const int64_t> clauses,
-    rust::Vec<uint64_t>& out_history);
+    const std::vector<int64_t>& clauses,
+    std::vector<uint64_t>& out_history);
 
 // Unify shared faces / collinear edges via ShapeUpgrade_UnifySameDomain.
 // `out_history` encodes how each old face maps onto the unified result.
 // Rust uses it to remap the colormap when the `color` feature is enabled.
 std::unique_ptr<TopoDS_Shape> builder_clean(
     const TopoDS_Shape& shape,
-    rust::Vec<uint64_t>& out_history);
+    std::vector<uint64_t>& out_history);
 
 // Shell (hollow) the solid by removing `open_faces` and offsetting the
 // remaining faces by `thickness` via BRepOffsetAPI_MakeThickSolid. Negative
@@ -155,7 +161,7 @@ std::unique_ptr<TopoDS_Shape> builder_thick_solid(
     const TopoDS_Shape& solid,
     const std::vector<TopoDS_Face>& open_faces,
     double thickness,
-    rust::Vec<uint64_t>& out_history);
+    std::vector<uint64_t>& out_history);
 
 // Fillet the given edges of `solid` with a uniform radius using
 // BRepFilletAPI_MakeFillet. Empty `edges` is a no-op (returns a shallow
@@ -168,7 +174,7 @@ std::unique_ptr<TopoDS_Shape> builder_fillet(
     const TopoDS_Shape& solid,
     const std::vector<TopoDS_Edge>& edges,
     double radius,
-    rust::Vec<uint64_t>& out_history);
+    std::vector<uint64_t>& out_history);
 
 // Chamfer (symmetric bevel) the given edges of `solid` with a uniform
 // distance using BRepFilletAPI_MakeChamfer. Empty `edges` is a no-op
@@ -182,7 +188,7 @@ std::unique_ptr<TopoDS_Shape> builder_chamfer(
     const TopoDS_Shape& solid,
     const std::vector<TopoDS_Edge>& edges,
     double distance,
-    rust::Vec<uint64_t>& out_history);
+    std::vector<uint64_t>& out_history);
 
 // ==================== Transforms (solid → solid, no history) ====================
 //
@@ -252,14 +258,12 @@ std::unique_ptr<std::vector<TopoDS_Edge>> face_edges(const TopoDS_Face& face);
 // `CxxVector::iter()`. Distinct from `deep_copy` / `deep_copy_edge` which
 // create new TShapes.
 std::unique_ptr<TopoDS_Shape> clone_shape_handle(const TopoDS_Shape& shape);
-std::unique_ptr<TopoDS_Edge> clone_edge_handle(const TopoDS_Edge& edge);
-std::unique_ptr<TopoDS_Face> clone_face_handle(const TopoDS_Face& face);
 
 // ==================== Edge Methods ====================
 
 // Approximate an edge as a polyline. Takes independent angular/chord
 // deflection bounds. Returns a flat xyz `Vec<f64>` (length = 3 * point count).
-rust::Vec<double> edge_approximation_segments(
+std::vector<double> edge_approximation_segments(
     const TopoDS_Edge& edge, double linear, double angular, bool relative);
 
 // Construct a single helical edge on a cylindrical surface centered at the
@@ -277,7 +281,7 @@ std::unique_ptr<TopoDS_Edge> make_helix_edge(
 // return its constituent edges in order. The closing edge from the last
 // point back to the first is included.
 std::unique_ptr<std::vector<TopoDS_Edge>> make_polygon_edges(
-    rust::Slice<const double> coords);
+    const std::vector<double>& coords);
 
 // Construct a closed circular edge of `radius` centered at the world origin,
 // lying in the plane normal to `axis`. The local +X axis of the circle's
@@ -310,7 +314,7 @@ std::unique_ptr<TopoDS_Edge> make_arc_edge(
 //   2 = Clamped  (open, explicit start/end tangents in (sx,sy,sz)/(ex,ey,ez))
 // Returns nullptr on any failure.
 std::unique_ptr<TopoDS_Edge> make_bspline_edge(
-    rust::Slice<const double> coords,
+    const std::vector<double>& coords,
     uint32_t end_kind,
     double sx, double sy, double sz,
     double ex, double ey, double ez);
@@ -378,20 +382,6 @@ std::unique_ptr<TopoDS_Shape> make_pipe_shell(
     double ux, double uy, double uz,
     const std::vector<TopoDS_Edge>& aux_spine_edges);
 
-// Helpers for the Rust side to construct a std::vector<TopoDS_Edge>.
-std::unique_ptr<std::vector<TopoDS_Edge>> edge_vec_new();
-void edge_vec_push(std::vector<TopoDS_Edge>& v, const TopoDS_Edge& e);
-void edge_vec_push_null(std::vector<TopoDS_Edge>& v);
-
-// Helpers for the Rust side to construct a std::vector<TopoDS_Face>.
-std::unique_ptr<std::vector<TopoDS_Face>> face_vec_new();
-void face_vec_push(std::vector<TopoDS_Face>& v, const TopoDS_Face& f);
-
-// Helpers for the Rust side to construct a std::vector<TopoDS_Shape>.
-// builder_cells に渡すための入力 solids ベクタを Rust 側から組み立てる。
-std::unique_ptr<std::vector<TopoDS_Shape>> shape_vec_new();
-void shape_vec_push(std::vector<TopoDS_Shape>& v, const TopoDS_Shape& s);
-
 // Loft (skin) a solid through N cross-section wires.
 // Sections in `all_edges` are separated by null-edge sentinels.
 // `ruled=false` interpolates a smooth B-spline surface through all sections;
@@ -429,7 +419,7 @@ std::unique_ptr<TopoDS_Shape> make_offset_shape(
 // (producing a torus); otherwise the U-ends are capped with planar faces
 // (producing a pipe). Returns nullptr on any OCCT failure.
 std::unique_ptr<TopoDS_Shape> make_bspline_solid(
-    rust::Slice<const double> coords,
+    const std::vector<double>& coords,
     uint32_t nu, uint32_t nv,
     bool u_periodic);
 
@@ -465,17 +455,17 @@ namespace cadrum {
 // [r0,g0,b0, r1,g1,b1, ...] sequence (length = 3 * out_ids.size()).
 // Returns nullptr on failure.
 std::unique_ptr<TopoDS_Shape> read_step_color_stream(
-    RustReader&          reader,
-    rust::Vec<uint64_t>& out_ids,
-    rust::Vec<float>&    out_rgb);
+    const CReader&        reader,
+    std::vector<uint64_t>& out_ids,
+    std::vector<float>&    out_rgb);
 
 // Write a colored STEP stream. `ids` lists TShape* of colored faces; `rgb`
 // is the matching flat [r,g,b,...] sequence (length = 3 * ids.size()).
 bool write_step_color_stream(
-    const TopoDS_Shape&         shape,
-    rust::Slice<const uint64_t> ids,
-    rust::Slice<const float>    rgb,
-    RustWriter&                 writer);
+    const TopoDS_Shape&          shape,
+    const std::vector<uint64_t>& ids,
+    const std::vector<float>&    rgb,
+    const CWriter&               writer);
 
 } // namespace cadrum
 

--- a/notes/20260620-cxx依存除去とextern_C化.md
+++ b/notes/20260620-cxx依存除去とextern_C化.md
@@ -1,0 +1,98 @@
+# cxx 依存除去と extern "C" 化 — 目的と達成内容
+
+PR #232。OCCT FFI を `cxx` クレートから手書き `extern "C"` へ置き換えた作業の記録。
+
+## 何がしたかったか（背景・動機）
+
+- **`cxx` を依存に置く限り、cxx 自身の `src/cxx.cc` が全 consumer ビルドでコンパイルされる。**
+  `cxx.cc` は `<iostream>` / `<string>` 等の libc++ ヘッダを include しており、これが
+  wasm ビルドで wasi-sdk（libc++ ヘッダ）を要求し続ける一因だった。OCCT を prebuilt
+  `.a` 化しても、wrapper.cpp を prebuilt 化しても、**cxx.cc のコンパイルだけは consumer
+  ビルドに残る**。
+- さらに **publish ライブラリとして downstream の cxx ビルドを制御する手段が無い**。
+  `.cargo/config.toml [env]` も `[patch.crates-io]` も「ビルド root」でしか効かず、
+  依存パッケージ側の設定は読まれない。build.rs から依存（cxx）の build.rs へ env を
+  注入することも不可能（実行順序＝依存先が先、かつ API も無い）。
+- 結論として、**downstream まで効かせて wasm 用 C++ コンパイラを選べるようにするには、
+  cxx を依存から外して全 C++ コンパイルを cadrum 自身の `cc::Build` に集約するしかない。**
+
+## 何を達成したか
+
+- `cxx` / `cxx-build` の依存を**完全に削除**。
+- OCCT FFI を手書き `extern "C"` に置換。
+- **全 C++ コンパイルが cadrum の build.rs（`cc::Build`）に集約**され、wasm 向けコンパイラを
+  build.rs ロジックで選べる土台ができた（AGENTS.md「依存を減らす」にも合致）。
+
+## 設計
+
+低リスクを優先し、**OCCT ロジック本体（`namespace cadrum` の関数群）はほぼ無改変**で、
+marshaling を薄い shim 層に集約する方針を採った。
+
+### C++ 側
+
+- **`cpp/ffi.h`（新規）** — 手書き C ABI。
+  - `CReader` / `CWriter`: streambuf コールバック（`{ ctx: void*, fn ポインタ }`）。
+  - `CMeshData`: mesh 結果の POD 構造体。
+  - `cadrum_free`（malloc 配列用 = free）/ `cadrum_shape_free` 等（所有ハンドル用 = delete）。
+  - 戻り値が可変長のものは `(ptr, len)` を malloc して返す規約。
+- **`cpp/wrapper.{h,cpp}`**
+  - OCCT ロジックは温存。`rust::Vec<T>&` → `std::vector<T>&`、`rust::Slice<const T>` →
+    `const std::vector<T>&`、`rust::Vec<T>` 戻り → `std::vector<T>` 戻り に置換しただけ
+    （`.push_back` / `.size()` / `[i]` / `.clear()` は std::vector で同一なので本体は不変）。
+  - 末尾に `extern "C"` **shim 層**を追加し、生 C ABI ↔ `cadrum::` 関数を marshaling。
+  - streambuf は `rust_reader_read`/`rust_writer_write` 呼びを `CReader/CWriter` の
+    fn ポインタ呼びに置換。
+  - 不要化した **vec ヘルパ 7 個**（`*_vec_new`/`push`/`push_null`）と
+    **`clone_edge_handle` / `clone_face_handle`** を削除（`clone_shape_handle` は残置）。
+
+### Rust 側
+
+- **`src/occt/ffi.rs`** — `#[cxx::bridge]` を撤去。
+  - 不透明型 `TopoDS_Shape/Face/Edge`（`[u8;0]` + `PhantomData` イディオム）。
+  - `Owned<T>`: `cxx::UniquePtr<T>` 相当の所有スマートポインタ。`Deref`（call site の
+    deref 強制で `&Owned<T>` → `&T`）と `is_null`、`Drop` で `cadrum_*_free`。
+  - 生 `extern "C"`（`mod raw`）+ 旧 bridge と同名・同シグネチャの安全ラッパ
+    （→ 下流の `ffi::*` 呼び出しはほぼ無改変で済む）。
+  - `MeshData` は平の Rust struct。
+- **`src/occt/stream.rs`** — `#[repr(C)]` の `CReader`/`CWriter` と `extern "C"`
+  トランポリンを追加（既存の reader/writer ロジックを再利用）。
+- **caller 群**（`solid`/`compound`/`edge`/`face`/`io`）
+  - wrapper struct のフィールド `cxx::UniquePtr` → `ffi::Owned`。
+  - `CxxVector` 入力は `Vec<*const TopoDS_*>` を組んで渡す。**null ポインタ = loft/pipe の
+    断面区切り**（旧 null-edge sentinel の置き換え）。
+  - `CxxVector` 返り値は `Vec<Owned<T>>` を直接消費（要素ごとの clone 廃止）。
+
+### 例外
+
+- OCCT 呼び出しは既存の `try/catch(Standard_Failure)` が **36 箇所すべて**を覆っており、
+  例外が FFI 境界を越えない。追加の境界実装は不要だった。
+
+## 検証
+
+- `cargo test`（default: color+png）green。
+- `cargo test --no-default-features --lib --tests`（color off）green。
+- `cargo build --examples`（default）OK、`cargo fmt` 適用。
+- `cargo build --target wasm32-unknown-unknown`（wasi-sdk-33 + prebuilt wasm OCCT）で
+  `wrapper.cpp` が clang++ でコンパイルされ rlib ビルド成功。
+
+native のテストは全 FFI 関数を実リンク・実行するので ABI を end-to-end で検証済み。
+wasm ビルドは wasi-sdk 下での C++ コンパイル成立を確認するもの。
+
+## ハマり所メモ
+
+- **wasm で `cstdint file not found`** が出たが、これは検証時に `--sysroot` を
+  **Unix 形式パス（`/c/...`）** で渡したため native Windows clang が解決できなかっただけ。
+  `cygpath -w` で Windows 形式（`C:\...`）に直すと解決。**コード側の問題ではない。**
+  wasi-sdk の `clang++.cfg` が相対 sysroot を提供しており、デフォルト target
+  `wasm32-unknown-wasip1` + `-fwasm-exceptions` で `wasm32-wasip1/eh/c++/v1` を自動解決する。
+  `sandbox-wasm/makefile` の `SYSROOT := $(CURDIR)/...` も同じ落とし穴があり得る（要留意・本PR対象外）。
+- `cargo test --no-default-features` で examples 09/10/12 がコンパイルエラーになるのは
+  `.color()`/`write_png` を使う例に `required-features` が無い**既存問題**で、本変更とは無関係。
+
+## 補足: 取らなかった代替案
+
+- **cxx を fork（`sandbox-cxx`）して build.rs に wasm 分岐**: `package` リネームで `::cxx::`
+  パスを維持すれば downstream にも伝播でき技術的には可能。ただし cxx fork の追従保守が
+  発生し、かつ「consumer ビルドで C++ をコンパイルし続ける」点は変わらない。
+- 本 PR の extern "C" 化なら **consumer ビルドの C++ を将来 prebuilt `.a` 化して
+  toolchain ゼロにする**道まで開ける（cxx fork ではそこに届かない）。

--- a/notes/20260620-cxx依存除去とextern_C化.md
+++ b/notes/20260620-cxx依存除去とextern_C化.md
@@ -96,3 +96,52 @@ wasm ビルドは wasi-sdk 下での C++ コンパイル成立を確認するも
   発生し、かつ「consumer ビルドで C++ をコンパイルし続ける」点は変わらない。
 - 本 PR の extern "C" 化なら **consumer ビルドの C++ を将来 prebuilt `.a` 化して
   toolchain ゼロにする**道まで開ける（cxx fork ではそこに届かない）。
+
+## フォローアップ案: ffi.h / ffi.rs の片側自動生成
+
+手書き化で失ったのは「1 定義から両側を生成する単一の真実の源」と「ABI 不一致のコンパイル時検証」。
+これを取り戻す（=ミニ cxx を自前で持つ）案。
+
+### 前提: proc-macro 単体では不可
+
+`cpp/ffi.h` は **build.rs が wrapper.cpp をコンパイルする時点**で必要だが、proc-macro の展開は
+build.rs より後（クレート本体コンパイル時）。間に合わない。生成するなら **build.rs 時点**で行う。
+これは cxx が `cxx-build`（build.rs から `.rs` を再パースする別クレート）を持つ理由と同じ。
+
+### 案A: build.rs で ffi.rs を解析して ffi.h を生成（自前ミニ cxx-build）
+
+`syn` 等で `mod raw { extern "C" {…} }` を読み、Rust 型→C 型（`*mut TopoDS_Shape`→`TopoDS_Shape*`、
+`usize`→`size_t`、`*mut *mut u64`→`uint64_t**` 等）に写して `ffi.h` を出力。
+
+- 利点: 真実の源を `ffi.rs` に一本化。
+- 欠点: `syn` を build-dep に復活（cxx-build を消した意義と一部相殺）。`#[cfg(feature=color)]` の
+  選別や、extern ブロック外の `CReader/CWriter/CMeshData` を別途扱う必要。
+  → 「自前 cxx-build」になりがちで、cxx を外した意義と一番ぶつかる。
+
+### 案B: bindgen で ffi.h から Rust の raw ブロックを生成
+
+`ffi.h`（手書き）を真実の源にし、build.rs で `bindgen` を回して `mod raw` と
+`CReader/CWriter/CMeshData` を生成。手書きの raw ブロックは削除。
+
+- 利点: C ABI の自然な源は C ヘッダ。bindgen は枯れている。**clang は wrapper.cpp ビルドで
+  既に必須**なので追加ツール要求は実質ゼロ。最小実装で堅牢。
+- 欠点: `bindgen`(+`clang-sys`) という重めの build-dep。color の `#ifdef` は bindgen 実行時の
+  define で揃える必要。
+
+### 案C: build.rs 内の「関数テーブル」から両方を生成（依存ゼロ）
+
+関数定義を build.rs 内の Rust データ（`(name, ret, [args])` のリスト）として 1 か所に書き、
+build.rs が **ffi.h（C 文字列）と raw.rs（`include!` する Rust extern）の両方**を文字列整形で出力。
+
+- 利点: 真実の源が 1 つ、**新規依存なし**（「依存を減らす」方針に最も合致）。
+- 欠点: テーブル DSL と 2 つのエミッタを自作・保守。
+
+### 共通効果と見立て
+
+- どの案でも「片側を生成」すれば、**ffi.h と wrapper.cpp の shim 定義の不一致を C++ コンパイラが
+  弾く**（宣言 vs 定義）。生成側が ffi.rs/ffi.h 由来なので **Rust↔C++ の食い違いがコンパイル時に
+  検出され**、cxx の安全性の大半が戻る（残る穴は型マッピング表自体の正しさのみ）。生成されるのは
+  宣言だけで、shim の中身と Rust 安全ラッパは引き続き手書き。
+- 今回の規模（FFI 面 1 つ・~75 関数・変更頻度低）なら手書き二面のままでも十分。ドリフトが
+  保守の痛みになったら **案C（依存ゼロのテーブル生成）**が方針に最も合う。clang 前提を許容できるなら
+  **案B（bindgen）**が最小実装で堅牢。**案A は非推奨**（自前 cxx-build 化）。

--- a/src/occt/compound.rs
+++ b/src/occt/compound.rs
@@ -7,7 +7,7 @@ use crate::common::color::Color;
 ///
 /// Provides type-safe distinction from individual `Solid` handles.
 pub(crate) struct CompoundShape {
-	inner: cxx::UniquePtr<ffi::TopoDS_Shape>,
+	inner: ffi::Owned<ffi::TopoDS_Shape>,
 	#[cfg(feature = "color")]
 	colormap: std::collections::HashMap<u64, Color>,
 	history: Vec<u64>,
@@ -24,7 +24,7 @@ impl CompoundShape {
 		#[cfg(feature = "color")]
 		let mut colormap = std::collections::HashMap::new();
 		for s in solids {
-			ffi::compound_add(inner.pin_mut(), s.inner());
+			ffi::compound_add(&mut inner, s.inner());
 			#[cfg(feature = "color")]
 			colormap.extend(s.colormap().iter().map(|(&k, &v)| (k, v)));
 		}
@@ -37,7 +37,7 @@ impl CompoundShape {
 	}
 
 	/// Create a compound from a raw `TopoDS_Shape` (e.g. from I/O or boolean ops).
-	pub fn from_raw(inner: cxx::UniquePtr<ffi::TopoDS_Shape>, #[cfg(feature = "color")] colormap: std::collections::HashMap<u64, Color>, history: Vec<u64>) -> Self {
+	pub fn from_raw(inner: ffi::Owned<ffi::TopoDS_Shape>, #[cfg(feature = "color")] colormap: std::collections::HashMap<u64, Color>, history: Vec<u64>) -> Self {
 		CompoundShape {
 			inner,
 			#[cfg(feature = "color")]
@@ -63,12 +63,11 @@ impl CompoundShape {
 	/// is harmless because `iter_history()` consumers filter pairs by checking
 	/// `src_id` against the original input's face IDs.
 	pub fn decompose(self) -> Vec<Solid> {
-		let solid_shapes = ffi::decompose_into_solids(&self.inner);
-		solid_shapes
-			.iter()
-			.map(|s| {
+		ffi::decompose_into_solids(&self.inner)
+			.into_iter()
+			.map(|owned| {
 				Solid::new(
-					ffi::clone_shape_handle(s),
+					owned,
 					#[cfg(feature = "color")]
 					self.colormap.clone(),
 					self.history.clone(),

--- a/src/occt/edge.rs
+++ b/src/occt/edge.rs
@@ -5,7 +5,7 @@ use glam::DVec3;
 
 /// An edge topology shape.
 pub struct Edge {
-	pub(crate) inner: cxx::UniquePtr<ffi::TopoDS_Edge>,
+	pub(crate) inner: ffi::Owned<ffi::TopoDS_Edge>,
 }
 
 impl Edge {
@@ -18,7 +18,7 @@ impl Edge {
 	/// iterators — all of which wrap an already-valid edge), callers use
 	/// `.expect("...")` with a descriptive message; the panic is unreachable
 	/// in practice but serves as a defensive marker.
-	pub(crate) fn try_from_ffi(inner: cxx::UniquePtr<ffi::TopoDS_Edge>, msg: String) -> Result<Self, Error> {
+	pub(crate) fn try_from_ffi(inner: ffi::Owned<ffi::TopoDS_Edge>, msg: String) -> Result<Self, Error> {
 		if inner.is_null() {
 			Err(Error::InvalidEdge(msg))
 		} else {
@@ -94,17 +94,15 @@ impl EdgeStruct for Edge {
 
 	fn polygon<'a>(points: impl IntoIterator<Item = &'a DVec3>) -> Result<Vec<Self>, Error> {
 		let coords: Vec<f64> = points.into_iter().flat_map(|p| [p.x, p.y, p.z]).collect();
-		let cxx_vec = ffi::make_polygon_edges(&coords);
+		let edges = ffi::make_polygon_edges(&coords);
 		// C++ 側は失敗時に空ベクタを返す (null ではない)。点数不足や
 		// OCCT の MakePolygon 失敗で empty になるので、それを InvalidEdge に変換。
-		if cxx_vec.is_empty() {
+		if edges.is_empty() {
 			return Err(Error::InvalidEdge(format!("polygon: construction failed (point count = {}, need ≥ 3 non-degenerate)", coords.len() / 3)));
 		}
-		// CxxVector<TopoDS_Edge> → Vec<Edge>: pull each element out into a
-		// UniquePtr<TopoDS_Edge> via deep_copy_edge so we own the topology.
-		// deep_copy_edge は既に有効な edge の複製なので null にはならない想定、
-		// 万一返った場合は InvalidEdge で failfast する。
-		cxx_vec.iter().map(|e| Edge::try_from_ffi(ffi::deep_copy_edge(e), "polygon: deep_copy_edge returned null".into())).collect()
+		// make_polygon_edges は各要素を所有ハンドルとして返すので、そのまま Edge へ。
+		// 構築済み edge なので null にはならない想定、万一返った場合は failfast する。
+		edges.into_iter().map(|owned| Edge::try_from_ffi(owned, "polygon: make_polygon_edges returned null".into())).collect()
 	}
 
 	fn circle(radius: f64, axis: DVec3) -> Result<Self, Error> {

--- a/src/occt/face.rs
+++ b/src/occt/face.rs
@@ -11,13 +11,13 @@ use std::sync::OnceLock;
 /// are constructed fresh each time the parent solid's face cache is built, so
 /// the OnceLock matches the lifetime of the enclosing `Vec<Face>`.
 pub struct Face {
-	pub(crate) inner: cxx::UniquePtr<ffi::TopoDS_Face>,
+	pub(crate) inner: ffi::Owned<ffi::TopoDS_Face>,
 	edges: OnceLock<Vec<Edge>>,
 }
 
 impl Face {
 	/// Create a Face wrapping a `TopoDS_Face`.
-	pub(crate) fn new(inner: cxx::UniquePtr<ffi::TopoDS_Face>) -> Self {
+	pub(crate) fn new(inner: ffi::Owned<ffi::TopoDS_Face>) -> Self {
 		Face { inner, edges: OnceLock::new() }
 	}
 }
@@ -39,16 +39,6 @@ impl FaceStruct for Face {
 	}
 
 	fn iter_edge(&self) -> impl Iterator<Item = &Edge> + '_ {
-		self.edges
-			.get_or_init(|| {
-				ffi::face_edges(&self.inner)
-					.iter()
-					.map(|e_ref| {
-						let owned = ffi::clone_edge_handle(e_ref);
-						Edge::try_from_ffi(owned, "face_edges: null".into()).expect("face_edges: unexpected null (this is a bug)")
-					})
-					.collect()
-			})
-			.iter()
+		self.edges.get_or_init(|| ffi::face_edges(&self.inner).into_iter().map(|owned| Edge::try_from_ffi(owned, "face_edges: null".into()).expect("face_edges: unexpected null (this is a bug)")).collect()).iter()
 	}
 }

--- a/src/occt/ffi.rs
+++ b/src/occt/ffi.rs
@@ -1,196 +1,603 @@
-use super::stream::{rust_reader_read, rust_writer_write};
-use super::stream::{RustReader, RustWriter};
+//! Hand-written FFI to the OCCT C++ wrapper (`cpp/wrapper.cpp` via `cpp/ffi.h`).
+//!
+//! This replaces the former `#[cxx::bridge]`. The C++ side keeps its OCCT logic
+//! in `namespace cadrum` and exposes a thin `extern "C"` shim; here we declare
+//! the matching raw signatures (`mod raw`) and wrap them in safe-ish functions
+//! that mirror the old bridge API so the rest of `src/occt/` is mostly
+//! unchanged. Owned C++ objects are held by [`Owned`] (a `UniquePtr`-like smart
+//! pointer); variable-length results are copied out of malloc'd buffers and the
+//! buffers freed via `cadrum_free`.
 
-#[cxx::bridge(namespace = "cadrum")]
-mod ffi_bridge {
-	// Shared struct for mesh data returned from C++
-	struct MeshData {
-		vertices: Vec<f64>, // flat xyz
-		uvs: Vec<f64>,      // flat uv
-		indices: Vec<u32>,
-		face_tshape_ids: Vec<u64>, // per-triangle TShape* address
-		success: bool,
+use super::stream::{CReader, CWriter, RustReader, RustWriter};
+use std::ffi::c_void;
+
+// ==================== Opaque OCCT topology types ====================
+//
+// Only ever used behind pointers. The zero-size + PhantomData idiom makes them
+// `!Send`/`!Sync`/`!Unpin` and impossible to construct on the Rust side.
+
+#[repr(C)]
+pub struct TopoDS_Shape {
+	_data: [u8; 0],
+	_marker: core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,
+}
+
+#[repr(C)]
+pub struct TopoDS_Face {
+	_data: [u8; 0],
+	_marker: core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,
+}
+
+#[repr(C)]
+pub struct TopoDS_Edge {
+	_data: [u8; 0],
+	_marker: core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,
+}
+
+/// Per-type deallocation (C++ `delete`). Implemented for the three opaque types.
+pub trait OcctFree {
+	/// # Safety
+	/// `ptr` must be a non-null pointer obtained from the C++ side and not yet freed.
+	unsafe fn occt_free(ptr: *mut Self);
+}
+
+impl OcctFree for TopoDS_Shape {
+	unsafe fn occt_free(ptr: *mut Self) {
+		raw::cadrum_shape_free(ptr)
 	}
-
-	// Expose Rust stream types to C++ for streambuf callbacks
-	extern "Rust" {
-		type RustReader;
-		type RustWriter;
-
-		fn rust_reader_read(reader: &mut RustReader, buf: &mut [u8]) -> usize;
-		fn rust_writer_write(writer: &mut RustWriter, buf: &[u8]) -> usize;
+}
+impl OcctFree for TopoDS_Face {
+	unsafe fn occt_free(ptr: *mut Self) {
+		raw::cadrum_face_free(ptr)
 	}
-
-	unsafe extern "C++" {
-		include!("cadrum/cpp/wrapper.h");
-
-		// Opaque C++ types (accessed as cadrum::TopoDS_Shape etc. via using aliases)
-		type TopoDS_Shape;
-		type TopoDS_Face;
-		type TopoDS_Edge;
-
-		// ==================== Shape I/O (streambuf callback) ====================
-
-		// Plain STEP I/O — used only without `color` feature.
-		// With color, STEP goes through XCAF (`read_step_color_stream` etc.).
-		#[cfg(not(feature = "color"))]
-		fn read_step_stream(reader: &mut RustReader) -> UniquePtr<TopoDS_Shape>;
-		#[cfg(not(feature = "color"))]
-		fn write_step_stream(shape: &TopoDS_Shape, writer: &mut RustWriter) -> bool;
-		fn read_brep_bin_stream(reader: &mut RustReader) -> UniquePtr<TopoDS_Shape>;
-		fn write_brep_bin_stream(shape: &TopoDS_Shape, writer: &mut RustWriter) -> bool;
-		fn read_brep_text_stream(reader: &mut RustReader) -> UniquePtr<TopoDS_Shape>;
-		fn write_brep_text_stream(shape: &TopoDS_Shape, writer: &mut RustWriter) -> bool;
-
-		// ==================== Shape Constructors ====================
-
-		fn make_half_space(ox: f64, oy: f64, oz: f64, nx: f64, ny: f64, nz: f64) -> UniquePtr<TopoDS_Shape>;
-
-		fn make_box(x1: f64, y1: f64, z1: f64, x2: f64, y2: f64, z2: f64) -> UniquePtr<TopoDS_Shape>;
-
-		fn make_cylinder(px: f64, py: f64, pz: f64, dx: f64, dy: f64, dz: f64, radius: f64, height: f64) -> UniquePtr<TopoDS_Shape>;
-
-		fn make_sphere(cx: f64, cy: f64, cz: f64, radius: f64) -> UniquePtr<TopoDS_Shape>;
-
-		fn make_cone(px: f64, py: f64, pz: f64, dx: f64, dy: f64, dz: f64, r1: f64, r2: f64, height: f64) -> UniquePtr<TopoDS_Shape>;
-
-		fn make_torus(px: f64, py: f64, pz: f64, dx: f64, dy: f64, dz: f64, r1: f64, r2: f64) -> UniquePtr<TopoDS_Shape>;
-
-		fn make_empty() -> UniquePtr<TopoDS_Shape>;
-
-		fn deep_copy(shape: &TopoDS_Shape) -> UniquePtr<TopoDS_Shape>;
-
-		// ==================== Colored STEP I/O (color feature only) ====================
-
-		#[cfg(feature = "color")]
-		fn read_step_color_stream(reader: &mut RustReader, out_ids: &mut Vec<u64>, out_rgb: &mut Vec<f32>) -> UniquePtr<TopoDS_Shape>;
-
-		#[cfg(feature = "color")]
-		fn write_step_color_stream(shape: &TopoDS_Shape, ids: &[u64], rgb: &[f32], writer: &mut RustWriter) -> bool;
-
-		// ==================== Builders (solid → solid with history) ====================
-
-		// Evaluate any boolean expression on N solids via BOPAlgo_CellsBuilder.
-		// `clauses` は DIMACS-flat DNF (`+i` = solids[i-1] を take、`-i` = avoid、`0` = clause 終端)。
-		// `out_history` の形式は builder_boolean と同じ。
-		fn builder_cells(solids: &CxxVector<TopoDS_Shape>, clauses: &[i64], out_history: &mut Vec<u64>) -> UniquePtr<TopoDS_Shape>;
-
-		// Unify shared faces. `out_history` receives flat [new_id, old_id, ...]
-		// pairs (same layout as `builder_boolean`), used by Solid::clean to populate
-		// `Solid::history` and remap the colormap when color is enabled.
-		fn builder_clean(shape: &TopoDS_Shape, out_history: &mut Vec<u64>) -> UniquePtr<TopoDS_Shape>;
-
-		// shell/fillet/chamfer fill `out_history` with flat [post_id, src_id]
-		// pairs (same layout as builder_cells) → Solid::history + colormap remap.
-		fn builder_thick_solid(solid: &TopoDS_Shape, open_faces: &CxxVector<TopoDS_Face>, thickness: f64, out_history: &mut Vec<u64>) -> UniquePtr<TopoDS_Shape>;
-		fn builder_fillet(solid: &TopoDS_Shape, edges: &CxxVector<TopoDS_Edge>, radius: f64, out_history: &mut Vec<u64>) -> UniquePtr<TopoDS_Shape>;
-		fn builder_chamfer(solid: &TopoDS_Shape, edges: &CxxVector<TopoDS_Edge>, distance: f64, out_history: &mut Vec<u64>) -> UniquePtr<TopoDS_Shape>;
-
-		// ==================== Transforms (solid → solid, no history) ====================
-
-		fn transform_translate(shape: &TopoDS_Shape, tx: f64, ty: f64, tz: f64) -> UniquePtr<TopoDS_Shape>;
-
-		fn transform_rotate(shape: &TopoDS_Shape, ox: f64, oy: f64, oz: f64, dx: f64, dy: f64, dz: f64, angle: f64) -> UniquePtr<TopoDS_Shape>;
-
-		fn transform_scale(shape: &TopoDS_Shape, cx: f64, cy: f64, cz: f64, factor: f64) -> UniquePtr<TopoDS_Shape>;
-
-		fn transform_mirror(shape: &TopoDS_Shape, ox: f64, oy: f64, oz: f64, nx: f64, ny: f64, nz: f64) -> UniquePtr<TopoDS_Shape>;
-
-		// ==================== Shape Queries ====================
-
-		fn shape_is_null(shape: &TopoDS_Shape) -> bool;
-		fn shape_is_solid(shape: &TopoDS_Shape) -> bool;
-		fn shape_volume(shape: &TopoDS_Shape) -> f64;
-		fn shape_surface_area(shape: &TopoDS_Shape) -> f64;
-		fn shape_center_of_mass(shape: &TopoDS_Shape, x: &mut f64, y: &mut f64, z: &mut f64);
-		fn shape_inertia_tensor(shape: &TopoDS_Shape, m00: &mut f64, m01: &mut f64, m02: &mut f64, m10: &mut f64, m11: &mut f64, m12: &mut f64, m20: &mut f64, m21: &mut f64, m22: &mut f64);
-		fn shape_contains_point(shape: &TopoDS_Shape, x: f64, y: f64, z: f64) -> bool;
-		fn shape_bounding_box(shape: &TopoDS_Shape, xmin: &mut f64, ymin: &mut f64, zmin: &mut f64, xmax: &mut f64, ymax: &mut f64, zmax: &mut f64);
-
-		// ==================== Compound Decompose/Compose ====================
-
-		fn decompose_into_solids(shape: &TopoDS_Shape) -> UniquePtr<CxxVector<TopoDS_Shape>>;
-		fn compound_add(compound: Pin<&mut TopoDS_Shape>, child: &TopoDS_Shape);
-
-		// ==================== Meshing ====================
-
-		fn mesh_shape(shape: &TopoDS_Shape, linear: f64, angular: f64, relative: bool) -> MeshData;
-
-		// ==================== Topology enumeration ====================
-
-		fn shape_edges(shape: &TopoDS_Shape) -> UniquePtr<CxxVector<TopoDS_Edge>>;
-		fn shape_faces(shape: &TopoDS_Shape) -> UniquePtr<CxxVector<TopoDS_Face>>;
-		fn face_edges(face: &TopoDS_Face) -> UniquePtr<CxxVector<TopoDS_Edge>>;
-
-		fn clone_shape_handle(shape: &TopoDS_Shape) -> UniquePtr<TopoDS_Shape>;
-		fn clone_edge_handle(edge: &TopoDS_Edge) -> UniquePtr<TopoDS_Edge>;
-		fn clone_face_handle(face: &TopoDS_Face) -> UniquePtr<TopoDS_Face>;
-
-		// ==================== Face Methods ====================
-
-		fn face_tshape_id(face: &TopoDS_Face) -> u64;
-		fn shape_tshape_id(shape: &TopoDS_Shape) -> u64;
-		fn edge_tshape_id(edge: &TopoDS_Edge) -> u64;
-
-		fn face_project_point(face: &TopoDS_Face, px: f64, py: f64, pz: f64, cpx: &mut f64, cpy: &mut f64, cpz: &mut f64, nx: &mut f64, ny: &mut f64, nz: &mut f64) -> bool;
-
-		// ==================== Edge Methods ====================
-
-		fn edge_approximation_segments(edge: &TopoDS_Edge, linear: f64, angular: f64, relative: bool) -> Vec<f64>;
-
-		fn make_helix_edge(ax: f64, ay: f64, az: f64, xrx: f64, xry: f64, xrz: f64, radius: f64, pitch: f64, height: f64) -> UniquePtr<TopoDS_Edge>;
-		fn make_polygon_edges(coords: &[f64]) -> UniquePtr<CxxVector<TopoDS_Edge>>;
-		fn make_circle_edge(ax: f64, ay: f64, az: f64, radius: f64) -> UniquePtr<TopoDS_Edge>;
-		fn make_line_edge(ax: f64, ay: f64, az: f64, bx: f64, by: f64, bz: f64) -> UniquePtr<TopoDS_Edge>;
-		fn make_arc_edge(sx: f64, sy: f64, sz: f64, mx: f64, my: f64, mz: f64, ex: f64, ey: f64, ez: f64) -> UniquePtr<TopoDS_Edge>;
-		fn make_bspline_edge(coords: &[f64], end_kind: u32, sx: f64, sy: f64, sz: f64, ex: f64, ey: f64, ez: f64) -> UniquePtr<TopoDS_Edge>;
-
-		fn edge_endpoints(edge: &TopoDS_Edge, sx: &mut f64, sy: &mut f64, sz: &mut f64, ex: &mut f64, ey: &mut f64, ez: &mut f64);
-		fn edge_tangents(edge: &TopoDS_Edge, sx: &mut f64, sy: &mut f64, sz: &mut f64, ex: &mut f64, ey: &mut f64, ez: &mut f64);
-		fn edge_is_closed(edge: &TopoDS_Edge) -> bool;
-		fn edge_project_point(edge: &TopoDS_Edge, px: f64, py: f64, pz: f64, cpx: &mut f64, cpy: &mut f64, cpz: &mut f64, tx: &mut f64, ty: &mut f64, tz: &mut f64) -> bool;
-
-		fn deep_copy_edge(edge: &TopoDS_Edge) -> UniquePtr<TopoDS_Edge>;
-
-		fn translate_edge(edge: &TopoDS_Edge, tx: f64, ty: f64, tz: f64) -> UniquePtr<TopoDS_Edge>;
-		fn rotate_edge(edge: &TopoDS_Edge, ox: f64, oy: f64, oz: f64, dx: f64, dy: f64, dz: f64, angle: f64) -> UniquePtr<TopoDS_Edge>;
-		fn scale_edge(edge: &TopoDS_Edge, cx: f64, cy: f64, cz: f64, factor: f64) -> UniquePtr<TopoDS_Edge>;
-		fn mirror_edge(edge: &TopoDS_Edge, ox: f64, oy: f64, oz: f64, nx: f64, ny: f64, nz: f64) -> UniquePtr<TopoDS_Edge>;
-
-		fn make_extrude(profile_edges: &CxxVector<TopoDS_Edge>, dx: f64, dy: f64, dz: f64) -> UniquePtr<TopoDS_Shape>;
-		fn make_pipe_shell(all_edges: &CxxVector<TopoDS_Edge>, spine_edges: &CxxVector<TopoDS_Edge>, orient: u32, ux: f64, uy: f64, uz: f64, aux_spine_edges: &CxxVector<TopoDS_Edge>) -> UniquePtr<TopoDS_Shape>;
-		fn make_loft(all_edges: &CxxVector<TopoDS_Edge>, ruled: bool) -> UniquePtr<TopoDS_Shape>;
-		fn make_sewn_solid(faces: &CxxVector<TopoDS_Face>, tolerance: f64) -> UniquePtr<TopoDS_Shape>;
-		fn make_offset_shape(shape: &TopoDS_Shape, offset: f64, tolerance: f64) -> UniquePtr<TopoDS_Shape>;
-		fn make_bspline_solid(coords: &[f64], nu: u32, nv: u32, u_periodic: bool) -> UniquePtr<TopoDS_Shape>;
-
-		fn edge_vec_new() -> UniquePtr<CxxVector<TopoDS_Edge>>;
-		fn edge_vec_push(v: Pin<&mut CxxVector<TopoDS_Edge>>, e: &TopoDS_Edge);
-		fn edge_vec_push_null(v: Pin<&mut CxxVector<TopoDS_Edge>>);
-
-		fn face_vec_new() -> UniquePtr<CxxVector<TopoDS_Face>>;
-		fn face_vec_push(v: Pin<&mut CxxVector<TopoDS_Face>>, f: &TopoDS_Face);
-
-		fn shape_vec_new() -> UniquePtr<CxxVector<TopoDS_Shape>>;
-		fn shape_vec_push(v: Pin<&mut CxxVector<TopoDS_Shape>>, s: &TopoDS_Shape);
-
+}
+impl OcctFree for TopoDS_Edge {
+	unsafe fn occt_free(ptr: *mut Self) {
+		raw::cadrum_edge_free(ptr)
 	}
 }
 
-// Re-export all bridge items so other modules can use `ffi::TopoDS_Shape` etc.
-pub use ffi_bridge::*;
+/// Owned C++ handle — the hand-written replacement for `cxx::UniquePtr<T>`.
+///
+/// Holds a raw `*mut T` returned by the wrapper and frees it on drop via the
+/// matching `cadrum_*_free`. `Deref` yields `&T` (callers rely on deref coercion
+/// when passing `&Owned<T>` to functions taking `&T`); `is_null` checks the
+/// Rust-level pointer (the FFI returns null on failure).
+pub struct Owned<T: OcctFree> {
+	ptr: *mut T,
+}
 
-// cxx opaque types default to `!Send + !Sync`. We mark them `Send` here so
-// that `UniquePtr<TopoDS_Shape>` (and friends) become `Send`, which in turn
-// makes our wrapper types (`Shape`, `Solid`, `Face`, `Edge`) auto-Send.
-//
-// Safety rationale:
-//   - `UniquePtr` gives exclusive ownership — no aliasing is possible.
-//   - These values are never shared across threads simultaneously; they are
-//     only *moved* to another thread, which is what `Send` permits.
-//   - `Sync` is intentionally NOT implemented: OCC's `Handle<Geom_XXX>`
-//     reference counts are non-atomic, so concurrent `&T` access across
-//     threads would be unsound.
-unsafe impl Send for TopoDS_Shape {}
-unsafe impl Send for TopoDS_Face {}
-unsafe impl Send for TopoDS_Edge {}
+impl<T: OcctFree> Owned<T> {
+	/// # Safety
+	/// `ptr` is either null or a valid owning pointer from the wrapper.
+	pub(crate) unsafe fn from_raw(ptr: *mut T) -> Self {
+		Owned { ptr }
+	}
+
+	pub fn is_null(&self) -> bool {
+		self.ptr.is_null()
+	}
+
+	pub(crate) fn as_ptr(&self) -> *const T {
+		self.ptr as *const T
+	}
+
+	pub(crate) fn as_mut_ptr(&mut self) -> *mut T {
+		self.ptr
+	}
+}
+
+impl<T: OcctFree> Drop for Owned<T> {
+	fn drop(&mut self) {
+		if !self.ptr.is_null() {
+			unsafe { T::occt_free(self.ptr) }
+		}
+	}
+}
+
+impl<T: OcctFree> std::ops::Deref for Owned<T> {
+	type Target = T;
+	fn deref(&self) -> &T {
+		// SAFETY: only ever called on a non-null handle — callers check
+		// `is_null()` on FFI returns before any deref (matching the previous
+		// `cxx::UniquePtr` contract).
+		unsafe { &*self.ptr }
+	}
+}
+
+// Mirrors the previous `unsafe impl Send for TopoDS_*`: an `Owned` handle has
+// exclusive ownership and may be *moved* across threads. `Sync` is intentionally
+// absent (raw pointer; OCC handle refcounts are non-atomic).
+unsafe impl<T: OcctFree> Send for Owned<T> {}
+
+// ==================== Mesh data ====================
+
+/// Triangulated mesh returned by [`mesh_shape`]. Plain Rust struct (the wrapper
+/// fills POD arrays which are copied in here).
+pub struct MeshData {
+	pub vertices: Vec<f64>, // flat xyz
+	pub uvs: Vec<f64>,      // flat uv
+	pub indices: Vec<u32>,
+	pub face_tshape_ids: Vec<u64>, // per-triangle TShape* address
+	pub success: bool,
+}
+
+/// POD mirror of `CMeshData` in `cpp/ffi.h`.
+#[repr(C)]
+struct CMeshData {
+	vertices: *mut f64,
+	vertices_len: usize,
+	uvs: *mut f64,
+	uvs_len: usize,
+	indices: *mut u32,
+	indices_len: usize,
+	face_ids: *mut u64,
+	face_ids_len: usize,
+	success: bool,
+}
+
+// ==================== Raw extern "C" declarations ====================
+
+mod raw {
+	use super::{CMeshData, CReader, CWriter, TopoDS_Edge, TopoDS_Face, TopoDS_Shape};
+	use std::ffi::c_void;
+
+	extern "C" {
+		pub fn cadrum_free(p: *mut c_void);
+		pub fn cadrum_shape_free(p: *mut TopoDS_Shape);
+		pub fn cadrum_face_free(p: *mut TopoDS_Face);
+		pub fn cadrum_edge_free(p: *mut TopoDS_Edge);
+
+		#[cfg(not(feature = "color"))]
+		pub fn read_step_stream(reader: *const CReader) -> *mut TopoDS_Shape;
+		#[cfg(not(feature = "color"))]
+		pub fn write_step_stream(shape: *const TopoDS_Shape, writer: *const CWriter) -> bool;
+		pub fn read_brep_bin_stream(reader: *const CReader) -> *mut TopoDS_Shape;
+		pub fn write_brep_bin_stream(shape: *const TopoDS_Shape, writer: *const CWriter) -> bool;
+		pub fn read_brep_text_stream(reader: *const CReader) -> *mut TopoDS_Shape;
+		pub fn write_brep_text_stream(shape: *const TopoDS_Shape, writer: *const CWriter) -> bool;
+
+		pub fn make_half_space(ox: f64, oy: f64, oz: f64, nx: f64, ny: f64, nz: f64) -> *mut TopoDS_Shape;
+		pub fn make_box(x1: f64, y1: f64, z1: f64, x2: f64, y2: f64, z2: f64) -> *mut TopoDS_Shape;
+		pub fn make_cylinder(px: f64, py: f64, pz: f64, dx: f64, dy: f64, dz: f64, radius: f64, height: f64) -> *mut TopoDS_Shape;
+		pub fn make_sphere(cx: f64, cy: f64, cz: f64, radius: f64) -> *mut TopoDS_Shape;
+		pub fn make_cone(px: f64, py: f64, pz: f64, dx: f64, dy: f64, dz: f64, r1: f64, r2: f64, height: f64) -> *mut TopoDS_Shape;
+		pub fn make_torus(px: f64, py: f64, pz: f64, dx: f64, dy: f64, dz: f64, r1: f64, r2: f64) -> *mut TopoDS_Shape;
+		pub fn make_empty() -> *mut TopoDS_Shape;
+		pub fn deep_copy(shape: *const TopoDS_Shape) -> *mut TopoDS_Shape;
+
+		pub fn builder_cells(solids: *const *const TopoDS_Shape, n_solids: usize, clauses: *const i64, n_clauses: usize, out_history: *mut *mut u64, out_history_len: *mut usize) -> *mut TopoDS_Shape;
+		pub fn builder_clean(shape: *const TopoDS_Shape, out_history: *mut *mut u64, out_history_len: *mut usize) -> *mut TopoDS_Shape;
+		pub fn builder_thick_solid(solid: *const TopoDS_Shape, open_faces: *const *const TopoDS_Face, n_faces: usize, thickness: f64, out_history: *mut *mut u64, out_history_len: *mut usize) -> *mut TopoDS_Shape;
+		pub fn builder_fillet(solid: *const TopoDS_Shape, edges: *const *const TopoDS_Edge, n_edges: usize, radius: f64, out_history: *mut *mut u64, out_history_len: *mut usize) -> *mut TopoDS_Shape;
+		pub fn builder_chamfer(solid: *const TopoDS_Shape, edges: *const *const TopoDS_Edge, n_edges: usize, distance: f64, out_history: *mut *mut u64, out_history_len: *mut usize) -> *mut TopoDS_Shape;
+
+		pub fn transform_translate(shape: *const TopoDS_Shape, tx: f64, ty: f64, tz: f64) -> *mut TopoDS_Shape;
+		pub fn transform_rotate(shape: *const TopoDS_Shape, ox: f64, oy: f64, oz: f64, dx: f64, dy: f64, dz: f64, angle: f64) -> *mut TopoDS_Shape;
+		pub fn transform_scale(shape: *const TopoDS_Shape, cx: f64, cy: f64, cz: f64, factor: f64) -> *mut TopoDS_Shape;
+		pub fn transform_mirror(shape: *const TopoDS_Shape, ox: f64, oy: f64, oz: f64, nx: f64, ny: f64, nz: f64) -> *mut TopoDS_Shape;
+
+		pub fn shape_is_null(shape: *const TopoDS_Shape) -> bool;
+		pub fn shape_is_solid(shape: *const TopoDS_Shape) -> bool;
+		pub fn shape_volume(shape: *const TopoDS_Shape) -> f64;
+		pub fn shape_surface_area(shape: *const TopoDS_Shape) -> f64;
+		pub fn shape_center_of_mass(shape: *const TopoDS_Shape, x: *mut f64, y: *mut f64, z: *mut f64);
+		pub fn shape_inertia_tensor(shape: *const TopoDS_Shape, m00: *mut f64, m01: *mut f64, m02: *mut f64, m10: *mut f64, m11: *mut f64, m12: *mut f64, m20: *mut f64, m21: *mut f64, m22: *mut f64);
+		pub fn shape_contains_point(shape: *const TopoDS_Shape, x: f64, y: f64, z: f64) -> bool;
+		pub fn shape_bounding_box(shape: *const TopoDS_Shape, xmin: *mut f64, ymin: *mut f64, zmin: *mut f64, xmax: *mut f64, ymax: *mut f64, zmax: *mut f64);
+
+		pub fn decompose_into_solids(shape: *const TopoDS_Shape, out_len: *mut usize) -> *mut *mut TopoDS_Shape;
+		pub fn compound_add(compound: *mut TopoDS_Shape, child: *const TopoDS_Shape);
+
+		pub fn mesh_shape(shape: *const TopoDS_Shape, linear: f64, angular: f64, relative: bool) -> CMeshData;
+
+		pub fn shape_edges(shape: *const TopoDS_Shape, out_len: *mut usize) -> *mut *mut TopoDS_Edge;
+		pub fn shape_faces(shape: *const TopoDS_Shape, out_len: *mut usize) -> *mut *mut TopoDS_Face;
+		pub fn face_edges(face: *const TopoDS_Face, out_len: *mut usize) -> *mut *mut TopoDS_Edge;
+		pub fn clone_shape_handle(shape: *const TopoDS_Shape) -> *mut TopoDS_Shape;
+
+		pub fn face_tshape_id(face: *const TopoDS_Face) -> u64;
+		pub fn shape_tshape_id(shape: *const TopoDS_Shape) -> u64;
+		pub fn edge_tshape_id(edge: *const TopoDS_Edge) -> u64;
+		pub fn face_project_point(face: *const TopoDS_Face, px: f64, py: f64, pz: f64, cpx: *mut f64, cpy: *mut f64, cpz: *mut f64, nx: *mut f64, ny: *mut f64, nz: *mut f64) -> bool;
+
+		pub fn edge_approximation_segments(edge: *const TopoDS_Edge, linear: f64, angular: f64, relative: bool, out_len: *mut usize) -> *mut f64;
+		pub fn make_helix_edge(ax: f64, ay: f64, az: f64, xrx: f64, xry: f64, xrz: f64, radius: f64, pitch: f64, height: f64) -> *mut TopoDS_Edge;
+		pub fn make_polygon_edges(coords: *const f64, n_coords: usize, out_len: *mut usize) -> *mut *mut TopoDS_Edge;
+		pub fn make_circle_edge(ax: f64, ay: f64, az: f64, radius: f64) -> *mut TopoDS_Edge;
+		pub fn make_line_edge(ax: f64, ay: f64, az: f64, bx: f64, by: f64, bz: f64) -> *mut TopoDS_Edge;
+		pub fn make_arc_edge(sx: f64, sy: f64, sz: f64, mx: f64, my: f64, mz: f64, ex: f64, ey: f64, ez: f64) -> *mut TopoDS_Edge;
+		pub fn make_bspline_edge(coords: *const f64, n_coords: usize, end_kind: u32, sx: f64, sy: f64, sz: f64, ex: f64, ey: f64, ez: f64) -> *mut TopoDS_Edge;
+		pub fn edge_endpoints(edge: *const TopoDS_Edge, sx: *mut f64, sy: *mut f64, sz: *mut f64, ex: *mut f64, ey: *mut f64, ez: *mut f64);
+		pub fn edge_tangents(edge: *const TopoDS_Edge, sx: *mut f64, sy: *mut f64, sz: *mut f64, ex: *mut f64, ey: *mut f64, ez: *mut f64);
+		pub fn edge_is_closed(edge: *const TopoDS_Edge) -> bool;
+		pub fn edge_project_point(edge: *const TopoDS_Edge, px: f64, py: f64, pz: f64, cpx: *mut f64, cpy: *mut f64, cpz: *mut f64, tx: *mut f64, ty: *mut f64, tz: *mut f64) -> bool;
+		pub fn deep_copy_edge(edge: *const TopoDS_Edge) -> *mut TopoDS_Edge;
+		pub fn translate_edge(edge: *const TopoDS_Edge, tx: f64, ty: f64, tz: f64) -> *mut TopoDS_Edge;
+		pub fn rotate_edge(edge: *const TopoDS_Edge, ox: f64, oy: f64, oz: f64, dx: f64, dy: f64, dz: f64, angle: f64) -> *mut TopoDS_Edge;
+		pub fn scale_edge(edge: *const TopoDS_Edge, cx: f64, cy: f64, cz: f64, factor: f64) -> *mut TopoDS_Edge;
+		pub fn mirror_edge(edge: *const TopoDS_Edge, ox: f64, oy: f64, oz: f64, nx: f64, ny: f64, nz: f64) -> *mut TopoDS_Edge;
+		pub fn make_extrude(profile_edges: *const *const TopoDS_Edge, n_profile: usize, dx: f64, dy: f64, dz: f64) -> *mut TopoDS_Shape;
+		pub fn make_pipe_shell(all_edges: *const *const TopoDS_Edge, n_all: usize, spine_edges: *const *const TopoDS_Edge, n_spine: usize, orient: u32, ux: f64, uy: f64, uz: f64, aux_spine_edges: *const *const TopoDS_Edge, n_aux: usize) -> *mut TopoDS_Shape;
+		pub fn make_loft(all_edges: *const *const TopoDS_Edge, n_all: usize, ruled: bool) -> *mut TopoDS_Shape;
+		pub fn make_sewn_solid(faces: *const *const TopoDS_Face, n_faces: usize, tolerance: f64) -> *mut TopoDS_Shape;
+		pub fn make_offset_shape(shape: *const TopoDS_Shape, offset: f64, tolerance: f64) -> *mut TopoDS_Shape;
+		pub fn make_bspline_solid(coords: *const f64, n_coords: usize, nu: u32, nv: u32, u_periodic: bool) -> *mut TopoDS_Shape;
+
+		#[cfg(feature = "color")]
+		pub fn read_step_color_stream(reader: *const CReader, out_ids: *mut *mut u64, out_ids_len: *mut usize, out_rgb: *mut *mut f32, out_rgb_len: *mut usize) -> *mut TopoDS_Shape;
+		#[cfg(feature = "color")]
+		pub fn write_step_color_stream(shape: *const TopoDS_Shape, ids: *const u64, n_ids: usize, rgb: *const f32, n_rgb: usize, writer: *const CWriter) -> bool;
+	}
+}
+
+// ==================== Marshaling helpers ====================
+
+/// Copy a malloc'd POD buffer into a `Vec` and free it.
+///
+/// # Safety
+/// `ptr` is null or points to `len` `T` allocated by the wrapper with malloc.
+unsafe fn take_pod<T: Copy>(ptr: *mut T, len: usize) -> Vec<T> {
+	if ptr.is_null() {
+		return Vec::new();
+	}
+	let v = std::slice::from_raw_parts(ptr, len).to_vec();
+	raw::cadrum_free(ptr as *mut c_void);
+	v
+}
+
+/// Wrap a malloc'd array of owned handles into `Vec<Owned<T>>` and free the array.
+///
+/// # Safety
+/// `arr` is null or points to `len` owning `*mut T` allocated with malloc.
+unsafe fn take_owned<T: OcctFree>(arr: *mut *mut T, len: usize) -> Vec<Owned<T>> {
+	let v = (0..len).map(|i| Owned::from_raw(*arr.add(i))).collect();
+	if !arr.is_null() {
+		raw::cadrum_free(arr as *mut c_void);
+	}
+	v
+}
+
+/// Append a malloc'd `u64` history buffer to `out` and free it.
+///
+/// # Safety
+/// `ptr` is null or points to `len` `u64` allocated with malloc.
+unsafe fn append_history(out: &mut Vec<u64>, ptr: *mut u64, len: usize) {
+	if !ptr.is_null() {
+		out.extend_from_slice(std::slice::from_raw_parts(ptr, len));
+		raw::cadrum_free(ptr as *mut c_void);
+	}
+}
+
+// ==================== Safe wrappers ====================
+
+// ---- Shape I/O ----
+
+#[cfg(not(feature = "color"))]
+pub fn read_step_stream(reader: &mut RustReader) -> Owned<TopoDS_Shape> {
+	let c = reader.as_c();
+	unsafe { Owned::from_raw(raw::read_step_stream(&c)) }
+}
+
+#[cfg(not(feature = "color"))]
+pub fn write_step_stream(shape: &TopoDS_Shape, writer: &mut RustWriter) -> bool {
+	let c = writer.as_c();
+	unsafe { raw::write_step_stream(shape, &c) }
+}
+
+pub fn read_brep_bin_stream(reader: &mut RustReader) -> Owned<TopoDS_Shape> {
+	let c = reader.as_c();
+	unsafe { Owned::from_raw(raw::read_brep_bin_stream(&c)) }
+}
+
+pub fn write_brep_bin_stream(shape: &TopoDS_Shape, writer: &mut RustWriter) -> bool {
+	let c = writer.as_c();
+	unsafe { raw::write_brep_bin_stream(shape, &c) }
+}
+
+pub fn read_brep_text_stream(reader: &mut RustReader) -> Owned<TopoDS_Shape> {
+	let c = reader.as_c();
+	unsafe { Owned::from_raw(raw::read_brep_text_stream(&c)) }
+}
+
+pub fn write_brep_text_stream(shape: &TopoDS_Shape, writer: &mut RustWriter) -> bool {
+	let c = writer.as_c();
+	unsafe { raw::write_brep_text_stream(shape, &c) }
+}
+
+// ---- Constructors ----
+
+pub fn make_half_space(ox: f64, oy: f64, oz: f64, nx: f64, ny: f64, nz: f64) -> Owned<TopoDS_Shape> {
+	unsafe { Owned::from_raw(raw::make_half_space(ox, oy, oz, nx, ny, nz)) }
+}
+pub fn make_box(x1: f64, y1: f64, z1: f64, x2: f64, y2: f64, z2: f64) -> Owned<TopoDS_Shape> {
+	unsafe { Owned::from_raw(raw::make_box(x1, y1, z1, x2, y2, z2)) }
+}
+pub fn make_cylinder(px: f64, py: f64, pz: f64, dx: f64, dy: f64, dz: f64, radius: f64, height: f64) -> Owned<TopoDS_Shape> {
+	unsafe { Owned::from_raw(raw::make_cylinder(px, py, pz, dx, dy, dz, radius, height)) }
+}
+pub fn make_sphere(cx: f64, cy: f64, cz: f64, radius: f64) -> Owned<TopoDS_Shape> {
+	unsafe { Owned::from_raw(raw::make_sphere(cx, cy, cz, radius)) }
+}
+pub fn make_cone(px: f64, py: f64, pz: f64, dx: f64, dy: f64, dz: f64, r1: f64, r2: f64, height: f64) -> Owned<TopoDS_Shape> {
+	unsafe { Owned::from_raw(raw::make_cone(px, py, pz, dx, dy, dz, r1, r2, height)) }
+}
+pub fn make_torus(px: f64, py: f64, pz: f64, dx: f64, dy: f64, dz: f64, r1: f64, r2: f64) -> Owned<TopoDS_Shape> {
+	unsafe { Owned::from_raw(raw::make_torus(px, py, pz, dx, dy, dz, r1, r2)) }
+}
+pub fn make_empty() -> Owned<TopoDS_Shape> {
+	unsafe { Owned::from_raw(raw::make_empty()) }
+}
+pub fn deep_copy(shape: &TopoDS_Shape) -> Owned<TopoDS_Shape> {
+	unsafe { Owned::from_raw(raw::deep_copy(shape)) }
+}
+
+// ---- Builders ----
+
+pub fn builder_cells(solids: &[*const TopoDS_Shape], clauses: &[i64], out_history: &mut Vec<u64>) -> Owned<TopoDS_Shape> {
+	let mut hp: *mut u64 = std::ptr::null_mut();
+	let mut hl: usize = 0;
+	unsafe {
+		let s = raw::builder_cells(solids.as_ptr(), solids.len(), clauses.as_ptr(), clauses.len(), &mut hp, &mut hl);
+		append_history(out_history, hp, hl);
+		Owned::from_raw(s)
+	}
+}
+
+pub fn builder_clean(shape: &TopoDS_Shape, out_history: &mut Vec<u64>) -> Owned<TopoDS_Shape> {
+	let mut hp: *mut u64 = std::ptr::null_mut();
+	let mut hl: usize = 0;
+	unsafe {
+		let s = raw::builder_clean(shape, &mut hp, &mut hl);
+		append_history(out_history, hp, hl);
+		Owned::from_raw(s)
+	}
+}
+
+pub fn builder_thick_solid(solid: &TopoDS_Shape, open_faces: &[*const TopoDS_Face], thickness: f64, out_history: &mut Vec<u64>) -> Owned<TopoDS_Shape> {
+	let mut hp: *mut u64 = std::ptr::null_mut();
+	let mut hl: usize = 0;
+	unsafe {
+		let s = raw::builder_thick_solid(solid, open_faces.as_ptr(), open_faces.len(), thickness, &mut hp, &mut hl);
+		append_history(out_history, hp, hl);
+		Owned::from_raw(s)
+	}
+}
+
+pub fn builder_fillet(solid: &TopoDS_Shape, edges: &[*const TopoDS_Edge], radius: f64, out_history: &mut Vec<u64>) -> Owned<TopoDS_Shape> {
+	let mut hp: *mut u64 = std::ptr::null_mut();
+	let mut hl: usize = 0;
+	unsafe {
+		let s = raw::builder_fillet(solid, edges.as_ptr(), edges.len(), radius, &mut hp, &mut hl);
+		append_history(out_history, hp, hl);
+		Owned::from_raw(s)
+	}
+}
+
+pub fn builder_chamfer(solid: &TopoDS_Shape, edges: &[*const TopoDS_Edge], distance: f64, out_history: &mut Vec<u64>) -> Owned<TopoDS_Shape> {
+	let mut hp: *mut u64 = std::ptr::null_mut();
+	let mut hl: usize = 0;
+	unsafe {
+		let s = raw::builder_chamfer(solid, edges.as_ptr(), edges.len(), distance, &mut hp, &mut hl);
+		append_history(out_history, hp, hl);
+		Owned::from_raw(s)
+	}
+}
+
+// ---- Transforms ----
+
+pub fn transform_translate(shape: &TopoDS_Shape, tx: f64, ty: f64, tz: f64) -> Owned<TopoDS_Shape> {
+	unsafe { Owned::from_raw(raw::transform_translate(shape, tx, ty, tz)) }
+}
+pub fn transform_rotate(shape: &TopoDS_Shape, ox: f64, oy: f64, oz: f64, dx: f64, dy: f64, dz: f64, angle: f64) -> Owned<TopoDS_Shape> {
+	unsafe { Owned::from_raw(raw::transform_rotate(shape, ox, oy, oz, dx, dy, dz, angle)) }
+}
+pub fn transform_scale(shape: &TopoDS_Shape, cx: f64, cy: f64, cz: f64, factor: f64) -> Owned<TopoDS_Shape> {
+	unsafe { Owned::from_raw(raw::transform_scale(shape, cx, cy, cz, factor)) }
+}
+pub fn transform_mirror(shape: &TopoDS_Shape, ox: f64, oy: f64, oz: f64, nx: f64, ny: f64, nz: f64) -> Owned<TopoDS_Shape> {
+	unsafe { Owned::from_raw(raw::transform_mirror(shape, ox, oy, oz, nx, ny, nz)) }
+}
+
+// ---- Queries ----
+
+pub fn shape_is_null(shape: &TopoDS_Shape) -> bool {
+	unsafe { raw::shape_is_null(shape) }
+}
+pub fn shape_is_solid(shape: &TopoDS_Shape) -> bool {
+	unsafe { raw::shape_is_solid(shape) }
+}
+pub fn shape_volume(shape: &TopoDS_Shape) -> f64 {
+	unsafe { raw::shape_volume(shape) }
+}
+pub fn shape_surface_area(shape: &TopoDS_Shape) -> f64 {
+	unsafe { raw::shape_surface_area(shape) }
+}
+pub fn shape_center_of_mass(shape: &TopoDS_Shape, x: &mut f64, y: &mut f64, z: &mut f64) {
+	unsafe { raw::shape_center_of_mass(shape, x, y, z) }
+}
+#[allow(clippy::too_many_arguments)]
+pub fn shape_inertia_tensor(shape: &TopoDS_Shape, m00: &mut f64, m01: &mut f64, m02: &mut f64, m10: &mut f64, m11: &mut f64, m12: &mut f64, m20: &mut f64, m21: &mut f64, m22: &mut f64) {
+	unsafe { raw::shape_inertia_tensor(shape, m00, m01, m02, m10, m11, m12, m20, m21, m22) }
+}
+pub fn shape_contains_point(shape: &TopoDS_Shape, x: f64, y: f64, z: f64) -> bool {
+	unsafe { raw::shape_contains_point(shape, x, y, z) }
+}
+pub fn shape_bounding_box(shape: &TopoDS_Shape, xmin: &mut f64, ymin: &mut f64, zmin: &mut f64, xmax: &mut f64, ymax: &mut f64, zmax: &mut f64) {
+	unsafe { raw::shape_bounding_box(shape, xmin, ymin, zmin, xmax, ymax, zmax) }
+}
+
+// ---- Compound ----
+
+pub fn decompose_into_solids(shape: &TopoDS_Shape) -> Vec<Owned<TopoDS_Shape>> {
+	let mut len: usize = 0;
+	unsafe {
+		let arr = raw::decompose_into_solids(shape, &mut len);
+		take_owned(arr, len)
+	}
+}
+
+pub fn compound_add(compound: &mut Owned<TopoDS_Shape>, child: &TopoDS_Shape) {
+	unsafe { raw::compound_add(compound.as_mut_ptr(), child) }
+}
+
+// ---- Meshing ----
+
+pub fn mesh_shape(shape: &TopoDS_Shape, linear: f64, angular: f64, relative: bool) -> MeshData {
+	unsafe {
+		let m = raw::mesh_shape(shape, linear, angular, relative);
+		MeshData {
+			vertices: take_pod(m.vertices, m.vertices_len),
+			uvs: take_pod(m.uvs, m.uvs_len),
+			indices: take_pod(m.indices, m.indices_len),
+			face_tshape_ids: take_pod(m.face_ids, m.face_ids_len),
+			success: m.success,
+		}
+	}
+}
+
+// ---- Topology enumeration ----
+
+pub fn shape_edges(shape: &TopoDS_Shape) -> Vec<Owned<TopoDS_Edge>> {
+	let mut len: usize = 0;
+	unsafe {
+		let arr = raw::shape_edges(shape, &mut len);
+		take_owned(arr, len)
+	}
+}
+pub fn shape_faces(shape: &TopoDS_Shape) -> Vec<Owned<TopoDS_Face>> {
+	let mut len: usize = 0;
+	unsafe {
+		let arr = raw::shape_faces(shape, &mut len);
+		take_owned(arr, len)
+	}
+}
+pub fn face_edges(face: &TopoDS_Face) -> Vec<Owned<TopoDS_Edge>> {
+	let mut len: usize = 0;
+	unsafe {
+		let arr = raw::face_edges(face, &mut len);
+		take_owned(arr, len)
+	}
+}
+pub fn clone_shape_handle(shape: &TopoDS_Shape) -> Owned<TopoDS_Shape> {
+	unsafe { Owned::from_raw(raw::clone_shape_handle(shape)) }
+}
+
+// ---- Face / Edge ids ----
+
+pub fn face_tshape_id(face: &TopoDS_Face) -> u64 {
+	unsafe { raw::face_tshape_id(face) }
+}
+pub fn shape_tshape_id(shape: &TopoDS_Shape) -> u64 {
+	unsafe { raw::shape_tshape_id(shape) }
+}
+pub fn edge_tshape_id(edge: &TopoDS_Edge) -> u64 {
+	unsafe { raw::edge_tshape_id(edge) }
+}
+#[allow(clippy::too_many_arguments)]
+pub fn face_project_point(face: &TopoDS_Face, px: f64, py: f64, pz: f64, cpx: &mut f64, cpy: &mut f64, cpz: &mut f64, nx: &mut f64, ny: &mut f64, nz: &mut f64) -> bool {
+	unsafe { raw::face_project_point(face, px, py, pz, cpx, cpy, cpz, nx, ny, nz) }
+}
+
+// ---- Edge methods ----
+
+pub fn edge_approximation_segments(edge: &TopoDS_Edge, linear: f64, angular: f64, relative: bool) -> Vec<f64> {
+	let mut len: usize = 0;
+	unsafe {
+		let p = raw::edge_approximation_segments(edge, linear, angular, relative, &mut len);
+		take_pod(p, len)
+	}
+}
+pub fn make_helix_edge(ax: f64, ay: f64, az: f64, xrx: f64, xry: f64, xrz: f64, radius: f64, pitch: f64, height: f64) -> Owned<TopoDS_Edge> {
+	unsafe { Owned::from_raw(raw::make_helix_edge(ax, ay, az, xrx, xry, xrz, radius, pitch, height)) }
+}
+pub fn make_polygon_edges(coords: &[f64]) -> Vec<Owned<TopoDS_Edge>> {
+	let mut len: usize = 0;
+	unsafe {
+		let arr = raw::make_polygon_edges(coords.as_ptr(), coords.len(), &mut len);
+		take_owned(arr, len)
+	}
+}
+pub fn make_circle_edge(ax: f64, ay: f64, az: f64, radius: f64) -> Owned<TopoDS_Edge> {
+	unsafe { Owned::from_raw(raw::make_circle_edge(ax, ay, az, radius)) }
+}
+pub fn make_line_edge(ax: f64, ay: f64, az: f64, bx: f64, by: f64, bz: f64) -> Owned<TopoDS_Edge> {
+	unsafe { Owned::from_raw(raw::make_line_edge(ax, ay, az, bx, by, bz)) }
+}
+pub fn make_arc_edge(sx: f64, sy: f64, sz: f64, mx: f64, my: f64, mz: f64, ex: f64, ey: f64, ez: f64) -> Owned<TopoDS_Edge> {
+	unsafe { Owned::from_raw(raw::make_arc_edge(sx, sy, sz, mx, my, mz, ex, ey, ez)) }
+}
+#[allow(clippy::too_many_arguments)]
+pub fn make_bspline_edge(coords: &[f64], end_kind: u32, sx: f64, sy: f64, sz: f64, ex: f64, ey: f64, ez: f64) -> Owned<TopoDS_Edge> {
+	unsafe { Owned::from_raw(raw::make_bspline_edge(coords.as_ptr(), coords.len(), end_kind, sx, sy, sz, ex, ey, ez)) }
+}
+pub fn edge_endpoints(edge: &TopoDS_Edge, sx: &mut f64, sy: &mut f64, sz: &mut f64, ex: &mut f64, ey: &mut f64, ez: &mut f64) {
+	unsafe { raw::edge_endpoints(edge, sx, sy, sz, ex, ey, ez) }
+}
+pub fn edge_tangents(edge: &TopoDS_Edge, sx: &mut f64, sy: &mut f64, sz: &mut f64, ex: &mut f64, ey: &mut f64, ez: &mut f64) {
+	unsafe { raw::edge_tangents(edge, sx, sy, sz, ex, ey, ez) }
+}
+pub fn edge_is_closed(edge: &TopoDS_Edge) -> bool {
+	unsafe { raw::edge_is_closed(edge) }
+}
+#[allow(clippy::too_many_arguments)]
+pub fn edge_project_point(edge: &TopoDS_Edge, px: f64, py: f64, pz: f64, cpx: &mut f64, cpy: &mut f64, cpz: &mut f64, tx: &mut f64, ty: &mut f64, tz: &mut f64) -> bool {
+	unsafe { raw::edge_project_point(edge, px, py, pz, cpx, cpy, cpz, tx, ty, tz) }
+}
+pub fn deep_copy_edge(edge: &TopoDS_Edge) -> Owned<TopoDS_Edge> {
+	unsafe { Owned::from_raw(raw::deep_copy_edge(edge)) }
+}
+pub fn translate_edge(edge: &TopoDS_Edge, tx: f64, ty: f64, tz: f64) -> Owned<TopoDS_Edge> {
+	unsafe { Owned::from_raw(raw::translate_edge(edge, tx, ty, tz)) }
+}
+pub fn rotate_edge(edge: &TopoDS_Edge, ox: f64, oy: f64, oz: f64, dx: f64, dy: f64, dz: f64, angle: f64) -> Owned<TopoDS_Edge> {
+	unsafe { Owned::from_raw(raw::rotate_edge(edge, ox, oy, oz, dx, dy, dz, angle)) }
+}
+pub fn scale_edge(edge: &TopoDS_Edge, cx: f64, cy: f64, cz: f64, factor: f64) -> Owned<TopoDS_Edge> {
+	unsafe { Owned::from_raw(raw::scale_edge(edge, cx, cy, cz, factor)) }
+}
+pub fn mirror_edge(edge: &TopoDS_Edge, ox: f64, oy: f64, oz: f64, nx: f64, ny: f64, nz: f64) -> Owned<TopoDS_Edge> {
+	unsafe { Owned::from_raw(raw::mirror_edge(edge, ox, oy, oz, nx, ny, nz)) }
+}
+pub fn make_extrude(profile_edges: &[*const TopoDS_Edge], dx: f64, dy: f64, dz: f64) -> Owned<TopoDS_Shape> {
+	unsafe { Owned::from_raw(raw::make_extrude(profile_edges.as_ptr(), profile_edges.len(), dx, dy, dz)) }
+}
+#[allow(clippy::too_many_arguments)]
+pub fn make_pipe_shell(all_edges: &[*const TopoDS_Edge], spine_edges: &[*const TopoDS_Edge], orient: u32, ux: f64, uy: f64, uz: f64, aux_spine_edges: &[*const TopoDS_Edge]) -> Owned<TopoDS_Shape> {
+	unsafe { Owned::from_raw(raw::make_pipe_shell(all_edges.as_ptr(), all_edges.len(), spine_edges.as_ptr(), spine_edges.len(), orient, ux, uy, uz, aux_spine_edges.as_ptr(), aux_spine_edges.len())) }
+}
+pub fn make_loft(all_edges: &[*const TopoDS_Edge], ruled: bool) -> Owned<TopoDS_Shape> {
+	unsafe { Owned::from_raw(raw::make_loft(all_edges.as_ptr(), all_edges.len(), ruled)) }
+}
+pub fn make_sewn_solid(faces: &[*const TopoDS_Face], tolerance: f64) -> Owned<TopoDS_Shape> {
+	unsafe { Owned::from_raw(raw::make_sewn_solid(faces.as_ptr(), faces.len(), tolerance)) }
+}
+pub fn make_offset_shape(shape: &TopoDS_Shape, offset: f64, tolerance: f64) -> Owned<TopoDS_Shape> {
+	unsafe { Owned::from_raw(raw::make_offset_shape(shape, offset, tolerance)) }
+}
+pub fn make_bspline_solid(coords: &[f64], nu: u32, nv: u32, u_periodic: bool) -> Owned<TopoDS_Shape> {
+	unsafe { Owned::from_raw(raw::make_bspline_solid(coords.as_ptr(), coords.len(), nu, nv, u_periodic)) }
+}
+
+// ---- Colored STEP I/O ----
+
+#[cfg(feature = "color")]
+pub fn read_step_color_stream(reader: &mut RustReader, out_ids: &mut Vec<u64>, out_rgb: &mut Vec<f32>) -> Owned<TopoDS_Shape> {
+	let c = reader.as_c();
+	let mut ids_p: *mut u64 = std::ptr::null_mut();
+	let mut ids_l: usize = 0;
+	let mut rgb_p: *mut f32 = std::ptr::null_mut();
+	let mut rgb_l: usize = 0;
+	unsafe {
+		let s = raw::read_step_color_stream(&c, &mut ids_p, &mut ids_l, &mut rgb_p, &mut rgb_l);
+		out_ids.extend(take_pod(ids_p, ids_l));
+		out_rgb.extend(take_pod(rgb_p, rgb_l));
+		Owned::from_raw(s)
+	}
+}
+
+#[cfg(feature = "color")]
+pub fn write_step_color_stream(shape: &TopoDS_Shape, ids: &[u64], rgb: &[f32], writer: &mut RustWriter) -> bool {
+	let c = writer.as_c();
+	unsafe { raw::write_step_color_stream(shape, ids.as_ptr(), ids.len(), rgb.as_ptr(), rgb.len(), &c) }
+}

--- a/src/occt/io.rs
+++ b/src/occt/io.rs
@@ -43,7 +43,7 @@ fn strip_color_trailer(buf: &[u8]) -> (std::collections::HashMap<u64, Color>, us
 #[cfg(feature = "color")]
 fn resolve_color_trailer(inner: &ffi::TopoDS_Shape, index_colormap: &std::collections::HashMap<u64, Color>) -> std::collections::HashMap<u64, Color> {
 	let faces = ffi::shape_faces(inner);
-	let index_to_id: Vec<u64> = faces.iter().map(ffi::face_tshape_id).collect();
+	let index_to_id: Vec<u64> = faces.iter().map(|f| ffi::face_tshape_id(f)).collect();
 	index_colormap.iter().filter_map(|(&idx, &color)| index_to_id.get(idx as usize).map(|&id| (id, color))).collect()
 }
 
@@ -112,7 +112,7 @@ pub(super) fn read_brep_text<R: Read>(reader: &mut R) -> Result<Vec<Solid>, Erro
 /// Shared body for BRep binary/text reads. The two variants differ only in
 /// which FFI stream parser they call; everything else (color trailer handling,
 /// null check, decompose) is identical.
-fn read_brep_with<R: Read>(reader: &mut R, ffi_read: fn(&mut RustReader) -> cxx::UniquePtr<ffi::TopoDS_Shape>) -> Result<Vec<Solid>, Error> {
+fn read_brep_with<R: Read>(reader: &mut R, ffi_read: fn(&mut RustReader) -> ffi::Owned<ffi::TopoDS_Shape>) -> Result<Vec<Solid>, Error> {
 	#[cfg(feature = "color")]
 	{
 		let mut buf = Vec::new();

--- a/src/occt/solid.rs
+++ b/src/occt/solid.rs
@@ -17,15 +17,15 @@ use std::sync::{Mutex, OnceLock};
 static LOFT_LOCK: Mutex<()> = Mutex::new(());
 
 /// Encode `ProfileOrient` into FFI arguments: (kind, ux, uy, uz, aux_spine_edges).
-fn encode_orient(orient: ProfileOrient) -> (u32, f64, f64, f64, cxx::UniquePtr<cxx::CxxVector<ffi::TopoDS_Edge>>) {
-	let mut aux_vec = ffi::edge_vec_new();
+fn encode_orient(orient: ProfileOrient) -> (u32, f64, f64, f64, Vec<*const ffi::TopoDS_Edge>) {
+	let mut aux_vec: Vec<*const ffi::TopoDS_Edge> = Vec::new();
 	let (kind, ux, uy, uz) = match orient {
 		ProfileOrient::Fixed => (0u32, 0.0, 0.0, 0.0),
 		ProfileOrient::Torsion => (1u32, 0.0, 0.0, 0.0),
 		ProfileOrient::Up(v) => (2u32, v.x, v.y, v.z),
 		ProfileOrient::Auxiliary(edges) => {
 			for e in edges {
-				ffi::edge_vec_push(aux_vec.pin_mut(), &e.inner);
+				aux_vec.push(e.inner.as_ptr());
 			}
 			(3u32, 0.0, 0.0, 0.0)
 		}
@@ -57,7 +57,7 @@ fn remap_colormap_by_order(old_inner: &ffi::TopoDS_Shape, new_inner: &ffi::TopoD
 /// (new instance → fresh `OnceLock::new()`). See
 /// `notes/20260420-OCCTトポロジ不変性と設計含意.md`.
 pub struct Solid {
-	inner: cxx::UniquePtr<ffi::TopoDS_Shape>,
+	inner: ffi::Owned<ffi::TopoDS_Shape>,
 	edges: OnceLock<Vec<Edge>>,
 	faces: OnceLock<Vec<Face>>,
 	#[cfg(feature = "color")]
@@ -83,7 +83,7 @@ impl Solid {
 	///
 	/// # Panics
 	/// Panics if `inner` is not `TopAbs_SOLID` (and not null).
-	pub(crate) fn new(inner: cxx::UniquePtr<ffi::TopoDS_Shape>, #[cfg(feature = "color")] colormap: std::collections::HashMap<u64, crate::common::color::Color>, history: Vec<u64>) -> Self {
+	pub(crate) fn new(inner: ffi::Owned<ffi::TopoDS_Shape>, #[cfg(feature = "color")] colormap: std::collections::HashMap<u64, crate::common::color::Color>, history: Vec<u64>) -> Self {
 		debug_assert!(ffi::shape_is_null(&inner) || ffi::shape_is_solid(&inner), "Solid::new called with a non-SOLID shape");
 		Solid {
 			inner,
@@ -212,21 +212,11 @@ impl SolidStruct for Solid {
 	// `OnceLock::new()`). See `notes/20260420-OCCTトポロジ不変性と設計含意.md`.
 
 	fn iter_edge(&self) -> impl Iterator<Item = &Edge> + '_ {
-		self.edges
-			.get_or_init(|| {
-				ffi::shape_edges(&self.inner)
-					.iter()
-					.map(|e_ref| {
-						let owned = ffi::clone_edge_handle(e_ref);
-						Edge::try_from_ffi(owned, "shape_edges: null".into()).expect("shape_edges: unexpected null (this is a bug)")
-					})
-					.collect()
-			})
-			.iter()
+		self.edges.get_or_init(|| ffi::shape_edges(&self.inner).into_iter().map(|owned| Edge::try_from_ffi(owned, "shape_edges: null".into()).expect("shape_edges: unexpected null (this is a bug)")).collect()).iter()
 	}
 
 	fn iter_face(&self) -> impl Iterator<Item = &Face> + '_ {
-		self.faces.get_or_init(|| ffi::shape_faces(&self.inner).iter().map(|f_ref| Face::new(ffi::clone_face_handle(f_ref))).collect()).iter()
+		self.faces.get_or_init(|| ffi::shape_faces(&self.inner).into_iter().map(Face::new).collect()).iter()
 	}
 
 	fn iter_history(&self) -> impl Iterator<Item = [u64; 2]> + '_ {
@@ -236,10 +226,7 @@ impl SolidStruct for Solid {
 	// ==================== Extrude ====================
 
 	fn extrude<'a>(profile: impl IntoIterator<Item = &'a Edge>, dir: DVec3) -> Result<Self, Error> {
-		let mut profile_vec = ffi::edge_vec_new();
-		for e in profile {
-			ffi::edge_vec_push(profile_vec.pin_mut(), &e.inner);
-		}
+		let profile_vec: Vec<*const ffi::TopoDS_Edge> = profile.into_iter().map(|e| e.inner.as_ptr()).collect();
 		let shape = ffi::make_extrude(&profile_vec, dir.x, dir.y, dir.z);
 		if shape.is_null() {
 			return Err(Error::ExtrudeFailed);
@@ -255,10 +242,7 @@ impl SolidStruct for Solid {
 	// ==================== Shell ====================
 
 	fn shell<'a>(&self, thickness: f64, open_faces: impl IntoIterator<Item = &'a Face>) -> Result<Self, Error> {
-		let mut face_vec = ffi::face_vec_new();
-		for f in open_faces {
-			ffi::face_vec_push(face_vec.pin_mut(), &f.inner);
-		}
+		let face_vec: Vec<*const ffi::TopoDS_Face> = open_faces.into_iter().map(|f| f.inner.as_ptr()).collect();
 		let mut history: Vec<u64> = Default::default();
 		let shape = ffi::builder_thick_solid(&self.inner, &face_vec, thickness, &mut history);
 		if shape.is_null() {
@@ -275,10 +259,7 @@ impl SolidStruct for Solid {
 	// ==================== Fillet / Chamfer ====================
 
 	fn fillet_edges<'a>(&self, radius: f64, edges: impl IntoIterator<Item = &'a Edge>) -> Result<Self, Error> {
-		let mut edge_vec = ffi::edge_vec_new();
-		for e in edges {
-			ffi::edge_vec_push(edge_vec.pin_mut(), &e.inner);
-		}
+		let edge_vec: Vec<*const ffi::TopoDS_Edge> = edges.into_iter().map(|e| e.inner.as_ptr()).collect();
 		let mut history: Vec<u64> = Default::default();
 		let shape = ffi::builder_fillet(&self.inner, &edge_vec, radius, &mut history);
 		if shape.is_null() {
@@ -293,10 +274,7 @@ impl SolidStruct for Solid {
 	}
 
 	fn chamfer_edges<'a>(&self, distance: f64, edges: impl IntoIterator<Item = &'a Edge>) -> Result<Self, Error> {
-		let mut edge_vec = ffi::edge_vec_new();
-		for e in edges {
-			ffi::edge_vec_push(edge_vec.pin_mut(), &e.inner);
-		}
+		let edge_vec: Vec<*const ffi::TopoDS_Edge> = edges.into_iter().map(|e| e.inner.as_ptr()).collect();
 		let mut history: Vec<u64> = Default::default();
 		let shape = ffi::builder_chamfer(&self.inner, &edge_vec, distance, &mut history);
 		if shape.is_null() {
@@ -313,14 +291,8 @@ impl SolidStruct for Solid {
 	// ==================== Sweep ====================
 
 	fn sweep<'a, 'b, 'c>(profile: impl IntoIterator<Item = &'a Edge>, spine: impl IntoIterator<Item = &'b Edge>, orient: ProfileOrient<'c>) -> Result<Self, Error> {
-		let mut profile_vec = ffi::edge_vec_new();
-		for e in profile {
-			ffi::edge_vec_push(profile_vec.pin_mut(), &e.inner);
-		}
-		let mut spine_vec = ffi::edge_vec_new();
-		for e in spine {
-			ffi::edge_vec_push(spine_vec.pin_mut(), &e.inner);
-		}
+		let profile_vec: Vec<*const ffi::TopoDS_Edge> = profile.into_iter().map(|e| e.inner.as_ptr()).collect();
+		let spine_vec: Vec<*const ffi::TopoDS_Edge> = spine.into_iter().map(|e| e.inner.as_ptr()).collect();
 		let (kind, ux, uy, uz, aux_vec) = encode_orient(orient);
 		let shape = ffi::make_pipe_shell(&profile_vec, &spine_vec, kind, ux, uy, uz, &aux_vec);
 		if shape.is_null() {
@@ -342,16 +314,17 @@ impl SolidStruct for Solid {
 	{
 		let _guard = LOFT_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
-		let mut all_edges = ffi::edge_vec_new();
+		let mut all_edges: Vec<*const ffi::TopoDS_Edge> = Vec::new();
 		let mut section_count = 0usize;
 
 		for sec in sections {
 			if section_count > 0 {
-				ffi::edge_vec_push_null(all_edges.pin_mut());
+				// null pointer = section separator (replaces the cxx null-edge sentinel).
+				all_edges.push(std::ptr::null());
 			}
 			let mut count = 0u32;
 			for edge in sec {
-				ffi::edge_vec_push(all_edges.pin_mut(), &edge.inner);
+				all_edges.push(edge.inner.as_ptr());
 				count += 1;
 			}
 			if count == 0 {
@@ -386,12 +359,8 @@ impl SolidStruct for Solid {
 	where
 		Face: 'a,
 	{
-		let mut face_vec = ffi::face_vec_new();
-		let mut count = 0usize;
-		for f in faces {
-			ffi::face_vec_push(face_vec.pin_mut(), &f.inner);
-			count += 1;
-		}
+		let face_vec: Vec<*const ffi::TopoDS_Face> = faces.into_iter().map(|f| f.inner.as_ptr()).collect();
+		let count = face_vec.len();
 		if count == 0 {
 			return Err(Error::SewFailed("sew: no faces given (need a face set forming one closed shell)".into()));
 		}
@@ -506,10 +475,7 @@ impl SolidStruct for Solid {
 		}
 		debug_assert!(clauses.last() == Some(&0), "clauses must be 0-terminated");
 
-		let mut solid_vec = ffi::shape_vec_new();
-		for s in solids {
-			ffi::shape_vec_push(solid_vec.pin_mut(), s.inner());
-		}
+		let solid_vec: Vec<*const ffi::TopoDS_Shape> = solids.iter().map(|s| s.inner() as *const ffi::TopoDS_Shape).collect();
 		let mut history: Vec<u64> = Default::default();
 		let inner = ffi::builder_cells(&solid_vec, clauses, &mut history);
 		if inner.is_null() {

--- a/src/occt/stream.rs
+++ b/src/occt/stream.rs
@@ -1,4 +1,38 @@
+use std::ffi::c_void;
 use std::io::{Read, Write};
+
+/// C ABI mirror of `CReader` in `cpp/ffi.h`: an opaque context plus a function
+/// pointer the C++ streambuf calls to pull bytes. `ctx` points at a
+/// [`RustReader`]; `read` is [`read_trampoline`].
+#[repr(C)]
+pub(crate) struct CReader {
+	ctx: *mut c_void,
+	read: extern "C" fn(*mut c_void, *mut u8, usize) -> usize,
+}
+
+/// C ABI mirror of `CWriter` in `cpp/ffi.h`.
+#[repr(C)]
+pub(crate) struct CWriter {
+	ctx: *mut c_void,
+	write: extern "C" fn(*mut c_void, *const u8, usize) -> usize,
+}
+
+/// Trampoline: recover the `RustReader` from the opaque ctx and read into `buf`.
+extern "C" fn read_trampoline(ctx: *mut c_void, buf: *mut u8, len: usize) -> usize {
+	// SAFETY: `ctx` is the `&mut RustReader` handed to `RustReader::as_c`, alive
+	// for the duration of the synchronous C++ call.
+	let reader = unsafe { &mut *(ctx as *mut RustReader) };
+	let slice = unsafe { std::slice::from_raw_parts_mut(buf, len) };
+	rust_reader_read(reader, slice)
+}
+
+/// Trampoline: recover the `RustWriter` from the opaque ctx and write `buf`.
+extern "C" fn write_trampoline(ctx: *mut c_void, buf: *const u8, len: usize) -> usize {
+	// SAFETY: see `read_trampoline`.
+	let writer = unsafe { &mut *(ctx as *mut RustWriter) };
+	let slice = unsafe { std::slice::from_raw_parts(buf, len) };
+	rust_writer_write(writer, slice)
+}
 
 /// Wrapper around `dyn Read` passed to C++ as an opaque extern Rust type.
 ///
@@ -26,6 +60,12 @@ impl RustReader {
 		// use transmute to erase the lifetime (lifetimes are compile-time only).
 		RustReader { inner: unsafe { std::mem::transmute::<*mut (dyn Read + 'a), *mut (dyn Read + 'static)>(reader as *mut (dyn Read + 'a)) } }
 	}
+
+	/// Build the C ABI view (`ctx` + trampoline) passed to the C++ streambuf.
+	/// The returned `CReader` borrows `self` and must not outlive it.
+	pub(crate) fn as_c(&mut self) -> CReader {
+		CReader { ctx: self as *mut RustReader as *mut c_void, read: read_trampoline }
+	}
 }
 
 /// Wrapper around `dyn Write` passed to C++ as an opaque extern Rust type.
@@ -45,6 +85,12 @@ impl RustWriter {
 		// SAFETY: Caller must ensure `writer` outlives this RustWriter.
 		// See RustReader::from_ref for the same rationale.
 		RustWriter { inner: unsafe { std::mem::transmute::<*mut (dyn Write + 'a), *mut (dyn Write + 'static)>(writer as *mut (dyn Write + 'a)) } }
+	}
+
+	/// Build the C ABI view (`ctx` + trampoline) passed to the C++ streambuf.
+	/// The returned `CWriter` borrows `self` and must not outlive it.
+	pub(crate) fn as_c(&mut self) -> CWriter {
+		CWriter { ctx: self as *mut RustWriter as *mut c_void, write: write_trampoline }
 	}
 }
 


### PR DESCRIPTION
## Why

Depending on the `cxx` crate forces compiling cxx's own `src/cxx.cc` (which includes `<iostream>`/`<string>` — libc++ headers) in **every** consumer build. That compilation can't be removed while `cxx` is a dependency, and it's a core reason the wasm build needs wasi-sdk. Replacing the bridge with hand-written `extern "C"` moves **all** C++ compilation into cadrum's own `cc::Build`, drops two dependencies (`cxx`, `cxx-build`), and lets cadrum control the wasm C++ toolchain itself.

## What

- **`cpp/ffi.h` (new)** — hand-written C ABI: `CReader`/`CWriter` (streambuf callbacks via fn pointer + ctx), `CMeshData`, `cadrum_*_free`, pointer-array collections, malloc'd POD buffers.
- **`cpp/wrapper.{h,cpp}`** — OCCT logic in `namespace cadrum` kept intact (`rust::Vec`/`Slice` → `std::vector` in the ~10 affected signatures; `.push_back`/`.size()`/`[i]` are identical). A thin `extern "C"` shim layer marshals to/from the raw ABI. Dead vec helpers and edge/face clone handles removed. All 36 existing `try/catch(Standard_Failure)` boundaries are unchanged, so no exception can cross FFI.
- **`src/occt/ffi.rs`** — opaque `TopoDS_*` types, an `Owned<T>` `UniquePtr`-like smart pointer (`Deref` + `is_null`, frees via `cadrum_*_free`), raw `extern "C"` block, and safe wrappers mirroring the old bridge API so callers barely change.
- **`src/occt/stream.rs`** — `repr(C)` `CReader`/`CWriter` + `extern "C"` trampolines reusing the existing reader/writer logic.
- **Callers** (`solid`/`compound`/`edge`/`face`/`io`) — `cxx::UniquePtr` → `ffi::Owned`; collection inputs built as `Vec<*const TopoDS_*>` (null pointer = loft/pipe section separator); `Vec<Owned<T>>` returns consumed directly (per-element clone removed).
- **`build.rs` / `Cargo.toml`** — `cxx_build::bridge` → `cc::Build::new().cpp(true)` (reusing `apply_compiler_flags` and the `release_name` archive); `cxx` and `cxx-build` removed.

## Verification

- `cargo test` (default: color+png) — pass
- `cargo test --no-default-features --lib --tests` (color off) — pass
- `cargo build --examples` (default) — pass; `cargo fmt` applied
- `cargo build --target wasm32-unknown-unknown` against the prebuilt wasm OCCT with the wasi-sdk-33 toolchain — compiles `wrapper.cpp` under clang++ and links the rlib

Native tests link and run every FFI function, validating the ABI end-to-end; the wasm build confirms the C++ compiles under wasi-sdk.