### PR TITLE
Carry the left operand's solid colour through a boolean

### DIFF
--- a/examples/00_chijin.rs
+++ b/examples/00_chijin.rs
@@ -3,6 +3,17 @@
 use cadrum::{Color, DVec3, Edge, ProfileOrient, Solid};
 use std::f64::consts::PI;
 
+/// Paint every face. A face colour outranks the solid colour, and boolean ops carry it
+/// via history, so it survives where `Solid::color` (the whole solid) would be overwritten.
+fn color_faces(mut solid: Solid, color: impl Into<Color>) -> Solid {
+	let c = color.into();
+	let ids: Vec<u64> = solid.iter_face().map(|f| f.id()).collect();
+	for id in ids {
+		solid.colormap_mut().insert(id, c);
+	}
+	solid
+}
+
 fn chijin() -> Result<Solid, cadrum::Error> {
 	// ── Body (cylinder): r=15, h=8, centered at origin (y=-4..+4) ────────
 	let cylinder = Solid::cylinder(15.0, DVec3::Y * 8.0).translate(DVec3::Y * -4.0).color("#999");
@@ -15,7 +26,7 @@ fn chijin() -> Result<Solid, cadrum::Error> {
 	//   - ProfileOrient::Up(Y) でプロファイルの上方向を Y 固定 → 回転(revolve)と等価
 	let cross_section = Edge::polygon(&[DVec3::new(0.0, 5.0, 0.0), DVec3::new(15.0, 5.0, 0.0), DVec3::new(17.0, 3.0, 0.0), DVec3::new(15.0, 4.0, 0.0), DVec3::new(0.0, 4.0, 0.0)])?;
 	let spine = Edge::circle(1.0, DVec3::Y)?;
-	let sheet = Solid::sweep(&cross_section, &[spine], ProfileOrient::Up(DVec3::Y))?.color("#fff");
+	let sheet = color_faces(Solid::sweep(&cross_section, &[spine], ProfileOrient::Up(DVec3::Y))?, "#fff");
 	let sheets = [sheet.clone().mirror(DVec3::ZERO, DVec3::Y), sheet];
 
 	// ── Lacing blocks: 2x1x8, rotated 60° around Y, placed at z=15 ──────
@@ -29,7 +40,7 @@ fn chijin() -> Result<Solid, cadrum::Error> {
 	const N: usize = 20;
 	let angle = |i: usize| 2.0 * PI * (i as f64) / (N as f64);
 	let color = |i: usize| Color::from_hsv(i as f32 / N as f32, 1.0, 1.0);
-	let blocks: [Solid; N] = std::array::from_fn(|i| block_proto.clone().rotate_y(-angle(i)).color(color(i)));
+	let blocks: [Solid; N] = std::array::from_fn(|i| color_faces(block_proto.clone().rotate_y(-angle(i)), color(i)));
 	let holes: [Solid; N] = std::array::from_fn(|i| hole_proto.clone().rotate_y(-angle(i)));
 	// ── Assemble with boolean operations: union, subtract, union ─────────
 	let mut result: Solid = (&cylinder + &sheets[0] + &sheets[1]).build()?;

--- a/examples/04_boolean.rs
+++ b/examples/04_boolean.rs
@@ -6,7 +6,7 @@ fn main() -> Result<(), cadrum::Error> {
 	let example_name = std::path::Path::new(file!()).file_stem().unwrap().to_str().unwrap();
 
 	let make_box = Solid::cube(DVec3::ZERO, DVec3::splat(20.0)).translate(DVec3::X * -10. + DVec3::Y * -10.).color("#4a90d9");
-	let make_cyl = Solid::cylinder(8.0, DVec3::Z * 30.0).translate(DVec3::Z * -5.).color("#e67e22");
+	let make_cyl = Solid::cylinder(8.0, DVec3::Z * 30.0).translate(DVec3::Z * -5.);
 
 	// union: merge both shapes into one — offset X=0
 	let union: Solid = (&make_box + &make_cyl).build()?;

--- a/src/occt/solid.rs
+++ b/src/occt/solid.rs
@@ -552,12 +552,9 @@ impl SolidStruct for Solid {
 		};
 
 		// No history carries a solid colour — the result volume descends from no single
-		// operand — so it survives only when the operands that have one agree.
+		// operand. Take the left operand's, as Fusion 360 does.
 		#[cfg(feature = "color")]
-		let agreed = {
-			let mut colors = solids.iter().filter_map(|s| s.colormap.get(&s.id()).copied());
-			colors.next().filter(|first| colors.all(|c| c == *first))
-		};
+		let solid_color = solids[0].colormap.get(&solids[0].id()).copied();
 
 		let compound = CompoundShape::from_raw(
 			inner,
@@ -569,7 +566,7 @@ impl SolidStruct for Solid {
 		let mut out = compound.decompose();
 		// Only now do the result solids exist, so only now can their ids be keyed.
 		#[cfg(feature = "color")]
-		if let Some(c) = agreed {
+		if let Some(c) = solid_color {
 			for s in &mut out {
 				let id = s.id();
 				s.colormap_mut().insert(id, c);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -510,6 +510,7 @@ pub trait SolidStruct: Sized + Clone + Transform {
 	// --- Color ---
 	/// Colour the solid as a whole, dropping any per-face colours it carried: one entry
 	/// keyed by `self.id()`, which STEP and BRep keep and `Mesh` expands onto the faces.
+	/// A boolean result inherits it from the left operand alone.
 	#[cfg(feature = "color")]
 	fn color(self, color: impl Into<Color>) -> Self;
 	/// Drop this solid's colour and all of its per-face colours.

--- a/tests/integration_color_step.rs
+++ b/tests/integration_color_step.rs
@@ -152,22 +152,22 @@ fn solid_level_color_round_trips() {
 }
 
 /// Unlike a face colour, no history carries a solid's — the result volume descends
-/// from no single operand.
+/// from no single operand. The left operand decides it, as in Fusion 360.
 #[test]
-fn boolean_carries_solid_color_only_when_operands_agree() {
+fn boolean_carries_the_left_operand_solid_color() {
 	let red = cadrum::Color::from_str("#ff0000").expect("valid hex");
 	let blue = cadrum::Color::from_str("#0000ff").expect("valid hex");
 	let at = |x: f64| Solid::cube(DVec3::ZERO, DVec3::splat(10.0)).translate(DVec3::X * x);
 
-	let same: Vec<Solid> = (&at(0.0).color(red) + &at(5.0).color(red)).build_vec().expect("union should succeed");
-	assert_eq!(same[0].colormap().get(&same[0].id()).copied(), Some(red), "agreeing operands carry their colour");
-
 	let mixed: Vec<Solid> = (&at(0.0).color(red) + &at(5.0).color(blue)).build_vec().expect("union should succeed");
-	assert_eq!(mixed[0].colormap().get(&mixed[0].id()).copied(), None, "a mixture of two colours has no single answer");
+	assert_eq!(mixed[0].colormap().get(&mixed[0].id()).copied(), Some(red), "the left operand's colour wins");
 
 	// A cutting tool usually has no colour of its own; it must not erase the part's.
 	let cut: Vec<Solid> = (&at(0.0).color(red) - &at(5.0)).build_vec().expect("cut should succeed");
-	assert_eq!(cut[0].colormap().get(&cut[0].id()).copied(), Some(red), "an uncoloured operand is ignored");
+	assert_eq!(cut[0].colormap().get(&cut[0].id()).copied(), Some(red), "an uncoloured right operand is ignored");
+
+	let promoted: Vec<Solid> = (&at(0.0) + &at(5.0).color(red)).build_vec().expect("union should succeed");
+	assert_eq!(promoted[0].colormap().get(&promoted[0].id()).copied(), None, "and an uncoloured left operand is not painted by the right");
 }
 
 /// Every topology-rebuilding op changes the solid's TShape id, and nothing in the type


### PR DESCRIPTION
#247 で `Solid::color` が「全 face を塗る」から「solid 自身を塗る」に変わり、solid 色を boolean でどう引き継ぐかという問題が生まれた。現状の規則は「全 operand の solid 色が一致したときだけ引き継ぐ」で、その帰結として `00_chijin` が全面灰色になっていた。バグではなく規則の問題。

- `(&cylinder + &sheets[0] + &sheets[1])` は `#999` と `#fff` が不一致 → 色なし
- 続く 20 回のループで締め木の虹色と結果の色が毎回不一致 → 付いては消えを繰り返し、最後（`i=19`）で None に落ちて終わる
- 最終 solid は solid 色も face 色も持たず、全面が既定灰 `0xdd` になる

## 変更

一致判定を廃し、Fusion 360 と同じく **結果の solid 色は左項のもの** とした。`Boolean` の DNF 合成は `dnf_union` / `dnf_intersect` / `dnf_subtract` のいずれも `a.solids` を先に置いて `b.solids` を後ろに extend するので、`solids[0]` が最左のリーフであることは構造から保証されている。

- 左項に色があれば、右項が何色でも／無色でもそれが結果の色になる
- 左項が無色なら結果も無色（右項の色は昇格しない）
- 無色の切削工具が色を消さない性質は維持

`00_chijin` は皮と締め木を face 色（solid 色より優先され、history が boolean を跨いで運ぶ）で塗り直し、胴だけ solid 色 `#999` のまま残した。左項ルールで胴の色が全 boolean を通過するので、見た目は色が壊れる前と同じに戻る。`04_boolean` は `make_cyl` の色指定が左項ルール下で結果に出ないため削除した。

## 確認

`cargo test --features color` 全 green、`cargo build --no-default-features`、`00_chijin.png` / `04_boolean.png` を実行して目視確認。