### PR TITLE
Read and write STEP's solid-level colour

### DIFF
--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -833,18 +833,7 @@ MeshData mesh_shape(const TopoDS_Shape& shape, double linear, double angular, bo
         TopLoc_Location location;
         Handle(Poly_Triangulation) triangulation = BRep_Tool::Triangulation(face, location);
 
-        // Nodal normals, taken from the underlying surface (GeomLib::NormEstim at
-        // each UV node) rather than averaged from the triangles, so curved faces
-        // carry their exact normal. OCCT falls back to averaging adjacent triangle
-        // normals at singular nodes (cone apex, sphere pole) and on faces without
-        // UV nodes. NOT Poly_Triangulation::ComputeNormals, which only averages
-        // triangle normals and would throw the surface away.
-        //
-        // Safe on a null handle, and every other path allocates the array, so the
-        // guard below rejects exactly the faces with nothing to emit: no
-        // triangulation at all, or a triangulation with no nodes.
-        BRepLib_ToolTriangulatedShape::ComputeNormals(face, triangulation);
-        if (triangulation.IsNull() || !triangulation->HasNormals()) {
+        if (triangulation.IsNull()) {
             continue;
         }
 
@@ -854,7 +843,17 @@ MeshData mesh_shape(const TopoDS_Shape& shape, double linear, double angular, bo
         // Shared by the nodal normals and the index winding below.
         bool reversed = (face.Orientation() == TopAbs_REVERSED);
 
-        // Position and normal of every node in one pass.
+        // Nodal normals, taken from the underlying surface (GeomLib::NormEstim at
+        // each UV node) rather than averaged from the triangles, so curved faces
+        // carry their exact normal. OCCT falls back to averaging adjacent triangle
+        // normals at singular nodes (cone apex, sphere pole) and on faces without
+        // UV nodes. NOT Poly_Triangulation::ComputeNormals, which only averages
+        // triangle normals and would throw the surface away.
+        BRepLib_ToolTriangulatedShape::ComputeNormals(face, triangulation);
+        bool has_normals = triangulation->HasNormals();
+
+        // Position and normal of every node in one pass. Absent normals are
+        // emitted as zero so both arrays stay one entry per vertex.
         for (int i = 1; i <= nb_nodes; i++) {
             gp_Pnt p = triangulation->Node(i);
             p.Transform(location.Transformation());
@@ -865,12 +864,18 @@ MeshData mesh_shape(const TopoDS_Shape& shape, double linear, double angular, bo
             // ComputeNormals ignores face orientation and works in the
             // triangulation's local frame, so apply the location and the REVERSED
             // flip here — the same rule the index winding below uses.
-            gp_Dir n = triangulation->Normal(i);
-            n.Transform(location.Transformation());
-            if (reversed) n.Reverse();
-            result.normals.push_back(n.X());
-            result.normals.push_back(n.Y());
-            result.normals.push_back(n.Z());
+            double nx = 0.0, ny = 0.0, nz = 0.0;
+            if (has_normals) {
+                gp_Dir n = triangulation->Normal(i);
+                n.Transform(location.Transformation());
+                if (reversed) n.Reverse();
+                nx = n.X();
+                ny = n.Y();
+                nz = n.Z();
+            }
+            result.normals.push_back(nx);
+            result.normals.push_back(ny);
+            result.normals.push_back(nz);
         }
 
         // Indices
@@ -2058,34 +2063,53 @@ std::unique_ptr<TopoDS_Shape> make_bspline_solid(
 
 namespace cadrum {
 
-// Traverse every label in the XDE document and record face-level colors.
+// Traverse every label in the XDE document and record colors at both levels.
 // Uses TDF_ChildIterator with allLevels=true for a flat, efficient walk.
-static void collect_face_colors(
+//
+// STEP styles a `styled_item` onto either an `advanced_face` (per-face) or a
+// `manifold_solid_brep` (whole solid); both occur in the wild, and a file may
+// carry both (the face style then overrides). Faces land in `faceMap`, anything
+// else has its color assigned to every SOLID it contains, keyed by that solid's
+// TShape*. Solid-level color is deliberately NOT expanded onto faces here —
+// doing so would turn one STYLED_ITEM into N on write-back.
+static void collect_colors(
     const Handle(TDocStd_Document)& doc,
     const Handle(XCAFDoc_ColorTool)& colorTool,
-    std::unordered_map<uint64_t, std::array<float, 3>>& colorMap)
+    std::unordered_map<uint64_t, std::array<float, 3>>& faceMap,
+    std::unordered_map<uint64_t, std::array<float, 3>>& solidMap)
 {
     for (TDF_ChildIterator it(doc->Main(), true); it.More(); it.Next()) {
         const TDF_Label& label = it.Value();
         if (!XCAFDoc_ShapeTool::IsShape(label)) continue;
 
         TopoDS_Shape s = XCAFDoc_ShapeTool::GetShape(label);
-        if (s.IsNull() || s.ShapeType() != TopAbs_FACE) continue;
+        if (s.IsNull()) continue;
 
         Quantity_Color color;
         bool ok = colorTool->GetColor(label, XCAFDoc_ColorSurf, color);
         if (!ok) ok = colorTool->GetColor(label, XCAFDoc_ColorGen, color);
         if (!ok) continue;
 
-        uint64_t id = reinterpret_cast<uint64_t>(s.TShape().get());
-        colorMap[id] = {(float)color.Red(), (float)color.Green(), (float)color.Blue()};
+        std::array<float, 3> rgb = {(float)color.Red(), (float)color.Green(), (float)color.Blue()};
+
+        if (s.ShapeType() == TopAbs_FACE) {
+            faceMap[reinterpret_cast<uint64_t>(s.TShape().get())] = rgb;
+            continue;
+        }
+        // A SOLID explores to itself; a COMPOUND/COMPSOLID spreads its color to
+        // every solid it holds. Shapes with no solid (loose shells/faces) drop out.
+        for (TopExp_Explorer ex(s, TopAbs_SOLID); ex.More(); ex.Next()) {
+            solidMap[reinterpret_cast<uint64_t>(ex.Current().TShape().get())] = rgb;
+        }
     }
 }
 
 std::unique_ptr<TopoDS_Shape> read_step_color_stream(
     RustReader&          reader,
     rust::Vec<uint64_t>& out_ids,
-    rust::Vec<float>&    out_rgb)
+    rust::Vec<float>&    out_rgb,
+    rust::Vec<uint64_t>& out_solid_ids,
+    rust::Vec<float>&    out_solid_rgb)
 {
     try {
         // Create XDE document directly — avoids XCAFApp_Application which
@@ -2121,12 +2145,15 @@ std::unique_ptr<TopoDS_Shape> read_step_color_stream(
             builder.Add(compound, shapeTool->GetShape(roots.Value(i)));
         }
 
-        // Build TShape* → color map from the XDE document labels.
+        // Build TShape* → color maps from the XDE document labels.
         std::unordered_map<uint64_t, std::array<float, 3>> colorMap;
-        collect_face_colors(doc, colorTool, colorMap);
+        std::unordered_map<uint64_t, std::array<float, 3>> solidColorMap;
+        collect_colors(doc, colorTool, colorMap, solidColorMap);
 
         // Recover Solids from disjoint shells / loose faces (#129); also
         // remaps colorMap keys for faces whose TShape* changed during sewing.
+        // Solids that already existed pass through with their TShape* intact, so
+        // solidColorMap needs no remap; solids invented by sewing simply miss.
         TopoDS_Shape post = try_sew_orphan_faces(compound, &colorMap);
 
         // Emit colors — walk POST-processed shape so new TShape* are picked up.
@@ -2141,6 +2168,17 @@ std::unique_ptr<TopoDS_Shape> read_step_color_stream(
             out_rgb.push_back(it->second[2]);
         }
 
+        for (TopExp_Explorer ex(post, TopAbs_SOLID); ex.More(); ex.Next()) {
+            uint64_t id =
+                reinterpret_cast<uint64_t>(ex.Current().TShape().get());
+            auto it = solidColorMap.find(id);
+            if (it == solidColorMap.end()) continue;
+            out_solid_ids.push_back(id);
+            out_solid_rgb.push_back(it->second[0]);
+            out_solid_rgb.push_back(it->second[1]);
+            out_solid_rgb.push_back(it->second[2]);
+        }
+
         return std::make_unique<TopoDS_Shape>(post);
     } catch (const Standard_Failure&) {
         return nullptr;
@@ -2151,6 +2189,8 @@ bool write_step_color_stream(
     const TopoDS_Shape&         shape,
     rust::Slice<const uint64_t> ids,
     rust::Slice<const float>    rgb,
+    rust::Slice<const uint64_t> solid_ids,
+    rust::Slice<const float>    solid_rgb,
     RustWriter&                 writer)
 {
     try {
@@ -2164,6 +2204,30 @@ bool write_step_color_stream(
         // Register the root shape.
         TDF_Label rootLabel = shapeTool->AddShape(shape, false);
 
+        // Attach `color` at `level` to the sub-shape label of `sub`, creating the
+        // label if XCAF does not have one yet. Shared by the solid and face passes.
+        auto set_color = [&](const TopoDS_Shape& sub, const std::array<float, 3>& c) {
+            TDF_Label label;
+            if (!shapeTool->FindSubShape(rootLabel, sub, label)) {
+                label = shapeTool->AddSubShape(rootLabel, sub);
+            }
+            Quantity_Color color(c[0], c[1], c[2], Quantity_TOC_RGB);
+            colorTool->SetColor(label, color, XCAFDoc_ColorSurf);
+        };
+
+        // Solid-level colors first, so a face-level color set below wins in
+        // viewers that honour the more specific style.
+        std::unordered_map<uint64_t, std::array<float, 3>> solidLookup;
+        for (size_t i = 0; i < solid_ids.size(); i++) {
+            solidLookup[solid_ids[i]] = {solid_rgb[3*i], solid_rgb[3*i+1], solid_rgb[3*i+2]};
+        }
+        for (TopExp_Explorer ex(shape, TopAbs_SOLID); ex.More(); ex.Next()) {
+            const TopoDS_Shape& solid = ex.Current();
+            auto it = solidLookup.find(reinterpret_cast<uint64_t>(solid.TShape().get()));
+            if (it == solidLookup.end()) continue;
+            set_color(solid, it->second);
+        }
+
         // Build TShape* → color lookup from the Rust-supplied arrays.
         std::unordered_map<uint64_t, std::array<float, 3>> colorLookup;
         for (size_t i = 0; i < ids.size(); i++) {
@@ -2173,18 +2237,9 @@ bool write_step_color_stream(
         // For each colored face, find/create its sub-shape label and set color.
         for (TopExp_Explorer ex(shape, TopAbs_FACE); ex.More(); ex.Next()) {
             const TopoDS_Shape& face = ex.Current();
-            uint64_t id = reinterpret_cast<uint64_t>(face.TShape().get());
-            auto it = colorLookup.find(id);
+            auto it = colorLookup.find(reinterpret_cast<uint64_t>(face.TShape().get()));
             if (it == colorLookup.end()) continue;
-
-            TDF_Label faceLabel;
-            if (!shapeTool->FindSubShape(rootLabel, face, faceLabel)) {
-                faceLabel = shapeTool->AddSubShape(rootLabel, face);
-            }
-
-            const auto& c = it->second;
-            Quantity_Color color(c[0], c[1], c[2], Quantity_TOC_RGB);
-            colorTool->SetColor(faceLabel, color, XCAFDoc_ColorSurf);
+            set_color(face, it->second);
         }
 
         // Transfer XDE doc to STEP model and write to stream.

--- a/cpp/wrapper.h
+++ b/cpp/wrapper.h
@@ -463,18 +463,29 @@ namespace cadrum {
 // `out_ids` the TShape* address of each colored face, and to `out_rgb` its
 // RGB components in OCC native space (0.0–1.0) as a flat
 // [r0,g0,b0, r1,g1,b1, ...] sequence (length = 3 * out_ids.size()).
+//
+// STEP also styles whole solids (`styled_item` → `manifold_solid_brep`), which
+// commercial CAD emits routinely. Those come back separately in
+// `out_solid_ids` / `out_solid_rgb`, keyed by the SOLID's TShape*, and are NOT
+// expanded onto faces — keeping the two levels apart is what lets a write-back
+// reproduce one STYLED_ITEM instead of N.
 // Returns nullptr on failure.
 std::unique_ptr<TopoDS_Shape> read_step_color_stream(
     RustReader&          reader,
     rust::Vec<uint64_t>& out_ids,
-    rust::Vec<float>&    out_rgb);
+    rust::Vec<float>&    out_rgb,
+    rust::Vec<uint64_t>& out_solid_ids,
+    rust::Vec<float>&    out_solid_rgb);
 
 // Write a colored STEP stream. `ids` lists TShape* of colored faces; `rgb`
 // is the matching flat [r,g,b,...] sequence (length = 3 * ids.size()).
+// `solid_ids` / `solid_rgb` do the same at solid level.
 bool write_step_color_stream(
     const TopoDS_Shape&         shape,
     rust::Slice<const uint64_t> ids,
     rust::Slice<const float>    rgb,
+    rust::Slice<const uint64_t> solid_ids,
+    rust::Slice<const float>    solid_rgb,
     RustWriter&                 writer);
 
 } // namespace cadrum

--- a/src/occt/compound.rs
+++ b/src/occt/compound.rs
@@ -62,6 +62,10 @@ impl CompoundShape {
 	/// Each result solid receives a clone of the full `history` — over-inclusion
 	/// is harmless because `iter_history()` consumers filter pairs by checking
 	/// `src_id` against the original input's face IDs.
+	///
+	/// The solid-level colour is left `None`: unlike the face colormap it cannot be
+	/// over-included, so whoever knows which solid is which sets it afterwards
+	/// (`io::read_step` by TShape id, `Solid::boolean_build` by operand agreement).
 	pub fn decompose(self) -> Vec<Solid> {
 		let solid_shapes = ffi::decompose_into_solids(&self.inner);
 		solid_shapes
@@ -71,6 +75,8 @@ impl CompoundShape {
 					ffi::clone_shape_handle(s),
 					#[cfg(feature = "color")]
 					self.colormap.clone(),
+					#[cfg(feature = "color")]
+					None,
 					self.history.clone(),
 				)
 			})

--- a/src/occt/ffi.rs
+++ b/src/occt/ffi.rs
@@ -63,10 +63,10 @@ mod ffi_bridge {
 		// ==================== Colored STEP I/O (color feature only) ====================
 
 		#[cfg(feature = "color")]
-		fn read_step_color_stream(reader: &mut RustReader, out_ids: &mut Vec<u64>, out_rgb: &mut Vec<f32>) -> UniquePtr<TopoDS_Shape>;
+		fn read_step_color_stream(reader: &mut RustReader, out_ids: &mut Vec<u64>, out_rgb: &mut Vec<f32>, out_solid_ids: &mut Vec<u64>, out_solid_rgb: &mut Vec<f32>) -> UniquePtr<TopoDS_Shape>;
 
 		#[cfg(feature = "color")]
-		fn write_step_color_stream(shape: &TopoDS_Shape, ids: &[u64], rgb: &[f32], writer: &mut RustWriter) -> bool;
+		fn write_step_color_stream(shape: &TopoDS_Shape, ids: &[u64], rgb: &[f32], solid_ids: &[u64], solid_rgb: &[f32], writer: &mut RustWriter) -> bool;
 
 		// ==================== Builders (solid → solid with history) ====================
 

--- a/src/occt/io.rs
+++ b/src/occt/io.rs
@@ -47,9 +47,29 @@ fn resolve_color_trailer(inner: &ffi::TopoDS_Shape, index_colormap: &std::collec
 	index_colormap.iter().filter_map(|(&idx, &color)| index_to_id.get(idx as usize).map(|&id| (id, color))).collect()
 }
 
+/// Effective colour of every face: its own if it has one, else the colour of the
+/// solid it belongs to.
+///
+/// Solid-level colour has no face key of its own, so consumers that speak only
+/// face colours — the BRep trailer and `Mesh` — get it expanded here. STEP does
+/// not go through this: it keeps the two levels apart, which is the whole point.
 #[cfg(feature = "color")]
-fn write_color_trailer<W: Write>(compound: &CompoundShape, writer: &mut W) -> Result<(), Error> {
-	let colormap = compound.colormap();
+fn resolve_face_colors<'a>(solids: impl IntoIterator<Item = &'a Solid>) -> std::collections::HashMap<u64, Color> {
+	let mut map = std::collections::HashMap::new();
+	for s in solids {
+		if let Some(c) = s.color_solid() {
+			for f in ffi::shape_faces(s.inner()).iter() {
+				map.insert(ffi::face_tshape_id(f), c);
+			}
+		}
+		// Face colours are the more specific style and win over the solid's.
+		map.extend(s.colormap().iter().map(|(&k, &v)| (k, v)));
+	}
+	map
+}
+
+#[cfg(feature = "color")]
+fn write_color_trailer<W: Write>(compound: &CompoundShape, colormap: &std::collections::HashMap<u64, Color>, writer: &mut W) -> Result<(), Error> {
 	if colormap.is_empty() {
 		return Ok(());
 	}
@@ -81,12 +101,22 @@ pub(super) fn read_step<R: Read>(reader: &mut R) -> Result<Vec<Solid>, Error> {
 		let mut rust_reader = RustReader::from_ref(reader);
 		let mut ids: Vec<u64> = Default::default();
 		let mut rgb: Vec<f32> = Default::default();
-		let inner = ffi::read_step_color_stream(&mut rust_reader, &mut ids, &mut rgb);
+		let mut solid_ids: Vec<u64> = Default::default();
+		let mut solid_rgb: Vec<f32> = Default::default();
+		let inner = ffi::read_step_color_stream(&mut rust_reader, &mut ids, &mut rgb, &mut solid_ids, &mut solid_rgb);
 		if inner.is_null() {
 			return Err(Error::StepReadFailed);
 		}
 		let colormap: std::collections::HashMap<u64, Color> = ids.into_iter().zip(rgb.chunks_exact(3)).map(|(id, c)| (id, Color { r: c[0], g: c[1], b: c[2] })).collect();
-		Ok(CompoundShape::from_raw(inner, colormap, Default::default()).decompose())
+		let solid_colors: std::collections::HashMap<u64, Color> = solid_ids.into_iter().zip(solid_rgb.chunks_exact(3)).map(|(id, c)| (id, Color { r: c[0], g: c[1], b: c[2] })).collect();
+
+		let mut solids = CompoundShape::from_raw(inner, colormap, Default::default()).decompose();
+		// `decompose` cannot know which solid is which; match by TShape id, which
+		// survives the compound → solid split (the handle is cloned, not rebuilt).
+		for s in &mut solids {
+			s.set_color_solid(solid_colors.get(&ffi::shape_tshape_id(s.inner())).copied());
+		}
+		Ok(solids)
 	}
 	#[cfg(not(feature = "color"))]
 	{
@@ -143,6 +173,24 @@ fn read_brep_with<R: Read>(reader: &mut R, ffi_read: fn(&mut RustReader) -> cxx:
 /// With the `color` feature enabled, face colors are automatically embedded
 /// in the STEP file (XDE / AP214 styled items).
 pub(super) fn write_step<'a, W: Write>(solids: impl IntoIterator<Item = &'a Solid>, writer: &mut W) -> Result<(), Error> {
+	#[cfg(feature = "color")]
+	let solids: Vec<&Solid> = solids.into_iter().collect();
+	#[cfg(feature = "color")]
+	// Solid-level colours, read off the inputs before they are merged into the
+	// compound (which flattens their identities away). TShape ids are shared with
+	// the compound, so these keys still resolve on the C++ side.
+	let (solid_ids, solid_rgb) = {
+		let mut ids: Vec<u64> = Vec::new();
+		let mut rgb: Vec<f32> = Vec::new();
+		for s in &solids {
+			if let Some(c) = s.color_solid() {
+				ids.push(ffi::shape_tshape_id(s.inner()));
+				rgb.extend_from_slice(&[c.r, c.g, c.b]);
+			}
+		}
+		(ids, rgb)
+	};
+
 	let compound = CompoundShape::new(solids);
 	#[cfg(feature = "color")]
 	{
@@ -154,7 +202,7 @@ pub(super) fn write_step<'a, W: Write>(solids: impl IntoIterator<Item = &'a Soli
 			rgb.extend_from_slice(&[c.r, c.g, c.b]);
 		}
 		let mut rust_writer = RustWriter::from_ref(writer);
-		if ffi::write_step_color_stream(compound.inner(), &ids, &rgb, &mut rust_writer) {
+		if ffi::write_step_color_stream(compound.inner(), &ids, &rgb, &solid_ids, &solid_rgb, &mut rust_writer) {
 			Ok(())
 		} else {
 			Err(Error::StepWriteFailed)
@@ -185,19 +233,34 @@ pub(super) fn write_brep_text<'a, W: Write>(solids: impl IntoIterator<Item = &'a
 
 /// Shared body for BRep binary/text writes — see `read_brep_with` for context.
 fn write_brep_with<'a, W: Write>(solids: impl IntoIterator<Item = &'a Solid>, writer: &mut W, ffi_write: fn(&ffi::TopoDS_Shape, &mut RustWriter) -> bool) -> Result<(), Error> {
+	#[cfg(feature = "color")]
+	let solids: Vec<&Solid> = solids.into_iter().collect();
+	// The trailer is keyed by face index and has nowhere to say "this solid",
+	// so a solid-level colour is flattened onto its faces. Appearance survives;
+	// the solid/face distinction does not. Only STEP keeps the two apart.
+	#[cfg(feature = "color")]
+	let colormap = resolve_face_colors(solids.iter().copied());
+
 	let compound = CompoundShape::new(solids);
 	let mut rust_writer = RustWriter::from_ref(writer);
 	if !ffi_write(compound.inner(), &mut rust_writer) {
 		return Err(Error::BrepWriteFailed);
 	}
 	#[cfg(feature = "color")]
-	write_color_trailer(&compound, writer)?;
+	write_color_trailer(&compound, &colormap, writer)?;
 	Ok(())
 }
 
 pub(super) fn mesh<'a>(solids: impl IntoIterator<Item = &'a Solid>, options: crate::traits::Tessellation) -> Result<crate::common::mesh::Mesh, Error> {
 	use crate::common::mesh::Mesh;
 	use glam::DVec3;
+
+	#[cfg(feature = "color")]
+	let solids: Vec<&Solid> = solids.into_iter().collect();
+	// `Mesh` speaks only face colours, so resolve the solid's onto its faces here.
+	// That keeps every renderer (glTF / STL / Scene2D) unchanged.
+	#[cfg(feature = "color")]
+	let face_colors = resolve_face_colors(solids.iter().copied());
 
 	let compound = CompoundShape::new(solids);
 	let data = ffi::mesh_shape(compound.inner(), options.deflection_linear, options.deflection_angular, options.relative_linear);
@@ -232,7 +295,7 @@ pub(super) fn mesh<'a>(solids: impl IntoIterator<Item = &'a Solid>, options: cra
 	let colormap = {
 		let mut map = std::collections::HashMap::new();
 		for &fid in &face_ids {
-			if let Some(&color) = compound.colormap().get(&fid) {
+			if let Some(&color) = face_colors.get(&fid) {
 				map.insert(fid, color);
 			}
 		}

--- a/src/occt/solid.rs
+++ b/src/occt/solid.rs
@@ -62,6 +62,16 @@ pub struct Solid {
 	faces: OnceLock<Vec<Face>>,
 	#[cfg(feature = "color")]
 	colormap: std::collections::HashMap<u64, crate::common::color::Color>,
+	/// Colour of the solid as a whole, independent of `colormap`.
+	///
+	/// STEP styles a `styled_item` onto either an `advanced_face` or a whole
+	/// `manifold_solid_brep`; commercial CAD routinely emits the latter. The two
+	/// levels are kept apart so a read → write round-trip reproduces the file's
+	/// structure instead of exploding one style into N face styles.
+	///
+	/// Resolution order for rendering is face colour → solid colour → default grey.
+	#[cfg(feature = "color")]
+	color: Option<crate::common::color::Color>,
 	/// Face-derivation history from the most recent boolean operation.
 	///
 	/// Flat `[post_id, src_id, post_id, src_id, ...]` pairs:
@@ -83,7 +93,7 @@ impl Solid {
 	///
 	/// # Panics
 	/// Panics if `inner` is not `TopAbs_SOLID` (and not null).
-	pub(crate) fn new(inner: cxx::UniquePtr<ffi::TopoDS_Shape>, #[cfg(feature = "color")] colormap: std::collections::HashMap<u64, crate::common::color::Color>, history: Vec<u64>) -> Self {
+	pub(crate) fn new(inner: cxx::UniquePtr<ffi::TopoDS_Shape>, #[cfg(feature = "color")] colormap: std::collections::HashMap<u64, crate::common::color::Color>, #[cfg(feature = "color")] color: Option<crate::common::color::Color>, history: Vec<u64>) -> Self {
 		debug_assert!(ffi::shape_is_null(&inner) || ffi::shape_is_solid(&inner), "Solid::new called with a non-SOLID shape");
 		Solid {
 			inner,
@@ -91,6 +101,8 @@ impl Solid {
 			faces: OnceLock::new(),
 			#[cfg(feature = "color")]
 			colormap,
+			#[cfg(feature = "color")]
+			color,
 			history,
 		}
 	}
@@ -114,6 +126,42 @@ impl Solid {
 	#[cfg(feature = "color")]
 	pub fn colormap_mut(&mut self) -> &mut std::collections::HashMap<u64, crate::common::color::Color> {
 		&mut self.colormap
+	}
+
+	/// The solid-level colour, if any. Named apart from the `color` builder,
+	/// which consumes `self`.
+	#[cfg(feature = "color")]
+	pub fn color_solid(&self) -> Option<crate::common::color::Color> {
+		self.color
+	}
+
+	/// Set the solid-level colour in place. Used by `io::read_step`, which only
+	/// learns which solid got which colour after the compound is decomposed.
+	#[cfg(feature = "color")]
+	pub(crate) fn set_color_solid(&mut self, color: Option<crate::common::color::Color>) {
+		self.color = color;
+	}
+
+	/// Solid-level colour of a boolean result: carried over when every operand
+	/// that *has* one agrees, `None` when they disagree.
+	///
+	/// Face colours ride the `[post_id, src_id]` history, which is a function —
+	/// every result face descends from exactly one source face. A solid colour has
+	/// no such function: the volume of `a ∪ b` is not derived from one operand but
+	/// is a mixture, so there is nothing to carry. Agreeing operands are the only
+	/// case with an answer that is not a guess. Operands with no colour (a cutting
+	/// tool, say) are ignored rather than forcing the result to `None`.
+	#[cfg(feature = "color")]
+	fn merge_solid_color<'a>(solids: impl IntoIterator<Item = &'a Solid>) -> Option<crate::common::color::Color> {
+		let mut agreed = None;
+		for c in solids.into_iter().filter_map(|s| s.color) {
+			match agreed {
+				None => agreed = Some(c),
+				Some(prev) if prev == c => {}
+				Some(_) => return None,
+			}
+		}
+		agreed
 	}
 
 	/// Carry each source face's color onto its derived result faces via
@@ -149,6 +197,8 @@ impl SolidStruct for Solid {
 			inner,
 			#[cfg(feature = "color")]
 			std::collections::HashMap::new(),
+			#[cfg(feature = "color")]
+			None,
 			Default::default(),
 		)
 	}
@@ -159,6 +209,8 @@ impl SolidStruct for Solid {
 			inner,
 			#[cfg(feature = "color")]
 			std::collections::HashMap::new(),
+			#[cfg(feature = "color")]
+			None,
 			Default::default(),
 		)
 	}
@@ -169,6 +221,8 @@ impl SolidStruct for Solid {
 			inner,
 			#[cfg(feature = "color")]
 			std::collections::HashMap::new(),
+			#[cfg(feature = "color")]
+			None,
 			Default::default(),
 		)
 	}
@@ -179,6 +233,8 @@ impl SolidStruct for Solid {
 			inner,
 			#[cfg(feature = "color")]
 			std::collections::HashMap::new(),
+			#[cfg(feature = "color")]
+			None,
 			Default::default(),
 		)
 	}
@@ -189,6 +245,8 @@ impl SolidStruct for Solid {
 			inner,
 			#[cfg(feature = "color")]
 			std::collections::HashMap::new(),
+			#[cfg(feature = "color")]
+			None,
 			Default::default(),
 		)
 	}
@@ -199,6 +257,8 @@ impl SolidStruct for Solid {
 			inner,
 			#[cfg(feature = "color")]
 			std::collections::HashMap::new(),
+			#[cfg(feature = "color")]
+			None,
 			Default::default(),
 		)
 	}
@@ -248,6 +308,8 @@ impl SolidStruct for Solid {
 			shape,
 			#[cfg(feature = "color")]
 			std::collections::HashMap::new(),
+			#[cfg(feature = "color")]
+			None,
 			Default::default(),
 		))
 	}
@@ -268,6 +330,8 @@ impl SolidStruct for Solid {
 			shape,
 			#[cfg(feature = "color")]
 			self.remap_colormap(&history),
+			#[cfg(feature = "color")]
+			self.color,
 			history,
 		))
 	}
@@ -288,6 +352,8 @@ impl SolidStruct for Solid {
 			shape,
 			#[cfg(feature = "color")]
 			self.remap_colormap(&history),
+			#[cfg(feature = "color")]
+			self.color,
 			history,
 		))
 	}
@@ -306,6 +372,8 @@ impl SolidStruct for Solid {
 			shape,
 			#[cfg(feature = "color")]
 			self.remap_colormap(&history),
+			#[cfg(feature = "color")]
+			self.color,
 			history,
 		))
 	}
@@ -330,6 +398,8 @@ impl SolidStruct for Solid {
 			shape,
 			#[cfg(feature = "color")]
 			std::collections::HashMap::new(),
+			#[cfg(feature = "color")]
+			None,
 			Default::default(),
 		))
 	}
@@ -376,6 +446,8 @@ impl SolidStruct for Solid {
 			shape,
 			#[cfg(feature = "color")]
 			std::collections::HashMap::new(),
+			#[cfg(feature = "color")]
+			None,
 			Default::default(),
 		))
 	}
@@ -407,6 +479,8 @@ impl SolidStruct for Solid {
 			shape,
 			#[cfg(feature = "color")]
 			std::collections::HashMap::new(),
+			#[cfg(feature = "color")]
+			None,
 			Default::default(),
 		))
 	}
@@ -426,6 +500,8 @@ impl SolidStruct for Solid {
 			shape,
 			#[cfg(feature = "color")]
 			std::collections::HashMap::new(),
+			#[cfg(feature = "color")]
+			None,
 			Default::default(),
 		))
 	}
