### PR TITLE
Drop stale doc comments, and record how downstream users actually use cadrum

### DIFF
--- a/notes/20260713-実利用3件から見た不足と過剰.md
+++ b/notes/20260713-実利用3件から見た不足と過剰.md
@@ -1,0 +1,125 @@
+# 実利用 3 件から見た不足と過剰
+
+公開されている cadrum の実利用が 3 件見つかったので、使われ方を突き合わせ、何が足りていて何が余っているかを整理する。
+「作者が想定した使われ方」と「実際の使われ方」を比較できる唯一の一次情報なので、次に何を作るかの優先順位はここから決める。
+
+利用者は **A / B / C** と呼ぶ。ドメインだけ記し、どのリポジトリかは書かない。
+
+## 1. 三者の使われ方
+
+| | 利用者 A | 利用者 B | 利用者 C |
+|---|---|---|---|
+| ドメイン | 格子ボルツマン法(LBM)の流体ソルバ。CUDA バックエンド + GUI ビューア | 自作の差動二輪ロボットの機構設計 | geometry-as-code のデモ |
+| cadrum の役割 | **STEP を読むだけ**。シミュレーションの障害物ジオメトリの入力経路 | **モデリングカーネル**。部品を作る | モデリング + 3 形式出力の実演 |
+| 依存の宣言 | `default-features = false` + `optional`、独自 feature でゲート、既定 OFF | **宣言が無い**。ソースは cadrum を使っているが Cargo.toml にも Cargo.lock にも存在せず、そのままではビルドできない | `cadrum = "0.8.13"`（default features のまま） |
+| 使っている API | `read_step`, `Solid::mesh`, `Tessellation`, `Mesh { vertices, indices, face_ids }` | `cube`, `cylinder`, `translate`, `fillet_edges`, `shell`, `Boolean` の畳み込み, `read_step`（購入部品の取り込み）, `color`, `colormap`, `volume`, `Solid::mesh` | `cube`, `cylinder`, `translate`, `color`, 演算子ブーリアン, `Solid::mesh`, `write_step`, `write_stl`, `write_gltf_binary` |
+| 自前で書き足したもの | 三角形法線 | **法線（スムーズ化）+ glTF ライタ 300 行超** | 無し（内蔵 glTF で足りている） |
+| wasm | 使っていない。web ビルドではファイル入力メニューごと封じている | 使っていない。ネイティブのオフライン資産生成 | 使っていない |
+
+三者が共通して踏んでいる中核は `Solid` / `DVec3` / `Solid::mesh` + `Tessellation` / `Mesh` の公開フィールド / STEP I/O。
+
+とくに **`face_ids` は A と B の両方で「元の CAD の面」を復元するために使われている**。A は面ごとに三角形をグループ化して GUI で選択可能にし、B は面の色を引くのに使う。三角形に元の面 ID を持たせた設計判断は当たっている。
+
+A の使い方（読むだけ）と B の使い方（作る）が綺麗に分かれているのも良い兆候で、`Solid` を「読み書きできる形状」として公開した方針は両方から支持されている。
+
+## 2. 不足しているもの
+
+### (a) `Mesh` が法線を持っていない
+
+`src/common/mesh.rs:11-30` に normal フィールドは無い。法線は必要な箇所でその場計算されているだけで、外には出ていない。
+
+- STL 書き出し: `src/common/mesh.rs:100` で `(v1 - v0).cross(v2 - v0).normalize_or_zero()` をインライン計算
+- 2D シーン: `src/common/mesh.rs:380` の `tri_normal()`（非正規化。背面カリングとランバート陰影に使う）
+
+結果、**A と B が独立に同じものを書き足した**。A は面法線を外積で、B は面 ID ごとに頂点を分割してスムーズ法線を平均している。3 件中 2 件が同じ穴を自分で埋めているので、これは埋める価値がある。
+
+### (b) glTF が `KHR_materials_unlit` を強制し、法線を出力しない
+
+`src/common/mesh.rs:242` のマテリアルはこうなっている。
+
+```
+{"pbrMetallicRoughness":{"baseColorFactor":[r,g,b,1.0],"metallicFactor":0.0,"roughnessFactor":1.0},
+ "alphaMode":"OPAQUE","doubleSided":true,"extensions":{"KHR_materials_unlit":{}}}
+```
+
+`metallicFactor` / `roughnessFactor` はハードコードで、しかも `KHR_materials_unlit` を必ず付けるので、対応ビューアでは PBR 計算自体がスキップされ baseColor がそのまま出る。`NORMAL` アトリビュートはコード中に存在しない（`src/common/mesh.rs:155,164` の出力は `POSITION` と indices のみ）。unlit なので法線が要らない、という一貫した設計ではある。
+
+**B が 300 行超の glTF ライタを書き直した理由はこれで完全に説明できる。** 彼が欲しかったのは、
+
+- 色ごとの metallic / roughness（材質ごとに金属・プラ・ゴムを描き分けたい）
+- スムーズ法線（陰影を付けたい）
+- 頂点数に応じた u16 / u32 インデックスの切り替え
+
+の 3 つ。C が内蔵 glTF で満足しているのは、陰影の要らない確認用プレビューだから。**つまり内蔵 glTF は「動作確認用」としては十分だが、「成果物のビューア」としては不足している。**
+
+### (c) オフライン / hermetic ビルドの手順が文書化されていない
+
+A は自分のリポジトリのドキュメントに、**「cadrum はビルド時に OCCT のアーカイブをダウンロードする（あるいは source feature でビルドする）ので、OCCT が固定入力として与えられるまで hermetic なパッケージでは STEP 対応 feature を有効にするな」** と明記している。ローカルではテストが通ることを認めた上で、パッケージビルドでは無効化している。**観測できた唯一の「明示的にブロックされている」事例。**
+
+しかし cadrum には既に逃げ道がある。
+
+- `OCCT_ROOT` — `build.rs:46` で feature に関係なく読まれる。有効な OCCT ツリーがあればダウンロードもソースビルドも走らない
+- `CADRUM_PREBUILT_URL` — `build.rs:248`。`file://` スキームに対応している（`build.rs:284-292`）
+
+にもかかわらず、README では `OCCT_ROOT` が「Building for other targets」の source ビルド文脈でしか触れられておらず（`README.md:112`）、**`CADRUM_PREBUILT_URL` は README にも CHANGELOG にも一行も無い**（内部ノートにあるだけで、crate 公開物からは exclude されている）。`CADRUM_BUNDLE_RUNTIME` も同様に未文書。
+
+**実装済みの機能が知られていないせいで利用者が止まっている。** README に「オフライン / ベンダリングされた OCCT でのビルド」の節を書くだけで解消する可能性が高い。投資対効果は今のところ最大。
+
+### (d) ライセンス整備
+
+別途調査した内容。Discussion で「cadrum は MIT で、OCCT の LGPL は viral ではない」と回答した以上、配布物をそれに整合させる必要がある。
+
+- **GNU ターゲットの prebuilt に GPL-3 の `libstdc++.a` / `libgcc.a` / `libgcc_eh.a` が同梱されている**（`build.rs:64`）。GCC Runtime Library Exception が許すのは「Runtime Library を Independent Modules と結合した Target Code の propagate」であって、Runtime Library のアーカイブ単体の再配布ではない。**最も直接的に「MIT で配れる」という説明と衝突する。**
+- wasm の prebuilt に LLVM の libc++ / libc++abi / libunwind と wasi-libc のアーカイブが、**ライセンス文書なしで**同梱されている（Apache-2.0 WITH LLVM-exception は配布時にライセンスのコピーを要求する）
+- 公開している Docker イメージにライセンス文書が一つも入っていない
+- OCCT は改変した 21 ファイルしか同梱していない。LGPL-2.1 §4 は「complete corresponding source」を求めるので、差分だけでは足りない可能性がある（同じ配布場所からソースへの equivalent access を提供すれば足りる、という条項はある）
+
+## 3. 過剰なもの
+
+### (a) `png` が default features に入っている
+
+`png` は `tiny-skia` を引き込む（`Cargo.toml:22,32`）。しかしそれが支えている公開 API は **約 92 個中わずか 3 個**。
+
+| メソッド | 場所 |
+|---|---|
+| `Scene2D::write_png` | `src/common/mesh.rs:794` |
+| `Mesh::write_multiview_png` | `src/common/mesh.rs:903` |
+| `Solid::write_multiview_png` | `src/traits.rs:721`, `src/lib.rs:250` |
+
+**そして三者の誰一人 PNG を使っていない。** SVG 出力（`src/common/mesh.rs:710` の `write_svg`）は文字列生成だけで無依存なので、`png` を外しても 2D 出力が全部消えるわけではない。
+
+→ **`default = ["color"]` に変え、`png` を opt-in にする**のが妥当。1.0 前なので破壊的変更は許容範囲。依存ツリーとビルド時間とライセンス面が同時に軽くなる。
+
+### (b) `pure` feature が壊れている
+
+`pure` を参照している cfg は `src/lib.rs:4-5` と `src/lib.rs:12-13` の 2 箇所だけ。有効にすると `occt` モジュールと `Solid` / `Edge` / `Face` が消え、**代替は何も出てこない**。`src/pure.rs` は存在せず、モジュール宣言は `src/lib.rs:6-11` でコメントアウトされている。`SolidStruct` を実装する具体型が無くなるので `Boolean` も `Solid::mesh` も使えず、実質「何もできない crate」になる。
+
+さらに **`build.rs` に `pure` の cfg が一つも無い**。したがって `--features pure` でも OCCT の prebuilt ダウンロードと静的リンクはそのまま走る。`Cargo.toml:24` のコメント「Pure Rust CAD backend (no OCCT dependency)」は事実に反している。
+
+→ 削除するか、少なくともコメントを実態に合わせる。今のままだと嘘の看板が出ている。
+
+### (c) `color` は default のままでよい
+
+追加の crate 依存はゼロ。増えるのは OCCT 側のライブラリ 4 つ（`TKLCAF` / `TKXCAF` / `TKCAF` / `TKCDF`、`build.rs:161-168`）と C++ 側のマクロだけ。B と C が使っていて、A は自分で `default-features = false` にして切っている。**実際の利用パターンに合っている。**
+
+### (d) wasm 対応
+
+三者とも使っていない。A は web ビルドでファイル入力メニューごと封じており（つまり STEP インポート＝cadrum の出番を web から明示的に外している）、B はネイティブのオフライン資産生成、C はローカル CLI。
+
+これは失敗ではない。wasm は「既存利用者の不満を解消する機能」ではなく「新しい利用者を連れてくる機能」なので、既存 3 名に刺さらないのは想定内。ただし、**観測できた実際の不満は (a)(b)(c) の方であり、そちらの方が投資対効果は明確に高い**という事実は記録しておく。特に (c) は実装済みの機能を README に書くだけで、コストがほぼゼロ。
+
+論理的には A だけが wasm の潜在候補ではある（web ビューアで STEP を読めるようになれば完成する形）。ただしソルバ本体が CUDA に依存しているので、ブラウザで完結する構図にはなっていない。
+
+## 4. ついでに見つかったドキュメント腐り
+
+- `src/common/mesh.rs:288` の doc コメントが、存在しない `Scene2D::to_svg` に言及している（実際は `write_svg`）
+- `src/common/boolean.rs:128-129` のコメントが、存在しない `TryFrom<Boolean<Self>> for Self` の実装に言及している（単一 Solid の取り出しは `.build()` のみ）
+- ブーリアン演算子は `+`(union) / `-`(difference) / **`*`(intersection)** の 3 つ。`&` は未実装
+
+## 5. 次にやること（優先順）
+
+1. **README にオフラインビルドの節を書く** — `OCCT_ROOT` と `CADRUM_PREBUILT_URL=file://` を prebuilt 文脈で文書化する。実装済み。コストほぼゼロ。利用者 A のブロッカーが外れる
+2. **ライセンス整備** — 特に GNU prebuilt の GPL-3 ランタイム同梱。「MIT で配れる」と回答した以上、放置すると信頼を失う類の問題
+3. **`Mesh` に法線を持たせる / glTF を lit にする** — 3 件中 2 件が自前で書いた穴。PBR パラメータを固定値でなく指定可能にする
+4. **`default` から `png` を外す** — 誰も使っていない `tiny-skia` 依存を全利用者に背負わせている
+5. **`pure` feature の始末** — 動かない看板を下ろす

