### PR TITLE
wasm: roll back exception model from exnref to legacy (#233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,11 +32,14 @@ changes until `1.0`.
   `occt-<version>_<rev>-<target>` (single sorted list, `-` between fields and
   `_` within a field, target hyphens underscored), e.g.
   `occt-8_0_0_rev2-wasm32_unknown_unknown.tar.gz` under tag `occt-8_0_0_rev2`. (#203)
-- **wasm exception-handling unified on exnref.** OCCT and the cxx wrapper are
-  now compiled with `-mllvm -wasm-use-legacy-eh=false` so their EH encoding
-  matches the exnref-built wasi-sdk eh sysroot, fixing the `module uses a mix of
-  legacy and new exception handling instructions` error. (#199)
-- Prebuilt `BUILD_REVISION` bumped to `rev2` (naming + EH encoding change).
+- **wasm exception-handling uses the legacy encoding.** OCCT and the cxx wrapper
+  are compiled with `-mllvm -wasm-use-legacy-eh=true`, matching a self-built
+  *legacy* wasi-sdk eh sysroot (the released wasi-sdk eh sysroot is exnref-only, so
+  the cross image rebuilds just the sysroot from source). This keeps both sides on
+  one EH encoding — avoiding the `module uses a mix of legacy and new exception
+  handling instructions` error — while dropping the exnref runtime opt-in (no
+  `--experimental-wasm-exnref` needed). (#199, #233)
+- Prebuilt `BUILD_REVISION` bumped to `rev4` (naming + EH encoding change).
 
 ### 0.8.10
 

--- a/README.md
+++ b/README.md
@@ -100,8 +100,9 @@ Then run the output through `wasm-bindgen` / `wasm-pack` for browser glue. See
 [`cadrum-wasm-example`](https://github.com/lzpel/cadrum-wasm-example) for a complete setup.
 
 **Runtime requirement:** the module is built with Wasm exception handling
-(`-fwasm-exceptions`, the newer `exnref` encoding), so it needs a runtime that
-supports it — a current browser, or Node run with `--experimental-wasm-exnref`.
+(`-fwasm-exceptions`, the legacy encoding), so it needs a runtime that supports the
+Wasm exception-handling proposal — any current browser, or Node (no
+`--experimental-wasm-exnref` flag required).
 
 ### Building for other targets
 

--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 const OCCT_VERSION: &str = "V8_0_0";
 
 /// Build revision for prebuilt tarballs. Update this when making non-OCCT-breaking changes that require cache invalidation (e.g. patch updates, build script changes, EH encoding changes, etc).
-const BUILD_REVISION: &str = "rev3";
+const BUILD_REVISION: &str = "rev4";
 
 /// Release tag / tarball / cache-dir name (#203). Fields are separated by `-` and
 /// characters within a field by `_`, so the name parses by splitting on `-` (the
@@ -171,17 +171,17 @@ const OCC_LIBS: &[&str] = &[
 /// Apply target-conditional C++ compiler flags through `apply`, which forwards each flag
 /// to the concrete builder (`cc::Build::flag` for the wrapper, `cmake::Config::cxxflag` for
 /// the OCCT source build). Shared so the wrapper and OCCT get identical flags — in particular
-/// the same wasm EH encoding, which must match the exnref-built wasi-sdk eh sysroot (#199).
+/// the same wasm EH encoding, which must match the legacy-built wasi-sdk eh sysroot (#199, #233).
 fn apply_compiler_flags(mut apply: impl FnMut(&str)) {
 	// MSVC: compile sources as UTF-8.
 	if env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc") {
 		apply("/utf-8");
 	}
-	// wasm: force the new (exnref) EH encoding so it matches the exnref wasi-sdk eh sysroot.
-	// No-op without -fwasm-exceptions, so it is safe even when exceptions are off.
+	// wasm: force the legacy EH encoding, matching the legacy eh sysroot the cross image
+	// self-builds (exnref needs a runtime opt-in; #233). No-op without -fwasm-exceptions.
 	if env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("wasm32") {
 		apply("-mllvm");
-		apply("-wasm-use-legacy-eh=false");
+		apply("-wasm-use-legacy-eh=true");
 	}
 }
 

--- a/docker/Dockerfile_wasm32-unknown-unknown
+++ b/docker/Dockerfile_wasm32-unknown-unknown
@@ -1,45 +1,57 @@
-# Prebuild OCCT for wasm32-unknown-unknown via the Linux wasi-sdk (clang + wasi-sysroot).
+# Prebuild OCCT for wasm32-unknown-unknown on the official wasi-sdk image
+# (ubuntu:24.04 + /opt/wasi-sdk + cmake/ninja/make, multi-arch), so neither the
+# wasi-sdk nor a new-enough CMake has to be fetched by hand here.
 #
-# The wasm output is produced by the wasi-sdk clang, so the host image is
-# irrelevant to the result: nothing built against the host glibc is shipped (only
-# the .wasm / OCCT static libraries are), so we use the small debian-slim base
-# rather than manylinux. HOST build-dependencies use the image's gcc; the wasm
-# TARGET (OCCT cmake + cxx-build) uses the wasi-sdk clang found first on PATH.
-# The example .wasm cannot run here; the `occt` make target tolerates that via `... | tee`,
-# then tarballs the OCCT static libraries.
-FROM debian:bookworm-slim
+# The wasm output is produced by the wasi-sdk clang, so the host image is irrelevant
+# to the result: nothing built against the host glibc is shipped (only the .wasm /
+# OCCT static libraries are). The example .wasm cannot run here; the `occt` make
+# target tolerates that via `... | tee`, then tarballs the OCCT static libraries.
+FROM ghcr.io/webassembly/wasi-sdk:wasi-sdk-33
 
-# Tools manylinux used to bundle (gcc/g++ C++17 capable, cmake, make, curl) and
-# that this build needs; find/xargs/tar/sed/bash already ship in the base image.
-# ca-certificates is required for the https downloads below (wasi-sdk, rustup,
-# and the OCCT source tarball fetched by build.rs). git is intentionally omitted:
-# there are no git dependencies and OCCT sources arrive as a tarball.
+# curl/ca-certificates: rustup and the OCCT source tarball fetched by build.rs.
+# git/python3: required by the wasi-sysroot rebuild below.
+# gcc/g++: HOST toolchain — rustc links build scripts with `cc`, and the `ring`
+# build-dependency (minreq -> rustls) compiles C for the host.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl ca-certificates make cmake \
-    gcc g++ \
+    curl ca-certificates git python3 gcc g++ \
     && rm -rf /var/lib/apt/lists/*
 
-# wasi-sdk (Linux): clang + prebuilt wasi-sysroot (libc / libc++, eh & noeh variants).
-# Rename the tarball's top dir to /wasi-sdk. The S/H flags keep the transform from
-# also rewriting sym/hardlink targets (e.g. bin/clang -> clang-22), which would break them.
-RUN curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-33.0-x86_64-linux.tar.gz | tar xzv --transform="s,^[^/]+,/wasi-sdk,xSH"
+# The base image points these at the wasm cross tools, which would break the host
+# build scripts above. The wasm TARGET is driven by CC_<target> further down.
+ENV CC=gcc CXX=g++ AR=ar RANLIB=ranlib LD=ld
+
+# Rebuild the sysroot with the legacy wasm-EH encoding (#233): every released wasi-sdk
+# hard-codes -wasm-use-legacy-eh=false, and exnref needs a runtime opt-in
+# (--experimental-wasm-exnref). Only the sysroot is rebuilt — the image's clang is reused
+# through its toolchain file, so LLVM is NOT rebuilt. DUAL keeps the eh/noeh layout clang
+# resolves under -fwasm-exceptions; wasm32-wasip1 is the only triple cadrum links against.
+RUN git clone --depth 1 --recurse-submodules --shallow-submodules \
+      --branch wasi-sdk-33 https://github.com/WebAssembly/wasi-sdk /tmp/src \
+ && sed -i 's/-wasm-use-legacy-eh=false/-wasm-use-legacy-eh=true/' /tmp/src/cmake/wasi-sdk-sysroot.cmake \
+ && rm -rf /opt/wasi-sdk/share/wasi-sysroot \
+ && cmake -G Ninja -B /tmp/build -S /tmp/src \
+      -DCMAKE_TOOLCHAIN_FILE=/opt/wasi-sdk/share/cmake/wasi-sdk.cmake \
+      -DCMAKE_C_COMPILER_WORKS=ON -DCMAKE_CXX_COMPILER_WORKS=ON \
+      -DCMAKE_INSTALL_PREFIX=/opt/wasi-sdk \
+      -DWASI_SDK_TARGETS=wasm32-wasip1 -DWASI_SDK_EXCEPTIONS=DUAL \
+      -DWASI_SDK_INCLUDE_TESTS=OFF \
+ && cmake --build /tmp/build --target install \
+ && rm -rf /tmp/src /tmp/build
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
 # wasi-sdk bin first so `clang`/`clang++` resolve to the wasi-sdk cross-compiler.
-ENV PATH=/wasi-sdk/bin:/root/.cargo/bin:$PATH
+ENV PATH=/opt/wasi-sdk/bin:/root/.cargo/bin:$PATH
 
 ENV CARGO_BUILD_TARGET=wasm32-unknown-unknown
 # add cargo target
 RUN rustup target add ${CARGO_BUILD_TARGET}
 
 # === wasm toolchain env (mirrors sandbox-wasm/makefile) ===
-ENV SYSROOT=/wasi-sdk/share/wasi-sysroot
-# build.rs forwards CC_<target>/CXX_<target> to CMAKE_C/CXX_COMPILER; host build-deps
-# keep using the image's gcc because these are target-specific.
+ENV SYSROOT=/opt/wasi-sdk/share/wasi-sysroot
+# build.rs forwards CC_<target>/CXX_<target> to CMAKE_C/CXX_COMPILER; the host keeps
+# using gcc because these are target-specific.
 ENV CC_wasm32_unknown_unknown=clang
 ENV CXX_wasm32_unknown_unknown=clang++
-# Avoid the host default generator; cmake honors CMAKE_GENERATOR.
-ENV CMAKE_GENERATOR="Unix Makefiles"
 # link-cplusplus defaults to libstdc++ on wasm; we use libc++.
 ENV CXXSTDLIB=c++
 # Compile C/C++ as wasm32-wasip1 so --sysroot auto-resolves include/lib (and eh/c++/v1

--- a/makefile
+++ b/makefile
@@ -42,6 +42,11 @@ cadrum: generate # output out/libocct-<rev>-<target>-cadrum-<version>.a (wrapper
 	cargo clean
 	cargo build --example 01_primitives --release
 	find $(or $(CARGO_TARGET_DIR),target) -name 'libocct-*-cadrum*.a' -exec cp {} out/ \;
+sample-wasm: # write out the throwaway cdylib (CHECK_WASM_* at the end of this file) and build it for wasm. Must run inside the cross image: only it has the legacy-EH wasi-sysroot the prebuilt was built against. --target-dir points at cadrum's own target/ (overriding the container's CARGO_TARGET_DIR), which both puts the .wasm where the host can see it and lets build.rs find the extracted prebuilt OCCT at its default location -- no OCCT_ROOT needed.
+	mkdir -p target/check-wasm/src
+	printf '%s\n' "$$CHECK_WASM_CARGO_TOML" > target/check-wasm/Cargo.toml
+	printf '%s\n' "$$CHECK_WASM_LIB_RS" > target/check-wasm/src/lib.rs
+	cd target/check-wasm && cargo build --release --target-dir $(CURDIR)/target
 cross-%: # run `make $(GOAL)` for target % inside its Docker cross env. GOAL is required. Source is bind-mounted at run time (image is a project-agnostic toolchain); CARGO_TARGET_DIR is redirected into the container (/tmp/target) so the build never touches/pollutes the host target/, and outputs still land in out/<target>/.
 	@test -n "$(GOAL)" || { echo "GOAL is required: make cross-$* GOAL=occt|cadrum"; exit 1; }
 	docker build -f docker/Dockerfile_$(*) -t cross-$(*) .
@@ -50,8 +55,65 @@ check-%: # validate the cross-built prebuilt OCCT runs on the host (extract -> r
 	$(MAKE) cross-$* GOAL=occt
 	mkdir -p target
 	find out -maxdepth 2 -type f -name '*.tar.gz' | xargs -IX tar -xzf X -C target
+	# wasm: link inside the image (only it has the legacy-EH sysroot), run here. Passing no import
+	# object is the point: a leftover WASI import fails instantiation. legacy EH needs no node flag.
 	if [ "$*" = "wasm32-unknown-unknown" ]; then \
-		$(MAKE) -C sandbox-wasm check-cadrum; \
+		$(MAKE) cross-$* GOAL=sample-wasm; \
+		node -e "const fs=require('fs');WebAssembly.instantiate(fs.readFileSync('target/wasm32-unknown-unknown/release/check_wasm.wasm')).then(({instance})=>{instance.exports.start();const v=instance.exports.volume();console.log('Solid volume:',v);process.exit(v===6000?0:1)})"; \
 	else \
 		timeout 300 cargo run --example 01_primitives; \
 	fi
+# The throwaway cdylib `sample-wasm` writes out. cadrum needs no wasm-bindgen: its WASI stubs live
+# in the rlib (src/wasi_stub.rs), so with __anchor_wasi_stub() pulling them in, the module has zero
+# imports and node can instantiate it raw. Comments inside a `define` are kept verbatim, and the
+# body reaches the recipe as an exported environment variable, so make never re-expands the
+# `#[...]` attributes.
+define CHECK_WASM_CARGO_TOML
+[package]
+name = "check-wasm"
+version = "0.0.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+cadrum = { path = "../..", default-features = false, features = ["color"] }
+
+# An empty [workspace] keeps this a standalone workspace root, without which cargo would ignore the
+# [profile] below. The optimizations only reach the Rust side -- the OCCT/libc++ archives are
+# prebuilt, so their size is untouched by any of this.
+[workspace]
+
+[profile.release]
+opt-level = "s"
+lto = true
+codegen-units = 1
+strip = true
+endef
+export CHECK_WASM_CARGO_TOML
+define CHECK_WASM_LIB_RS
+use cadrum::{DVec3, Solid};
+
+// A cdylib links with --no-entry, so OCCT's C++ global constructors never run on their own.
+#[unsafe(no_mangle)]
+pub extern "C" fn start() {
+	cadrum::__anchor_wasi_stub();
+	unsafe extern "C" {
+		fn __wasm_call_ctors();
+	}
+	unsafe { __wasm_call_ctors() };
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn volume() -> f64 {
+	let solid = Solid::cube(DVec3::ZERO, DVec3::new(10.0, 20.0, 30.0)).color("#4a90d9");
+	// Round-trip STEP through memory, never a file, so the OSD_File stub layer stays out of it.
+	let mut bytes: Vec<u8> = Vec::new();
+	Solid::write_step([&solid], &mut bytes).expect("write_step to memory failed");
+	let mut cursor = std::io::Cursor::new(&bytes);
+	let solids = Solid::read_step(&mut cursor).expect("read_step from memory failed");
+	solids.first().expect("no solid after round-trip").volume()
+}
+endef
+export CHECK_WASM_LIB_RS

--- a/sandbox-wasm/Cargo.lock
+++ b/sandbox-wasm/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "cadrum"
-version = "0.8.11"
+version = "0.8.13"
 dependencies = [
  "cc",
  "cmake",

--- a/sandbox-wasm/README.md
+++ b/sandbox-wasm/README.md
@@ -375,7 +375,7 @@ make -C sandbox-wasm run-cxx     # => Solid volume: 5
 
 **OCCT を載せる段階では例外が要る**（`Standard_Failure` 等）。その時は wasi-sdk の `define_libcxx`（このファイル上部）が示すとおり、
 
-- libc++/libc++abi/**libunwind** を `-fwasm-exceptions -mllvm -wasm-use-legacy-eh=false` で**作り直し**、
+- libc++/libc++abi/**libunwind** を `-fwasm-exceptions -mllvm -wasm-use-legacy-eh=true`（legacy EH, #233）で**作り直し**、
 - cadrum/cxx 側も同じ `-fwasm-exceptions` でコンパイルし（ABI 一致）、
 - 実行する node が wasm EH 対応（最近の Node は既定で可）、
 

--- a/sandbox-wasm/makefile
+++ b/sandbox-wasm/makefile
@@ -49,12 +49,10 @@ run-raw-%: # build wasm, and run it with node. hyphens in % become comma-separat
 	cargo build --target wasm32-unknown-unknown --features "$(subst -, ,$*)"
 	../out/bin/wasm-pack build . -d ./target --features "$(subst -, ,$*)"
 	node -e "import('./target/wasm_experiment.js').then(m=>console.log(m.print_volume()))"
-check-cadrum: download # build the cadrum wasm sample (--target web, like the browser) against ../target's prebuilt OCCT and run it under node; surfaces the WASI-import / EH-mix / __wasm_call_ctors errors
-	cargo clean
-	OCCT="$$(find $(CURDIR)/../target -maxdepth 1 -type d -name 'occt-*-wasm32_unknown_unknown' | head -1)"; \
-	test -n "$$OCCT" || { echo "no extracted wasm OCCT under ../target — run 'make check-wasm32-unknown-unknown' first"; exit 1; }; \
-	OCCT_ROOT="$$OCCT" ../out/bin/wasm-pack build . -d ./target --target web --features cadrum
-	node --experimental-wasm-exnref run_node.mjs
+# The cadrum check lives in the root makefile (`make check-wasm32-unknown-unknown`): it must
+# link inside the cross image, which is the only place with the legacy-EH wasi-sysroot the
+# prebuilt OCCT was built against. The released sysroot downloaded below is exnref-only (#233),
+# so it can only serve the exception-free run-* experiments here.
 download: # download wasi-sdk (clang + prebuilt sysroot with libc / libc++).
 	cargo install --root ../out wasm-pack
 	cd ../out && ( ls $(call stem,$(WASI_SDK))/bin/clang.exe || ( curl -L -O $(WASI_SDK) && tar xf $(notdir $(WASI_SDK)) --transform="s,^[^/]+,$(call stem,$(WASI_SDK)),x" ) )


### PR DESCRIPTION
Close #233.

## Why

The wasm32-unknown-unknown prebuilt was built with the **exnref** (new) Wasm exception model,
which requires a runtime opt-in (`node --experimental-wasm-exnref`) and has no current benefit.
This switches everything to the **legacy** exception model so the module runs on stock runtimes
(current browsers, plain Node).

## What was found

- The EH model is forced in `build.rs` (`-mllvm -wasm-use-legacy-eh`), applied to both the OCCT
  cmake build and the cxx wrapper, and must match the wasi-sdk **eh sysroot** (#199).
- **No released wasi-sdk ships a legacy eh sysroot** — every release that has an eh variant
  hard-codes `-wasm-use-legacy-eh=false` in `cmake/wasi-sdk-sysroot.cmake`. A version downgrade
  cannot work; the sysroot must be self-built.
- Only the *sysroot* needs rebuilding, not LLVM: wasi-sdk's own `build-only-sysroot` CI job builds
  it against an existing clang. The official `ghcr.io/webassembly/wasi-sdk` image can play that
  role — it already carries `/opt/wasi-sdk` plus cmake/ninja/make.
- **cadrum needs no wasm-bindgen.** Its WASI stubs live in its own rlib (`src/wasi_stub.rs`), so a
  plain cdylib that calls `__anchor_wasi_stub()` has **zero imports** and node can instantiate it
  raw — no wasm-pack, no wasm-bindgen CLI, no JS glue.

## What changed

- **`build.rs`**: flip `-wasm-use-legacy-eh=false` → `=true`; bump `BUILD_REVISION` `rev3` → `rev4`
  (EH-model change ⇒ new prebuilt content under a fresh release tag, leaving `rev3` untouched).
- **`docker/Dockerfile_wasm32-unknown-unknown`**: rebase on
  `ghcr.io/webassembly/wasi-sdk:wasi-sdk-33` (ubuntu:24.04 + `/opt/wasi-sdk` + cmake 3.28 / ninja /
  make, **multi-arch**), which removes the wasi-sdk tarball download and the hand-installed CMake
  outright. On top of it:
  - a one-line patch flips the EH model, and the sysroot is rebuilt with
    `WASI_SDK_TARGETS=wasm32-wasip1` / `WASI_SDK_EXCEPTIONS=DUAL`, installed **over**
    `/opt/wasi-sdk` so `SYSROOT` stays on the standard path;
  - the image points `CC/CXX/AR/RANLIB/LD` at the wasm cross tools, which breaks host build scripts
    (`ring`, pulled in by `minreq` → `rustls`, compiles C for the host), so they are reset to the
    host toolchain;
  - the `CMAKE_GENERATOR` pin is dropped — `cmake-rs` only forces a generator on MSVC and Unix
    already defaults to `Unix Makefiles`.
- **`makefile`**: rework the wasm `check-%` branch. The host can no longer link against the
  prebuilt (that needs the legacy sysroot, which only the cross image has), so the check splits:
  `sample-wasm` writes a **throwaway cdylib** (source + manifest live in two `define` blocks at the
  end of the file) and links it **inside the image**; only the run happens on the host. It shares
  cadrum's `target/`, so `build.rs` finds the extracted prebuilt at its default location — no
  `OCCT_ROOT` plumbing. node instantiates the module **with no import object**, precisely so a
  leftover WASI import fails the check.
- **`sandbox-wasm`**: drop `check-cadrum`. It linked against the host's downloaded (exnref) sysroot,
  so it could only ever go green against the wrong libc++. The `run-*` experiments are
  exception-free and stay. Also drop `--experimental-wasm-exnref` from the node run.
- docs: README / CHANGELOG / sandbox README updated to legacy EH.

## Verification

`make check-wasm32-unknown-unknown` is green end to end:

```
Solid volume: 6000
```

— no `--experimental-wasm-exnref`, no import object. Disassembly confirms **legacy EH only** on
both sides, zero `try_table` / `throw_ref`:

| | `try` | `catch` | `delegate` | `try_table` / `throw_ref` |
|---|---|---|---|---|
| self-built `eh/libc++abi.a` | — | 10 | 2 | **0** |
| rev4 `libTKernel.a` | 4191 | 513 | 670 | **0** |