@@ -455,6 +531,8 @@ impl SolidStruct for Solid {
 			shape,
 			#[cfg(feature = "color")]
 			std::collections::HashMap::new(),
+			#[cfg(feature = "color")]
+			None,
 			Default::default(),
 		))
 	}
@@ -471,6 +549,8 @@ impl SolidStruct for Solid {
 			inner,
 			#[cfg(feature = "color")]
 			self.remap_colormap(&history),
+			#[cfg(feature = "color")]
+			self.color,
 			history,
 		))
 	}
@@ -493,6 +573,8 @@ impl SolidStruct for Solid {
 				faces: OnceLock::new(),
 				#[cfg(feature = "color")]
 				colormap: s.colormap.clone(),
+				#[cfg(feature = "color")]
+				color: s.color,
 				history: s.history.clone(),
 			})
 			.collect();
@@ -530,13 +612,23 @@ impl SolidStruct for Solid {
 			m
 		};
 
+		// A boolean invents new solids, so the solid-level colour cannot be looked
+		// up per result — it is the operands' agreed colour or nothing.
+		#[cfg(feature = "color")]
+		let solid_color = Self::merge_solid_color(solids.iter());
+
 		let compound = CompoundShape::from_raw(
 			inner,
 			#[cfg(feature = "color")]
 			colormap,
 			history,
 		);
