### PR TITLE
Give Mesh per-vertex surface normals, drop the unused uvs

### DIFF
--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -33,6 +33,7 @@
 #include <BRep_Builder.hxx>
 #include <BRep_Tool.hxx>
 #include <BRepLib.hxx>
+#include <BRepLib_ToolTriangulatedShape.hxx>
 #include <BRepBuilderAPI_Copy.hxx>
 #include <BRepBuilderAPI_MakeFace.hxx>
 #include <BRepBuilderAPI_MakePolygon.hxx>
@@ -832,51 +833,47 @@ MeshData mesh_shape(const TopoDS_Shape& shape, double linear, double angular, bo
         TopLoc_Location location;
         Handle(Poly_Triangulation) triangulation = BRep_Tool::Triangulation(face, location);
 
-        if (triangulation.IsNull()) {
+        // Nodal normals, taken from the underlying surface (GeomLib::NormEstim at
+        // each UV node) rather than averaged from the triangles, so curved faces
+        // carry their exact normal. OCCT falls back to averaging adjacent triangle
+        // normals at singular nodes (cone apex, sphere pole) and on faces without
+        // UV nodes. NOT Poly_Triangulation::ComputeNormals, which only averages
+        // triangle normals and would throw the surface away.
+        //
+        // Safe on a null handle, and every other path allocates the array, so the
+        // guard below rejects exactly the faces with nothing to emit: no
+        // triangulation at all, or a triangulation with no nodes.
+        BRepLib_ToolTriangulatedShape::ComputeNormals(face, triangulation);
+        if (triangulation.IsNull() || !triangulation->HasNormals()) {
             continue;
         }
 
         int nb_nodes = triangulation->NbNodes();
         int nb_triangles = triangulation->NbTriangles();
 
-        // Vertices
+        // Shared by the nodal normals and the index winding below.
+        bool reversed = (face.Orientation() == TopAbs_REVERSED);
+
+        // Position and normal of every node in one pass.
         for (int i = 1; i <= nb_nodes; i++) {
             gp_Pnt p = triangulation->Node(i);
             p.Transform(location.Transformation());
             result.vertices.push_back(p.X());
             result.vertices.push_back(p.Y());
             result.vertices.push_back(p.Z());
-        }
 
-        // UVs - normalize per face
-        if (triangulation->HasUVNodes()) {
-            double u_min = 1e30, u_max = -1e30, v_min = 1e30, v_max = -1e30;
-            for (int i = 1; i <= nb_nodes; i++) {
-                gp_Pnt2d uv = triangulation->UVNode(i);
-                u_min = std::min(u_min, uv.X());
-                u_max = std::max(u_max, uv.X());
-                v_min = std::min(v_min, uv.Y());
-                v_max = std::max(v_max, uv.Y());
-            }
-            double u_range = u_max - u_min;
-            double v_range = v_max - v_min;
-            if (u_range < 1e-10) u_range = 1.0;
-            if (v_range < 1e-10) v_range = 1.0;
-
-            for (int i = 1; i <= nb_nodes; i++) {
-                gp_Pnt2d uv = triangulation->UVNode(i);
-                result.uvs.push_back((uv.X() - u_min) / u_range);
-                result.uvs.push_back((uv.Y() - v_min) / v_range);
-            }
-        } else {
-            for (int i = 1; i <= nb_nodes; i++) {
-                result.uvs.push_back(0.0);
-                result.uvs.push_back(0.0);
-            }
+            // ComputeNormals ignores face orientation and works in the
+            // triangulation's local frame, so apply the location and the REVERSED
+            // flip here — the same rule the index winding below uses.
+            gp_Dir n = triangulation->Normal(i);
+            n.Transform(location.Transformation());
+            if (reversed) n.Reverse();
+            result.normals.push_back(n.X());
+            result.normals.push_back(n.Y());
+            result.normals.push_back(n.Z());
         }
 
         // Indices
-        bool reversed = (face.Orientation() == TopAbs_REVERSED);
         uint64_t face_id = reinterpret_cast<uint64_t>(face.TShape().get());
         for (int i = 1; i <= nb_triangles; i++) {
             const Poly_Triangle& tri = triangulation->Triangle(i);

--- a/src/common/mesh.rs
+++ b/src/common/mesh.rs
@@ -5,14 +5,16 @@ use std::collections::HashMap;
 
 /// A triangle mesh produced by meshing a solid shape.
 ///
-/// All vectors have the same length: one entry per vertex.
 /// `indices` contains triangle indices (groups of 3).
 #[derive(Debug, Clone)]
 pub struct Mesh {
 	/// Vertex positions in 3D space.
 	pub vertices: Vec<DVec3>,
-	/// UV coordinates, normalized to [0, 1] per face.
-	pub uvs: Vec<DVec2>,
+	/// Unit outward normal per vertex, evaluated on the underlying B-rep surface
+	/// (not averaged from the triangles). Vertices are not shared between B-rep
+	/// faces, so each face acts as its own smoothing group: a cylinder's side is
+	/// smooth and its sharp edges stay sharp.
+	pub normals: Vec<DVec3>,
 	/// Triangle indices (groups of 3, referencing into `vertices`).
 	pub indices: Vec<usize>,
 	/// Per-triangle face ID. Length equals `indices.len() / 3`.
@@ -96,8 +98,9 @@ impl Mesh {
 			let v0 = self.vertices[i0];
 			let v1 = self.vertices[i1];
 			let v2 = self.vertices[i2];
-			// Face normal from cross product / 外積から面法線を計算
-			let n = (v1 - v0).cross(v2 - v0).normalize_or_zero();
+			// STL stores the facet normal, so this is the triangle's geometric
+			// normal — not the per-vertex surface normal in `self.normals`.
+			let n = tri_normal(self, ti).normalize_or_zero();
 			// Normal (3 x f32 LE)
 			for c in [n.x, n.y, n.z] {
 				writer.write_all(&(c as f32).to_le_bytes()).map_err(|_| super::error::Error::StlWriteFailed)?;

--- a/src/occt/ffi.rs
+++ b/src/occt/ffi.rs
@@ -6,7 +6,7 @@ mod ffi_bridge {
 	// Shared struct for mesh data returned from C++
 	struct MeshData {
 		vertices: Vec<f64>, // flat xyz
-		uvs: Vec<f64>,      // flat uv
+		normals: Vec<f64>,  // flat xyz, one per vertex
 		indices: Vec<u32>,
 		face_tshape_ids: Vec<u64>, // per-triangle TShape* address
 		success: bool,

--- a/src/occt/io.rs
+++ b/src/occt/io.rs
@@ -197,7 +197,7 @@ fn write_brep_with<'a, W: Write>(solids: impl IntoIterator<Item = &'a Solid>, wr
 
 pub(super) fn mesh<'a>(solids: impl IntoIterator<Item = &'a Solid>, options: crate::traits::Tessellation) -> Result<crate::common::mesh::Mesh, Error> {
 	use crate::common::mesh::Mesh;
-	use glam::{DVec2, DVec3};
+	use glam::DVec3;
 
 	let compound = CompoundShape::new(solids);
 	let data = ffi::mesh_shape(compound.inner(), options.deflection_linear, options.deflection_angular, options.relative_linear);
@@ -206,7 +206,7 @@ pub(super) fn mesh<'a>(solids: impl IntoIterator<Item = &'a Solid>, options: cra
 	}
 	let vertex_count = data.vertices.len() / 3;
 	let vertices: Vec<DVec3> = (0..vertex_count).map(|i| DVec3::new(data.vertices[i * 3], data.vertices[i * 3 + 1], data.vertices[i * 3 + 2])).collect();
-	let uvs: Vec<DVec2> = (0..vertex_count).map(|i| DVec2::new(data.uvs[i * 2], data.uvs[i * 2 + 1])).collect();
+	let normals: Vec<DVec3> = (0..vertex_count).map(|i| DVec3::new(data.normals[i * 3], data.normals[i * 3 + 1], data.normals[i * 3 + 2])).collect();
 	let indices: Vec<usize> = data.indices.iter().map(|&i| i as usize).collect();
 	let face_ids = data.face_tshape_ids;
 
@@ -241,7 +241,7 @@ pub(super) fn mesh<'a>(solids: impl IntoIterator<Item = &'a Solid>, options: cra
 
 	Ok(Mesh {
 		vertices,
-		uvs,
+		normals,
 		indices,
 		face_ids,
 		#[cfg(feature = "color")]

--- a/tests/mesh.rs
+++ b/tests/mesh.rs
@@ -10,6 +10,27 @@ fn dvec3(x: f64, y: f64, z: f64) -> DVec3 {
 	DVec3::new(x, y, z)
 }
 
+// ==================== Vertex normals (Mesh::normals) ====================
+
+/// 頂点法線が三角形の平均ではなく元の曲面から来ていることを検証する。
+/// 原点中心・半径 r の球なら、法線は必ず中心からの単位ベクトルに一致する。
+/// 三角形法線の平均だと deflection のオーダー (1e-3 級) でずれるので、
+/// この許容差では通らない。
+#[test]
+fn sphere_normals_come_from_the_surface() {
+	let tess = Tessellation { deflection_linear: 0.1, relative_linear: false, ..Default::default() };
+	let mesh = Solid::mesh(&[Solid::sphere(5.0)], tess).unwrap();
+
+	assert_eq!(mesh.normals.len(), mesh.vertices.len(), "one normal per vertex");
+	assert!(!mesh.normals.is_empty(), "sphere must produce vertices");
+
+	for (v, n) in mesh.vertices.iter().zip(&mesh.normals) {
+		assert!((n.length() - 1.0).abs() < 1e-6, "normal must be unit length at {v:?}: {n:?}");
+		let radial = v.normalize();
+		assert!(n.dot(radial) > 1.0 - 1e-6, "normal must be the exact surface normal at {v:?}: got {n:?}, expected {radial:?}");
+	}
+}
+
 // ==================== SVG (Scene2D::write_svg) ====================
 
 mod svg {
@@ -43,17 +64,6 @@ mod svg {
 
 		write("svg_box_isometric", &svg);
 		println!("SVG length: {} bytes", svg.len());
-	}
-
-	#[test]
-	fn box_top_down() {
-		let shape = [Solid::cube(DVec3::ZERO, DVec3::splat(10.0))];
-		let svg = svg_string(&shape, DVec3::Z, 0.1);
-
-		assert!(svg.starts_with("<svg"));
-		assert!(svg.contains("<polyline"));
-
-		write("svg_box_top_down", &svg);
 	}
 
 	#[test]
@@ -211,21 +221,6 @@ mod png {
 	fn write(name: &str, buf: &[u8]) {
 		std::fs::create_dir_all("out").unwrap();
 		std::fs::write(format!("out/{name}.png"), buf).unwrap();
-	}
-
-	#[test]
-	fn box_isometric() {
-		let shape = [Solid::cube(DVec3::ZERO, DVec3::splat(10.0))];
-		let mesh = Solid::mesh(&shape, cadrum::Tessellation { deflection_linear: 0.1, relative_linear: false, ..Default::default() }).unwrap();
-		let scene = mesh.scene(cadrum::SceneOption { view: dvec3(1.0, 1.0, 1.0).normalize(), ..Default::default() });
-
-		let mut buf = Vec::new();
-		scene.write_png([400, 400], &mut buf).unwrap();
-
-		assert_eq!(&buf[0..8], PNG_MAGIC, "PNG signature missing");
-		assert_eq!(png_dimensions(&buf), (400, 400));
-
-		write("png_box_isometric", &buf);
 	}
 
 	#[test]


### PR DESCRIPTION
## Why

`Mesh` carried no normals, so every consumer re-derived what it needed and downstream users ended up hand-rolling their own (see `notes/20260713-実利用3件から見た不足と過剰.md` §2).

A triangulation is what is left after the surface has been thrown away, so **a cylinder's true side normal cannot be recovered from the triangles**. Averaging cross products is only an approximation. The one thing worth storing is the per-vertex normal, and its rightful source is the original surface that OCCT still holds.

## What

### Add `Mesh.normals: Vec<DVec3>`

Normals come from `BRepLib_ToolTriangulatedShape::ComputeNormals`, which evaluates the **exact surface normal** at each UV node (`GeomLib::NormEstim`). Nodes where the normal is undefined — a cone apex, a sphere pole — fall back to averaging the adjacent triangles inside OCCT itself, so no gap-filling code is needed on our side.

`Poly_Triangulation::ComputeNormals` is a different function whose doc says "averaging triangle normals". It is **deliberately not used**: it would discard the surface.

Normals are reversed on `TopAbs_REVERSED` faces and carried through the face location so they share the vertices' frame — the same rule the index winding already uses.

**Vertices are never shared across B-rep faces** (`mesh_shape` appends each face's nodes separately), so a face acts as its own smoothing group. A cylinder's side comes out smooth and its sharp edges stay sharp, with no vertex splitting.

### Remove `Mesh.uvs`

Searched the whole repository: **nothing ever read it**. `write_gltf_binary` emits no TEXCOORD_0, and neither STL nor Scene2D touches it.

Removing it deletes the per-face min/max pre-pass that existed solely to normalize UVs to [0, 1], so `mesh_shape` now walks the nodes exactly once.

### Deduplicate `write_stl`

`tri_normal()` already existed, yet `write_stl` inlined the same cross product. Routed through the former.

**STL stores the facet normal by format definition**, so it keeps using the triangle's geometric normal rather than the new per-vertex one. The same holds for backface culling, occlusion and silhouette detection: all three define visibility in terms of **facet orientation**, and would break if handed a vertex normal.

## Tests

For a sphere of radius 5, every vertex normal must match the radial unit vector to within `1e-6`. **An average of triangle normals would miss by the deflection (~1e-3), so it could not pass this tolerance** — which is what makes the test proof that the normals come from the surface. Pole nodes pass too.

Dropped `svg::box_top_down` and `png::box_isometric`, whose assertions were strict subsets of siblings that remain (the view=Z / up=Y basis path, the PNG magic and the dimension checks are all covered by the surviving tests).

## Breaking change

`Mesh` has only `pub` fields and no `#[non_exhaustive]`, so removing `uvs` and adding `normals` breaks downstream `Mesh { .. }` literals. A version policy decision is needed at release time.

## Not covered

`write_gltf_binary` still emits no `NORMAL` attribute. This PR lays the groundwork only; exposing it through glTF is a separate change.

---

## なぜ

`Mesh` は法線を一切持っておらず、必要な箇所がそれぞれ自前で導出していた。結果として下流の実利用者が法線を手書きする事態になっている（`notes/20260713-実利用3件から見た不足と過剰.md` §2）。

三角形分割は曲面を捨てた後の姿なので、**円柱側面の本当の法線は三角形からは復元できない**。外積の平均は近似にすぎない。保存する価値があるのは頂点法線だけで、その出所は OCCT が持つ元の曲面である。

## なにを

### `Mesh.normals: Vec<DVec3>` を追加

`BRepLib_ToolTriangulatedShape::ComputeNormals` で、各 UV ノード上の**厳密な曲面法線**（`GeomLib::NormEstim`）を取る。球の極・円錐の頂点など法線が未定義なノードは OCCT 自身が隣接三角形の平均にフォールバックするので、穴埋めコードは不要。

`Poly_Triangulation::ComputeNormals` は doc が "averaging triangle normals" と明言している別物で、**意図的に使っていない**。曲面情報を捨ててしまうため。

法線は REVERSED 面で反転し、face の location を掛けて頂点と同じ座標系に揃える（index の巻き方向と同じ規則）。

**頂点は B-rep 面をまたいで共有されない**（`mesh_shape` は面ごとにノードを積む）ので、面がそのまま smoothing group として機能する。円柱側面は滑らかに、稜線は鋭いまま出る。頂点分割は不要。

### `Mesh.uvs` を削除

リポジトリ全体を検索したが、**読み手が 1 人もいなかった**。`write_gltf_binary` は TEXCOORD_0 を出しておらず、STL も Scene2D も使っていない。

削除により、UV の [0,1] 正規化のためだけに存在していた**面ごとの min/max 事前パスが消え**、`mesh_shape` のノード走査が正真正銘 1 本になった。

### `write_stl` の重複を解消

`tri_normal()` があるのに `write_stl` が同じ外積をインラインで書いていた。前者に一本化。

**STL は仕様上ファセット法線を格納する形式**なので、新しい頂点法線は使わず三角形の幾何法線のまま。背面カリング・遮蔽判定・シルエット検出も同様で、いずれも可視性を**ファセットの向き**で定義しているため頂点法線に置き換えると壊れる。

## テスト

半径 5 の球で、全頂点の法線が中心からの単位ベクトルと `1e-6` 以内で一致することを検証する。**三角形法線の平均だと deflection のオーダー（1e-3 級）でずれるので、この許容差では通らない** — 曲面から取れていることの証明になる。極ノードも含めて通っている。

アサーションが兄弟テストの真部分集合だった `svg::box_top_down` と `png::box_isometric` を削除（view=Z / up=Y の基底パスも PNG magic も寸法検査も、残るテストがカバーしている）。

## 破壊的変更

`Mesh` は `pub` フィールドのみで `#[non_exhaustive]` が無いため、`uvs` の削除と `normals` の追加は下流の `Mesh { .. }` リテラル構築を壊す。リリース時にバージョン方針の判断が要る。

## 未対応

`write_gltf_binary` は依然として `NORMAL` 属性を出していない。この PR は土台までで、glTF への露出は別途。
