### PR TITLE
Bump the prebuilt release tag to rev4

### DIFF
--- a/.github/workflows/prebuilt.yaml
+++ b/.github/workflows/prebuilt.yaml
@@ -136,6 +136,6 @@ jobs:
       # lockstep with OCCT_VERSION / BUILD_REVISION in build.rs.
       - uses: softprops/action-gh-release@v2
         with:
-          tag_name: occt-8_0_0_rev3
-          name: OCCT prebuilt v8.0.0 (rev3)
+          tag_name: occt-8_0_0_rev4
+          name: OCCT prebuilt v8.0.0 (rev4)
           files: dist/*.tar.gz

--- a/build.rs
+++ b/build.rs
@@ -14,9 +14,9 @@ const BUILD_REVISION: &str = "rev4";
 /// target's hyphens are underscored too). `has_version` appends the cadrum crate
 /// version for the per-crate FFI artifact.
 ///
-/// - `release_name(None, false)`    → `occt-8_0_0_rev3`                              (GitHub Release タグ)
-/// - `release_name(Some(t), false)` → `occt-8_0_0_rev3-wasm32_unknown_unknown`       (OCCT tarball / cache dir)
-/// - `release_name(Some(t), true)`  → `occt-8_0_0_rev3-wasm32_unknown_unknown-cadrum-0_8_11` (FFI tarball)
+/// - `release_name(None, false)`    → `occt-8_0_0_rev4`                              (GitHub Release タグ)
+/// - `release_name(Some(t), false)` → `occt-8_0_0_rev4-wasm32_unknown_unknown`       (OCCT tarball / cache dir)
+/// - `release_name(Some(t), true)`  → `occt-8_0_0_rev4-wasm32_unknown_unknown-cadrum-0_8_13` (FFI tarball)
 fn release_name(target: Option<&str>, has_version: bool) -> String {
 	let occt = OCCT_VERSION.trim_start_matches(['V', 'v']);
 	let mut name = format!("occt-{}_{}", occt, BUILD_REVISION);


### PR DESCRIPTION
#234 bumped `BUILD_REVISION` to `rev4`, but `.github/workflows/prebuilt.yaml` still hardcoded `occt-8_0_0_rev3` as the release tag.

Running the workflow in that state would have attached the freshly built `occt-8_0_0_rev4-*.tar.gz` assets **to the rev3 release**, so no `occt-8_0_0_rev4` tag would ever exist — and `build.rs`, which looks for the tarball under the tag it derives from `BUILD_REVISION`, would 404 for every user on the prebuilt path. The workflow has not been run yet, so nothing is broken in the wild.

Also refreshes the `release_name` doc examples, which still showed `rev3` seven lines below the `rev4` constant (and a crate version two releases old).

The workflow comment says "Bump this in lockstep with `OCCT_VERSION` / `BUILD_REVISION` in build.rs" — a manual sync that was, predictably, about to be missed. Deriving the tag from the artifact filenames (which `build.rs` already names) would remove the second source of truth entirely; tracked in #238.