-		Ok(compound.decompose())
+		let mut out = compound.decompose();
+		#[cfg(feature = "color")]
+		for s in &mut out {
+			s.color = solid_color;
+		}
+		Ok(out)
 	}
 
 	// --- I/O (delegates to super::io helpers) ---
@@ -622,14 +714,15 @@ impl SolidStruct for Solid {
 
 	#[cfg(feature = "color")]
 	fn color(self, color: impl Into<crate::common::color::Color>) -> Self {
-		let c = color.into();
-		let colormap = ffi::shape_faces(&self.inner).iter().map(|f| (ffi::face_tshape_id(f), c)).collect();
-		Self::new(self.inner, colormap, self.history)
+		// Paint the solid, not each of its faces: one STYLED_ITEM on the
+		// manifold_solid_brep instead of N on the advanced_faces. Face overrides are
+		// dropped, since "colour the whole solid" means exactly that.
+		Self::new(self.inner, std::collections::HashMap::new(), Some(color.into()), self.history)
 	}
 
 	#[cfg(feature = "color")]
 	fn color_clear(self) -> Self {
-		Self::new(self.inner, std::collections::HashMap::new(), self.history)
+		Self::new(self.inner, std::collections::HashMap::new(), None, self.history)
 	}
 }
 
@@ -646,6 +739,8 @@ impl Transform for Solid {
 			inner,
 			#[cfg(feature = "color")]
 			self.colormap,
+			#[cfg(feature = "color")]
+			self.color,
 			self.history,
 		)
 	}