--- a/src/common/boolean.rs
+++ b/src/common/boolean.rs
@@ -125,14 +125,11 @@ impl<S: SolidStruct> TryFrom<Boolean<S>> for Vec<S> {
 	}
 }
 
-// 汎用 `impl<S: SolidStruct> TryFrom<Boolean<S>> for S` は orphan rule 違反のため、
-// 「Boolean<Self> → Self」の TryFrom は具象側 (src/occt/solid.rs) に置く。
-
 // ==================== From / 演算子 ====================
 //
 // `From` が `Solid`/`&Solid` → `Boolean<S>` の入口。演算子は `Boolean<S>` 左辺に集約
 // (dnf 呼び出しはこのファイルのみ)。裸の Solid/&Solid 左辺の糖衣は orphan rule で
-// generic 化できず traits::impl_solid_boolean_ops! が src/occt/solid.rs で生成する。
+// generic 化できず、src/lib.rs の impl_solid_boolean_ops! が生成する。
 
 impl<S: SolidStruct> From<S> for Boolean<S> {
 	// owned でも借用渡し。metadata move 最適化はしない (generic 契約の軽微なコスト)。

--- a/src/common/mesh.rs
+++ b/src/common/mesh.rs
@@ -285,7 +285,7 @@ impl Mesh {
 	/// (`hidden_edges` / `shading`) parameters. `SceneOption::default()` is the
 	/// standard Z-up isometric CAD view.
 	///
-	/// Render via `Scene2D::to_svg` / `Scene2D::write_svg`.
+	/// Render via `Scene2D::write_svg`.
 	pub fn scene(&self, option: SceneOption) -> Scene2D {
 		let SceneOption { view, up, hidden_edges, shading } = option;
 		let (u, v, dir) = projection_basis(view, up);


### PR DESCRIPTION
Two unrelated-but-small changes.

## Doc comments that reference items which do not exist

Three comments had drifted away from the code:

- `src/common/mesh.rs` pointed readers at `Scene2D::to_svg`. That method was removed in 0.8.1 when 2D rendering moved to `Scene2D`; only `write_svg` exists.
- `src/common/boolean.rs` claimed `TryFrom<Boolean<Self>> for Self` lives in `src/occt/solid.rs`. **No such impl exists anywhere** — the only `TryFrom` is the one for `Vec<S>` right above the comment, and extracting a single solid is `.build()`. The comment was written ahead of an implementation that never landed.
- The same block said `traits::impl_solid_boolean_ops!` is generated in `src/occt/solid.rs`. The macro is both defined and expanded in `src/lib.rs`, and is not in `traits`.

Comment-only; nothing compiles differently.

## notes/ — how the three known downstream users actually use cadrum

Three public repositories were found using cadrum. Their names are deliberately withheld from the note. Summarised as users A/B/C by domain, with the API surface each exercises and what each of them had to write themselves.

The two findings worth acting on:

- **Two of the three hand-rolled normals**, because `Mesh` has no normal field and the glTF writer forces `KHR_materials_unlit` with hardcoded metallic/roughness. One of them rewrote the whole glTF exporter to get lit PBR materials.
- **One is explicitly blocked** and says so in their own repo: cadrum downloads OCCT at build time, so they cannot enable the feature in a hermetic package. `OCCT_ROOT` and `CADRUM_PREBUILT_URL=file://` already exist and would unblock them — they are just not documented.

The note also flags that `png` is in `default` while supporting only 3 of ~92 public methods (and none of the three users touch PNG), and that the `pure` feature removes `Solid` without providing a replacement while still linking OCCT.

Follow-ups are filed as separate issues.