### PR TITLE
Emit NORMAL in glTF and drop KHR_materials_unlit

### DIFF
--- a/src/common/mesh.rs
+++ b/src/common/mesh.rs
@@ -125,13 +125,13 @@ impl Mesh {
 	/// このメッシュをバイナリ glTF (GLB) 形式で書き出す。
 	///
 	/// Emits a single mesh whose primitives are:
-	/// - triangles (`mode` TRIANGLES) — with the `color` feature, one primitive
-	///   per distinct face color, each backed by a `KHR_materials_unlit`
-	///   material (same-color faces share one material); otherwise a single
-	///   uncolored primitive.
+	/// - triangles (`mode` TRIANGLES) carrying POSITION and NORMAL — with the
+	///   `color` feature, one primitive per distinct face color, each backed by a
+	///   lit metallic-roughness material (same-color faces share one material);
+	///   otherwise a single uncolored primitive on the glTF default material.
 	/// - edges (`mode` LINES, `extras: {"cadrum":"edges"}`) built from
 	///   `self.edges`, so viewers render the wireframe and `cadrum` readers can
-	///   identify it.
+	///   identify it. POSITION only — a normal means nothing on a line.
 	///
 	/// Geometry lives in the GLB BIN chunk; JSON is hand-written (no serde
 	/// dependency). `RWGltf_CafWriter` is intentionally not used.
@@ -144,10 +144,14 @@ impl Mesh {
 		#[allow(unused_mut)]
 		let mut materials: Vec<String> = Vec::new();
 
-		// ---- Triangle primitives (shared POSITION accessor) ----
+		// ---- Triangle primitives (shared POSITION + NORMAL accessors) ----
+		// Vertices are never shared across B-rep faces, so `normals` is index-parallel
+		// with `vertices` and one NORMAL accessor is valid for every group — the same
+		// reason POSITION can be shared.
 		let tri_groups = self.gltf_triangle_groups(&mut materials);
-		if !tri_groups.is_empty() && !self.vertices.is_empty() {
-			let pos_acc = push_accessor_position(&mut buffer_views, &mut accessors, &mut bin, self.vertices.iter().map(|v| [v.x as f32, v.y as f32, v.z as f32]));
+		if !tri_groups.is_empty() && !self.vertices.is_empty() && !self.normals.is_empty() {
+			let pos_acc = push_accessor_vec3(&mut buffer_views, &mut accessors, &mut bin, self.vertices.iter().map(|v| [v.x as f32, v.y as f32, v.z as f32]));
+			let nrm_acc = push_accessor_vec3(&mut buffer_views, &mut accessors, &mut bin, self.normals.iter().map(|n| [n.x as f32, n.y as f32, n.z as f32]));
 
 			for (indices, material) in tri_groups {
 				if indices.is_empty() {
@@ -155,14 +159,14 @@ impl Mesh {
 				}
 				let acc = push_accessor_index(&mut buffer_views, &mut accessors, &mut bin, &indices, self.vertices.len());
 				let mat = material.map_or(String::new(), |m| format!(r#","material":{}"#, m));
-				primitives.push(format!(r#"{{"attributes":{{"POSITION":{}}},"indices":{},"mode":4{}}}"#, pos_acc, acc, mat));
+				primitives.push(format!(r#"{{"attributes":{{"POSITION":{},"NORMAL":{}}},"indices":{},"mode":4{}}}"#, pos_acc, nrm_acc, acc, mat));
 			}
 		}
 
 		// ---- Edge LINES primitive ----
 		let (epos, eidx) = self.gltf_edge_buffers();
 		if !eidx.is_empty() {
-			let pos_acc = push_accessor_position(&mut buffer_views, &mut accessors, &mut bin, epos.iter().copied());
+			let pos_acc = push_accessor_vec3(&mut buffer_views, &mut accessors, &mut bin, epos.iter().copied());
 			let idx_acc = push_accessor_index(&mut buffer_views, &mut accessors, &mut bin, &eidx, epos.len());
 			primitives.push(format!(r#"{{"attributes":{{"POSITION":{}}},"indices":{},"mode":1,"extras":{{"cadrum":"edges"}}}}"#, pos_acc, idx_acc));
 		}
@@ -180,7 +184,6 @@ impl Mesh {
 		}
 		if !materials.is_empty() {
 			members.push(format!(r#""materials":[{}]"#, materials.join(",")));
-			members.push(r#""extensionsUsed":["KHR_materials_unlit"]"#.to_string());
 		}
 		if !primitives.is_empty() {
 			members.push(format!(r#""meshes":[{{"primitives":[{}]}}]"#, primitives.join(",")));
@@ -219,10 +222,13 @@ impl Mesh {
 		Ok(())
 	}
 
-	/// Group triangle indices by face color, appending one `KHR_materials_unlit`
+	/// Group triangle indices by face color, appending one lit metallic-roughness
 	/// material per distinct color to `materials`. Returns `(index_buffer,
 	/// Some(material_index))` per group. Faces without a color use a default
 	/// gray material.
+	///
+	/// `metallicFactor: 0` + `roughnessFactor: 1` is pure Lambertian diffuse, the
+	/// same shading model `Scene2D` uses for SVG / PNG.
 	#[cfg(feature = "color")]
 	fn gltf_triangle_groups(&self, materials: &mut Vec<String>) -> Vec<(Vec<u32>, Option<usize>)> {
 		const DEFAULT: [f32; 3] = [0.8667, 0.8667, 0.8667]; // 0xdd, matches scene fallback
@@ -242,7 +248,7 @@ impl Mesh {
 			.into_iter()
 			.map(|(indices, col)| {
 				let mat = materials.len();
-				materials.push(format!(r#"{{"pbrMetallicRoughness":{{"baseColorFactor":[{},{},{},1.0],"metallicFactor":0.0,"roughnessFactor":1.0}},"alphaMode":"OPAQUE","doubleSided":true,"extensions":{{"KHR_materials_unlit":{{}}}}}}"#, col[0], col[1], col[2]));
+				materials.push(format!(r#"{{"pbrMetallicRoughness":{{"baseColorFactor":[{},{},{},1.0],"metallicFactor":0.0,"roughnessFactor":1.0}},"alphaMode":"OPAQUE","doubleSided":true}}"#, col[0], col[1], col[2]));
 				(indices, Some(mat))
 			})
 			.collect()
@@ -326,9 +332,10 @@ fn push_buffer_view(views: &mut Vec<String>, bin: &mut Vec<u8>, data: &[u8], tar
 	idx
 }
 
-/// Append a POSITION buffer to BIN and register the VEC3 float accessor over it,
-/// computing the glTF-required min/max in the same pass. Returns the accessor index.
-fn push_accessor_position(views: &mut Vec<String>, accs: &mut Vec<String>, bin: &mut Vec<u8>, points: impl ExactSizeIterator<Item = [f32; 3]>) -> usize {
+/// Append a VEC3 float buffer (POSITION or NORMAL) to BIN and register the accessor
+/// over it, computing min/max in the same pass. Returns the accessor index.
+/// glTF requires min/max on POSITION and permits it elsewhere, so one emitter serves both.
+fn push_accessor_vec3(views: &mut Vec<String>, accs: &mut Vec<String>, bin: &mut Vec<u8>, points: impl ExactSizeIterator<Item = [f32; 3]>) -> usize {
 	let n = points.len();
 	let mut bytes = Vec::with_capacity(n * 12);
 	let (mut min, mut max) = ([f32::INFINITY; 3], [f32::NEG_INFINITY; 3]);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6,7 +6,7 @@
 //! 各テスト名の `t0N` は合格基準番号に対応:
 //!   T-01: Bug 1 — ブール演算結果の drop 順序で STATUS_HEAP_CORRUPTION が起きない
 //!   T-02: Bug 2 — read_step 複数回呼び出し後にプロセスが正常終了する
-//!   T-03: 廃止（Mesh::normals フィールド削除に伴い検証対象が消滅）
+//!   T-03: Mesh::normals — tests/mesh.rs::sphere_normals_come_from_the_surface に移設
 //!   T-04: Bug 4 — approximation_segments の tolerance が反映される（ハードコード脱却）
 //!   T-05: Bug 5 — union 後コンパウンドへの平行移動が全頂点に正確に反映される
 //!   T-06: I/O  — BRep バイナリの write→read ラウンドトリップ

--- a/tests/mesh.rs
+++ b/tests/mesh.rs
@@ -169,18 +169,7 @@ mod glb {
 		assert!(json.contains(r#""mode":4"#), "triangle primitive present");
 		assert!(json.contains(r#""mode":1"#), "edge LINES primitive present");
 		assert!(json.contains(r#""cadrum":"edges""#), "edge extras marker present");
-	}
-
-	/// With the `color` feature, faces get unlit materials.
-	#[cfg(feature = "color")]
-	#[test]
-	fn has_unlit_material() {
-		let mut buf = Vec::new();
-		Solid::mesh(&[Solid::cube(DVec3::ZERO, DVec3::splat(10.0))], Default::default()).unwrap().write_gltf_binary(&mut buf).expect("glb write");
-		let json = glb_json(&buf);
-		assert!(json.contains(r#""materials""#), "materials array present");
-		assert!(json.contains("KHR_materials_unlit"), "unlit extension declared");
-		assert!(json.contains(r#""extensionsUsed":["KHR_materials_unlit"]"#), "extensionsUsed lists the unlit ext");
+		assert!(json.contains(r#""NORMAL":"#), "triangles must carry vertex normals");
 	}
 
 	/// A small mesh (≤ 65535 vertices) stores indices as UNSIGNED_SHORT (5123);


### PR DESCRIPTION
Closes #239

## Why

#243 gave `Mesh` exact per-vertex surface normals, taken from the underlying B-rep surface — but **nothing read them**. `write_gltf_binary` emitted no `NORMAL` attribute and forced `KHR_materials_unlit`, so the one field carrying information the triangles cannot reproduce never reached a consumer.

The choice is asymmetric. A consumer can always force unlit back on (swap in a `MeshBasicMaterial` after loading). But **without `NORMAL` it cannot recover the exact normals**: the glTF spec makes flat normals mandatory in their absence, and `computeVertexNormals()` only averages triangle normals — the very approximation #243 avoided, off by the deflection. So `NORMAL` is the load-bearing part; the lit/unlit flag is a default worth picking for the sake of viewers you cannot script.

## What

**Emit `NORMAL` alongside `POSITION`** on the triangle primitives. Vertices are never shared across B-rep faces, so `normals` is index-parallel with `vertices` and a single NORMAL accessor is valid for every color group — the same reason `POSITION` could already be shared. The edge `LINES` primitive stays POSITION-only: it builds its own position buffer, and a normal means nothing on a line.

**Drop `KHR_materials_unlit`**, leaving a plain metallic-roughness material. `metallicFactor: 0` + `roughnessFactor: 1` is pure Lambertian diffuse, which matches the shading model `Scene2D` already uses for SVG and PNG. `extensionsUsed` disappears entirely — it listed nothing else.

**`push_accessor_position` → `push_accessor_vec3`.** It was already a generic VEC3 / float(5126) emitter; `min`/`max` is *required* on POSITION and *permitted* elsewhere, so one emitter serves both attributes. No new function.

## Verification

Inspected the generated GLBs directly:

| | cube | sphere |
|---|---|---|
| triangle primitive attributes | `[POSITION, NORMAL]` | `[POSITION, NORMAL]` |
| POSITION accessor count | 24 | 66632 |
| NORMAL accessor count | **24** | **66632** |
| `KHR_materials_unlit` | absent | absent |
| `extensionsUsed` | absent | absent |

The cube's 24 vertices (6 faces × 4 nodes, not 8) confirm the per-face split that makes a single shared NORMAL accessor correct. Index accessors keep their u16/u32 switch (5123 / 5125); NORMAL is 5126 and does not disturb it.

Resulting material:

```json
{"pbrMetallicRoughness":{"baseColorFactor":[0.8667,0.8667,0.8667,1.0],"metallicFactor":0.0,"roughnessFactor":1.0},"alphaMode":"OPAQUE","doubleSided":true}
```

## Behaviour change to be aware of

**A three.js scene with no lights and no environment map will now render the mesh black**, because `MeshStandardMaterial` needs a light source where `MeshBasicMaterial` did not. Drag-and-drop viewers (Blender, the VS Code glTF preview, Windows 3D Viewer, online viewers) supply default lighting and are unaffected — they now show shading instead of a flat silhouette-less blob. Consumers building their own three.js scene must add a light.

## Tests

`glb::header_and_chunks` now asserts the triangle primitive carries `NORMAL`. It is not gated on the `color` feature, which is right: NORMAL is emitted regardless.

`glb::has_unlit_material` is deleted rather than rewritten. Once its unlit assertions are gone, everything it checked (`materials`, `pbrMetallicRoughness`) was already true before this change, so it verified nothing new.

Also fixed a stale doc comment in `tests/integration.rs` claiming T-03 was retired because `Mesh::normals` had been deleted — #243 brought the field back.

## Note on #239

`Closes #239`, but one item in that issue's scope is deliberately left undone: **metallic / roughness are still hardcoded** (`0.0` / `1.0`) rather than configurable per colour. The other two items — expose normals from `Mesh` (#243) and emit `NORMAL` while dropping the forced `KHR_materials_unlit` (this PR) — are complete.

---

## なぜ

#243 で `Mesh` に B-rep 曲面由来の厳密な頂点法線を持たせたが、**読み手が誰もいなかった**。`write_gltf_binary` は `NORMAL` 属性を出さず `KHR_materials_unlit` でライティングを殺していたため、三角形からは再現できない情報を運ぶ唯一のフィールドが、消費者に届いていなかった。

この選択は非対称である。下流はロード後に `MeshBasicMaterial` へ差し替えれば **unlit をいつでも強制できる**。しかし **`NORMAL` が無ければ正確な法線は復元できない** — glTF 仕様は「NORMAL が無ければフラット法線を計算しなければならない」と定めており、滑らかにするには `computeVertexNormals()`（＝三角形法線の平均、まさに #243 が避けた近似で deflection オーダーの誤差）に頼るしかない。つまり載せる価値があるのは `NORMAL` のほうで、lit/unlit はスクリプトを書けないビューアのための既定値選択にすぎない。

## なにを

**三角形プリミティブに `POSITION` と並べて `NORMAL` を出す。** 頂点は B-rep 面をまたいで共有されないので `normals` は `vertices` と添字が 1:1 で並行し、**単一の NORMAL アクセサが全カラーグループに対して正しい** — `POSITION` が既に共有できていたのと同じ理由。エッジ `LINES` プリミティブは POSITION のみのまま（独自の位置バッファを持ち、線分に法線は無意味）。

**`KHR_materials_unlit` を削除**し、素の metallic-roughness マテリアルにする。`metallicFactor: 0` + `roughnessFactor: 1` は純粋なランバート拡散で、`Scene2D` が SVG/PNG で使っている陰影モデルと一致する。他に拡張を使っていないので `extensionsUsed` 自体が消える。

**`push_accessor_position` → `push_accessor_vec3`。** 中身は元々汎用の VEC3 / float(5126) エミッタで、`min`/`max` は POSITION では必須・それ以外では許容なので、そのまま両属性に使える。新規関数はゼロ。

## 検証

生成した GLB を直接検査した。

| | 立方体 | 球 |
|---|---|---|
| 三角形プリミティブの attributes | `[POSITION, NORMAL]` | `[POSITION, NORMAL]` |
| POSITION アクセサの count | 24 | 66632 |
| NORMAL アクセサの count | **24** | **66632** |
| `KHR_materials_unlit` | 無し | 無し |
| `extensionsUsed` | 無し | 無し |

立方体が 8 頂点でなく **24 頂点**（6 面 × 4 節点）であることが、単一の共有 NORMAL アクセサを正当化する面ごとの分割の証拠になっている。インデックスの u16/u32 切り替え（5123 / 5125）はそのままで、NORMAL は 5126 なので干渉しない。

## 注意すべき挙動変化

**ライトも環境マップも無い three.js シーンでは、メッシュが真っ黒になる。** `MeshStandardMaterial` は光源を要求するが `MeshBasicMaterial` は要求しなかったため。ドラッグ&ドロップ系ビューア（Blender、VS Code の glTF プレビュー、Windows 3D ビューア、オンライン viewer）は既定のライト/環境を持つので影響を受けず、むしろ陰影の無いベタ塗りから陰影付きに改善する。自前でシーンを組む下流は光源の追加が必要。

## テスト

`glb::header_and_chunks` に、三角形プリミティブが `NORMAL` を持つことの検査を追加した。`color` feature でゲートしていないのは正しい — NORMAL は feature に関係なく出るため。

`glb::has_unlit_material` は書き換えではなく**削除**した。unlit のアサーションを外すと、残る検査（`materials`、`pbrMetallicRoughness`）はこの変更の**前から真だった**ので、何も新しく検証していないため。

あわせて `tests/integration.rs` の古いコメント（「`Mesh::normals` フィールド削除に伴い T-03 は廃止」）を修正した。#243 でフィールドは復活している。

## #239 について

`Closes #239` としているが、issue のスコープのうち **metallic / roughness の設定可能化は意図的に未実装**のまま（`0.0` / `1.0` のハードコード）。残る 2 項目 — `Mesh` からの法線露出（#243）と、`NORMAL` の出力＋`KHR_materials_unlit` 強制の撤廃（この PR）— は完了している。