@@ -656,6 +751,8 @@ impl Transform for Solid {
 			inner,
 			#[cfg(feature = "color")]
 			self.colormap,
+			#[cfg(feature = "color")]
+			self.color,
 			self.history,
 		)
 	}
@@ -681,6 +778,8 @@ impl Transform for Solid {
 			inner,
 			#[cfg(feature = "color")]
 			colormap,
+			#[cfg(feature = "color")]
+			self.color,
 			Default::default(),
 		)
 	}
@@ -693,6 +792,8 @@ impl Transform for Solid {
 			inner,
 			#[cfg(feature = "color")]
 			colormap,
+			#[cfg(feature = "color")]
+			self.color,
 			Default::default(),
 		)
 	}
@@ -709,6 +810,8 @@ impl Clone for Solid {
 			inner,
 			#[cfg(feature = "color")]
 			colormap,
+			#[cfg(feature = "color")]
+			self.color,
 			Default::default(),
 		)
 	}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -508,11 +508,19 @@ pub trait SolidStruct: Sized + Clone + Transform {
 	fn bounding_box(&self) -> [DVec3; 2];
 
 	// --- Color ---
-	/// Paint every face of the solid with `color` (stored in the colormap and
-	/// propagated through STEP / BRep / STL / SVG I/O).
+	/// Colour the solid as a whole, dropping any per-face colours it carried.
+	///
+	/// STEP stores this as one `styled_item` on the `manifold_solid_brep` rather
+	/// than one per `advanced_face`, which is what commercial CAD emits and what a
+	/// read → write round-trip then reproduces. BRep and the renderers speak only
+	/// face colours, so they see it expanded onto every face — appearance is
+	/// identical, but the solid/face distinction survives in STEP alone.
+	///
+	/// Per-face colours (from `read_step`, or set through `colormap_mut`) override
+	/// it. Read it back with `Solid::color_solid`.
 	#[cfg(feature = "color")]
 	fn color(self, color: impl Into<Color>) -> Self;
-	/// Drop all per-face color from this solid.
+	/// Drop this solid's colour and all of its per-face colours.
 	#[cfg(feature = "color")]
 	fn color_clear(self) -> Self;
 

--- a/tests/history.rs
+++ b/tests/history.rs
@@ -119,10 +119,18 @@ fn test_chamfer_history_modifies_adjacent_identity_elsewhere() {
 
 /// color: fillet 後も Modified/identity 面が src 面の色を history 経由で引き継ぐ
 /// （colormap remap が history を流路にしている）。
+/// 面色は `colormap_mut` で直接置く — `Solid::color` はソリッド単位の色を塗るので
+/// colormap を経由しない。
 #[cfg(feature = "color")]
 #[test]
 fn test_fillet_carries_face_color_via_history() {
-	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(10.0)).color("#ff0000");
+	let red = cadrum::Color::from_str("#ff0000").expect("valid hex");
+	let mut cube = Solid::cube(DVec3::ZERO, DVec3::splat(10.0));
+	let face_ids: Vec<u64> = cube.iter_face().map(|f| f.id()).collect();
+	for id in face_ids {
+		cube.colormap_mut().insert(id, red);
+	}
+
 	let edge = cube.iter_edge().next().expect("cube has edges");
 	let filleted = cube.fillet_edges(0.5, [edge]).expect("fillet");
 
@@ -131,4 +139,16 @@ fn test_fillet_carries_face_color_via_history() {
 	for [post, _] in &hist {
 		assert!(filleted.colormap().contains_key(post), "face {post} should inherit color via history");
 	}
+}
+
+/// ソリッド単位の色は history を通らず、単一ソース op ではそのまま引き継がれる。
+#[cfg(feature = "color")]
+#[test]
+fn test_fillet_carries_solid_color() {
+	let red = cadrum::Color::from_str("#ff0000").expect("valid hex");
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(10.0)).color(red);
+	let edge = cube.iter_edge().next().expect("cube has edges");
+	let filleted = cube.fillet_edges(0.5, [edge]).expect("fillet");
+
+	assert_eq!(filleted.color_solid(), Some(red), "solid colour must survive fillet");
 }

--- a/tests/integration_color_brep.rs
+++ b/tests/integration_color_brep.rs
@@ -17,6 +17,16 @@ fn colormap_len(shape: &[Solid]) -> usize {
 	shape.iter().map(|s| s.colormap().len()).sum()
 }
 
+/// Colour each face actually renders in: its own, else its solid's.
+///
+/// The BRep trailer is keyed by face index and has nowhere to record "this is the
+/// solid's colour", so a solid-level colour is flattened onto its faces on write.
+/// Appearance is preserved exactly; the count of colormap entries is not, which is
+/// why the boolean round-trip below compares effective colours rather than counts.
+fn effective_colors(shape: &[Solid]) -> Vec<Option<Color>> {
+	shape.iter().flat_map(|s| s.iter_face().map(move |f| s.colormap().get(&f.id()).copied().or(s.color_solid()))).collect()
+}
+
 fn roundtrip_bin(shape: &[Solid]) -> Vec<Solid> {
 	let mut buf = Vec::new();
 	cadrum::Solid::write_brep_binary(shape, &mut buf).expect("write_brep_binary should succeed");
@@ -63,7 +73,10 @@ fn bin_roundtrip_after_boolean() {
 	assert!(colormap_len(&solids) >= 1, "at least one color should survive intersect");
 
 	let reloaded = roundtrip_bin(&solids);
-	assert_eq!(colormap_len(&reloaded), colormap_len(&solids), "color count should survive round-trip (binary)");
+	// Counts are not comparable: colored_box.step styles its solid *and* 11 of its
+	// faces, and the trailer can only speak faces, so the solid's colour lands on
+	// every face on write. What must hold is that no face changes how it looks.
+	assert_eq!(effective_colors(&reloaded), effective_colors(&solids), "every face should keep its effective colour (binary)");
 }
 
 // ── text tests ───────────────────────────────────────────────────────────────

--- a/tests/integration_color_step.rs
+++ b/tests/integration_color_step.rs
@@ -127,3 +127,85 @@ fn multicolor_solvespace_step_recovers_solid_with_colors() {
 	let mut svg = std::fs::File::create("out/multicolor_solvespace_recovered.svg").expect("svg file");
 	cadrum::Solid::mesh(&solids, cadrum::Tessellation { deflection_linear: 0.1, relative_linear: false, ..Default::default() }).and_then(|m| m.scene(cadrum::SceneOption { shading: true, ..Default::default() }).write_svg(&mut svg)).expect("svg write should succeed");
 }
+
+// ── solid-level colour (STYLED_ITEM → MANIFOLD_SOLID_BREP) ────────────────────
+
+/// `LAMBDA360-BOX-*.step` is a real commercial-CAD export whose single
+/// `STYLED_ITEM` targets `#14 = MANIFOLD_SOLID_BREP`, not an `ADVANCED_FACE`.
+/// cadrum used to skip every non-FACE label and silently drop the colour, so
+/// the box rendered in the default grey. The bug hid for so long because the
+/// file's own colour is `#a0a0a0` ("鋼 - サテン") — grey, like the fallback.
+const LAMBDA360_STEP: &str = "steps/LAMBDA360-BOX-d6cb2eb2d6e0d802095ea1eda691cf9a3e9bf3394301a0d148f53e55f0f97951.step";
+
+#[test]
+fn solid_level_styled_item_is_read() {
+	let data = fs::read(LAMBDA360_STEP).expect("fixture should exist");
+	let solids = cadrum::Solid::read_step(&mut data.as_slice()).expect("read_step should succeed");
+	assert_eq!(solids.len(), 1, "expected 1 solid");
+
+	let c = solids[0].color_solid().expect("solid-level colour must survive the read");
+	// The file says COLOUR_RGB('鋼 - サテン', 0.627450980392157, ×3). OCCT reads STEP
+	// colours as sRGB and stores Quantity_Color in linear RGB, so what comes back is
+	// the linear form. That conversion is not new here — face colours have always
+	// gone through it.
+	let srgb = 0.627_450_98_f32;
+	let linear = ((srgb + 0.055) / 1.055).powf(2.4);
+	for v in [c.r, c.g, c.b] {
+		assert!((v - linear).abs() < 1e-5, "expected {linear} (linear of sRGB {srgb}), got {v}");
+	}
+	assert!(solids[0].colormap().is_empty(), "a solid-level style must not be expanded onto faces");
+}
+
+/// The solid colour must reach the renderers, which speak only face colours —
+/// `io::mesh` resolves it onto every face.
+#[test]
+fn solid_level_color_reaches_the_mesh() {
+	let data = fs::read(LAMBDA360_STEP).expect("fixture should exist");
+	let solids = cadrum::Solid::read_step(&mut data.as_slice()).expect("read_step should succeed");
+	let mesh = cadrum::Solid::mesh(&solids, Default::default()).expect("mesh should succeed");
+
+	assert!(!mesh.colormap.is_empty(), "solid colour must be resolved onto faces for rendering");
+	for fid in &mesh.face_ids {
+		assert!(mesh.colormap.contains_key(fid), "every meshed face should carry the solid's colour");
+	}
+}
+
+/// Round-trip: a solid colour goes out as ONE styled item on the solid, not N on
+/// its faces, and comes back as a solid colour.
+#[test]
+fn solid_level_color_round_trips() {
+	let red = cadrum::Color::from_str("#ff0000").unwrap();
+	let src = Solid::cube(DVec3::ZERO, DVec3::splat(10.0)).color(red);
+	assert_eq!(src.color_solid(), Some(red));
+	assert!(src.colormap().is_empty(), "color() paints the solid, not its faces");
+
+	let mut buf = Vec::new();
+	cadrum::Solid::write_step(&[src], &mut buf).expect("write_step should succeed");
+	let step = String::from_utf8_lossy(&buf);
+	assert_eq!(step.matches("STYLED_ITEM").count(), 1, "one styled item, not one per face");
+	assert!(step.contains("MANIFOLD_SOLID_BREP"), "the styled item must target the solid");
+
+	let back = cadrum::Solid::read_step(&mut buf.as_slice()).expect("read_step should succeed");
+	assert_eq!(back.len(), 1);
+	assert_eq!(back[0].color_solid(), Some(red), "solid colour must round-trip");
+	assert!(back[0].colormap().is_empty(), "and must not have leaked onto the faces");
+}
+
+/// Boolean results take the operands' colour only when the ones that have a
+/// colour agree — a union of two different colours has no single answer.
+#[test]
+fn boolean_carries_solid_color_only_when_operands_agree() {
+	let red = cadrum::Color::from_str("#ff0000").unwrap();
+	let blue = cadrum::Color::from_str("#0000ff").unwrap();
+	let at = |x: f64| Solid::cube(DVec3::ZERO, DVec3::splat(10.0)).translate(DVec3::X * x);
+
+	let same: Vec<Solid> = (&at(0.0).color(red) + &at(5.0).color(red)).build_vec().unwrap();
+	assert_eq!(same[0].color_solid(), Some(red), "agreeing operands carry their colour");
+
+	let mixed: Vec<Solid> = (&at(0.0).color(red) + &at(5.0).color(blue)).build_vec().unwrap();
+	assert_eq!(mixed[0].color_solid(), None, "a mixture has no single colour");
+
+	// A cutting tool usually has no colour of its own; it must not erase the part's.
+	let cut: Vec<Solid> = (&at(0.0).color(red) - &at(5.0)).build_vec().unwrap();
+	assert_eq!(cut[0].color_solid(), Some(red), "an uncoloured operand is ignored");
+}


### PR DESCRIPTION
## Why

A STEP `styled_item` targets **either** an `advanced_face` **or** a whole `manifold_solid_brep`. cadrum only ever looked at the first kind:

```cpp
if (s.IsNull() || s.ShapeType() != TopAbs_FACE) continue;   // everything else dropped
```

So **every colour a CAD system attached to the body itself was silently discarded.**

`steps/LAMBDA360-BOX-*.step` is a real commercial export whose single `STYLED_ITEM` targets `#14 = MANIFOLD_SOLID_BREP('ボディ1')`. Reading it produced **zero coloured faces** and rendered the default grey.

The bug survived because the file's own colour is `#a0a0a0` — «鋼 - サテン», i.e. grey, the same as the fallback — and because **the fixture was never wired into any test** (`grep -rn LAMBDA360 tests/` was empty). Recolouring it to pure red and re-rendering changed **nothing**; the two PNGs were pixel-identical. `notes/20260304-color機能設計_jp.md` lists «形全体への色はすべての面への色へ変換する» in the requirements. It was never built.

## What

`Solid` gains `color: Option<Color>` **beside** the per-face `colormap`, mirroring STEP's own two levels instead of flattening one into the other. Expanding a solid style onto N faces at read time would write back **N styled items instead of one** — lossy in the file's structure, and it bloats every export.

Resolution for rendering: **face colour → solid colour → default grey.**

- **`Solid::color` now paints the solid, not each of its faces.** A coloured cube exports **one** `STYLED_ITEM` on the `manifold_solid_brep` instead of one per `advanced_face`. Face colours still override it. Read it back with `Solid::color_solid`.
- **Single-source ops carry it** (translate / rotate / scale / mirror / shell / fillet / chamfer / clean / clone).
- **A boolean takes it only when the operands that *have* one agree.** The volume of `a ∪ b` is a mixture, not a descendant of one operand, so there is no function to carry — unlike face colours, which ride the `[post_id, src_id]` history. Uncoloured operands (a cutting tool) are ignored rather than erasing the part's colour.
  ```
  cut(red, uncoloured tool) → red
  union(red, red)           → red
  union(red, blue)          → None
  ```
- **BRep flattens it.** The trailer is keyed by face index and has nowhere to say "this is the solid"; a solid colour is written onto its faces. Appearance survives exactly; the solid/face distinction lives only in STEP. `Mesh` does the same, which leaves **every renderer (glTF / STL / Scene2D) untouched**.

Adding the field to `Solid::new` was deliberate. It makes the compiler demand a propagation rule at **all 20 construction sites**. A magic `colormap[0]` key would have compiled fine while being silently dropped by `remap_colormap`, `remap_colormap_by_order`, `boolean_build`, the trailer and the STEP writer — the same class of silent loss this PR is fixing.

## Verification

Rendered the fixture before and after. The red-recoloured copy proves it: **before, the output was byte-identical to the grey one; now it is red.**

```
solid colour   : Some(Color { r: 1.0, g: 0.0, b: 0.0 })
face colours   : 0                       ← not expanded onto faces
mesh colormap  : 15 entries              ← resolved at mesh time, for the renderers
```

The round-trip test asserts the written STEP contains exactly **one** `STYLED_ITEM` and that it targets `MANIFOLD_SOLID_BREP`.

## Two things found on the way

**`colored_box.step` styles its solid *and* 11 of its faces.** So "solid colour + face overrides" is not an exotic case — the repo's own fixture does it. Before this PR the solid style was being dropped, which is why nobody noticed. This is what forced the BRep boolean round-trip test to compare *effective colours* rather than colormap counts: flattening changes the count while preserving every face's appearance.

**OCCT reads STEP colours as sRGB and stores them linear.** `COLOUR_RGB(0.627450980392157, …)` comes back as `0.3515326` = `((0.627451 + 0.055) / 1.055)^2.4`. This is not new — face colours have always gone through it — but it means a hex string and a STEP value with the same number are *different colours* in cadrum. Out of scope here; worth its own issue.

## Breaking

`Solid::color()` changes meaning (paint every face → colour the solid), so `colormap()` now returns empty for a solid coloured that way. Downstream reading `colormap()` after `.color()` is affected. `Mesh.colormap` is unchanged — the solid colour is resolved onto faces before it gets there.

---

## なぜ

STEP の `styled_item` は `advanced_face` **か** `manifold_solid_brep` **のどちらか**を対象にする。cadrum は前者しか見ていなかった。

```cpp
if (s.IsNull() || s.ShapeType() != TopAbs_FACE) continue;   // それ以外は全部捨てる
```

つまり **CAD がボディ本体に付けた色は、すべて黙って捨てられていた。**

`steps/LAMBDA360-BOX-*.step` は実在の商用 CAD 出力で、唯一の `STYLED_ITEM` が `#14 = MANIFOLD_SOLID_BREP('ボディ1')` を指している。読むと**着色面ゼロ**で、既定の灰色で描画されていた。

このバグが生き延びたのは、**ファイル自身の色が `#a0a0a0`（「鋼 - サテン」）＝ フォールバックと同じ灰色**だったことと、**この fixture がどのテストからも使われていなかった**（`grep -rn LAMBDA360 tests/` がゼロヒット）ため。色を純赤に書き換えて描き直しても**出力は 1 ピクセルも変わらなかった**。`notes/20260304-color機能設計_jp.md` は「形全体への色はすべての面への色へ変換する」を要求仕様に挙げているが、実装されていなかった。

## なにを

`Solid` に、面ごとの `colormap` と**並べて** `color: Option<Color>` を持たせる。STEP 自身の 2 階層をそのまま写す。読み込み時にソリッド色を N 面へ展開すると、**書き戻しで 1 個の styled item が N 個になる** — ファイル構造として非可逆で、出力も膨らむ。

描画時の解決順序: **面色 → ソリッド色 → 既定の灰色。**

- **`Solid::color` は面ではなくソリッドを塗るようになった。** 着色した cube は `advanced_face` ごとに N 個ではなく、`manifold_solid_brep` に **1 個**の `STYLED_ITEM` を出す。面色は依然として優先される。読み出しは `Solid::color_solid`。
- **単一ソース op は引き継ぐ**（translate / rotate / scale / mirror / shell / fillet / chamfer / clean / clone）。
- **boolean は、色を持つオペランドが全員一致したときだけ引き継ぐ。** `a ∪ b` の体積はどれか 1 つのオペランドの子孫ではなく**混合物**なので、引き継ぐ関数が存在しない（面色は `[post_id, src_id]` history という関数に乗れる）。色を持たないオペランド（切削ツール）は無視し、部品の色を消さない。
  ```
  cut(赤, 色なしツール) → 赤
  union(赤, 赤)         → 赤
  union(赤, 青)         → None
  ```
- **BRep は平坦化する。** トレイラーは face index をキーにしており「これはソリッドの色だ」と言う場所が無いので、ソリッド色は面に書き出される。見た目は完全に保たれるが、ソリッド／面の区別は STEP にしか残らない。`Mesh` も同様に解決するので、**glTF / STL / Scene2D は 1 行も変更していない**。

`Solid::new` にフィールドを足したのは意図的。**20 箇所すべての構築サイトでコンパイラが伝播規則を要求する**。`colormap[0]` のマジックキーなら、`remap_colormap` / `remap_colormap_by_order` / `boolean_build` / トレイラー / STEP writer のすべてで**黙って落ちながらコンパイルは通る** — この PR が直しているのと同じ種類の静かな損失になる。

## 検証

修正前後で fixture を描画。**赤に書き換えたコピーが決定的で、修正前は灰色版とバイト同一だったものが、いまは赤く描かれる。**

```
solid colour   : Some(Color { r: 1.0, g: 0.0, b: 0.0 })
face colours   : 0                       ← 面へ展開していない
mesh colormap  : 15 entries              ← 描画のためメッシュ生成時に解決
```

往復テストは、書き出した STEP に `STYLED_ITEM` が**ちょうど 1 個**あり、それが `MANIFOLD_SOLID_BREP` を指すことを検査する。

## 途中で見つかった 2 点

**`colored_box.step` はソリッドと 11 面の両方にスタイルを持っていた。** つまり「ソリッド色 + 面上書き」は例外ではなく、リポジトリ自身の fixture がそうなっている。修正前はソリッドスタイルが捨てられていたので誰も気づかなかった。これが原因で BRep の boolean 往復テストは、colormap の**個数**ではなく**実効色**を比較する形に変えた（平坦化で個数は変わるが、各面の見た目は保たれる）。

**OCCT は STEP の色を sRGB として読み、リニアで保持する。** `COLOUR_RGB(0.627450980392157, …)` は `0.3515326` = `((0.627451 + 0.055) / 1.055)^2.4` として返る。これは新しい挙動ではない（面色も常にこれを通っていた）が、**16 進文字列と STEP の同じ数値が cadrum では別の色になる**ということでもある。本 PR のスコープ外。別 issue に値する。

## 破壊的変更

`Solid::color()` の意味が変わる（全面を塗る → ソリッドを塗る）ため、その方法で着色したソリッドの `colormap()` は空を返す。`.color()` の後に `colormap()` を読んでいる下流は影響を受ける。`Mesh.colormap` は不変（ソリッド色は Mesh に届く前に面へ解決される）。
