### PR TITLE
Fix links to renamed wasm example repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ cadrum has several goals:
 - **Runs in the browser.** <br/> cadrum also ships a static OpenCASCADE build for
   the `wasm32-unknown-unknown` target, making it well suited to running what
   you build directly in the browser via WebAssembly.
-  <br> [**Live demo**](https://lzpel.github.io/cadrum-wasm-example/) — STEP → glTF converted entirely in-browser ([source](https://github.com/lzpel/cadrum-wasm-example)).
-  <br/> <img src="https://github.com/lzpel/cadrum-wasm-example/raw/main/screenshot.png" alt="cadrum compiled to WebAssembly converting a STEP file to glTF in the browser" height="200"/>
+  <br> [**Live demo**](https://lzpel.github.io/opencascade-wasm32-unknown-unknown-example/) — STEP → glTF converted entirely in-browser ([source](https://github.com/lzpel/opencascade-wasm32-unknown-unknown-example)).
+  <br/> <img src="https://github.com/lzpel/opencascade-wasm32-unknown-unknown-example/raw/main/screenshot.png" alt="cadrum compiled to WebAssembly converting a STEP file to glTF in the browser" height="200"/>
 - **Fully headless.** <br/> No GUI, no windowing, no OS-specific dependencies —
   cadrum is pure geometry and I/O, suitable for servers, CI, and wasm.
 - **Major formats in and out.** <br/> Reads and writes **STEP** and **BRep**,
@@ -97,7 +97,7 @@ unsafe { __wasm_call_ctors() };
 ```
 
 Then run the output through `wasm-bindgen` / `wasm-pack` for browser glue. See
-[`cadrum-wasm-example`](https://github.com/lzpel/cadrum-wasm-example) for a complete setup.
+[`opencascade-wasm32-unknown-unknown-example`](https://github.com/lzpel/opencascade-wasm32-unknown-unknown-example) for a complete setup.
 
 **Runtime requirement:** the module is built with Wasm exception handling
 (`-fwasm-exceptions`, the newer `exnref` encoding), so it needs a runtime that

--- a/sandbox-wasm/run_node.mjs
+++ b/sandbox-wasm/run_node.mjs
@@ -1,4 +1,4 @@
-// CLI validation of the --target web path the browser (cadrum-wasm-example) uses.
+// CLI validation of the --target web path the browser (opencascade-wasm32-unknown-unknown-example) uses.
 // node cannot fetch file: URLs, so we hand the raw .wasm bytes to the wasm-bindgen init.
 import { readFile } from "node:fs/promises";
 import init, { print_volume } from "./target/wasm_experiment.js";


### PR DESCRIPTION
The wasm example repository was renamed from `cadrum-wasm-example` to `opencascade-wasm32-unknown-unknown-example`, leaving broken links.

## Changes
- `README.md` — update Live demo URL, source link, screenshot image URL, and the setup reference link
- `sandbox-wasm/run_node.mjs` — update stale repo name in comment

Verified the new demo page (https://lzpel.github.io/opencascade-wasm32-unknown-unknown-example/) and repository resolve correctly.