### PR TITLE
Build linux-gnu prebuilts with the manylinux base gcc, drop the runtime bundle

### DIFF
--- a/.github/workflows/prebuilt.yaml
+++ b/.github/workflows/prebuilt.yaml
@@ -136,6 +136,6 @@ jobs:
       # lockstep with OCCT_VERSION / BUILD_REVISION in build.rs.
       - uses: softprops/action-gh-release@v2
         with:
-          tag_name: occt-8_0_0_rev4
-          name: OCCT prebuilt v8.0.0 (rev4)
+          tag_name: occt-8_0_0_rev5
+          name: OCCT prebuilt v8.0.0 (rev5)
           files: dist/*.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,14 @@ changes until `1.0`.
   than flattened onto its faces. (#247)
 - **New prebuilt artifact naming scheme.** `occt-<version>_<rev>-<target>`, e.g.
   `occt-8_0_0_rev2-wasm32_unknown_unknown.tar.gz` under tag `occt-8_0_0_rev2`;
-  `BUILD_REVISION` is now `rev4`. (#203)
+  `BUILD_REVISION` is now `rev5`. (#203)
+- **Linux prebuilts are built with the manylinux base gcc (~8.5), not the
+  gcc-toolset.** The tarball then references only old libstdc++/libgcc symbols,
+  which resolve against any newer consumer runtime (Amazon Linux 2023 / gcc 11.4.1
+  and up) via the system libstdc++ — replacing the bundled `libstdc++.a` /
+  `libgcc.a`. Same `__cxa_call_terminate` fix as the bundle, without shipping a
+  static C++ runtime. windows-gnu keeps its bundle (no stable Windows system
+  libstdc++). (#147)
 - **wasm exception-handling uses the legacy encoding.** OCCT and the cxx wrapper
   build with `-mllvm -wasm-use-legacy-eh=true` against a self-built *legacy* eh
   sysroot (the released wasi-sdk one is exnref-only), dropping `--experimental-wasm-exnref`. (#199, #233)

--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 const OCCT_VERSION: &str = "V8_0_0";
 
 /// Build revision for prebuilt tarballs. Update this when making non-OCCT-breaking changes that require cache invalidation (e.g. patch updates, build script changes, EH encoding changes, etc).
-const BUILD_REVISION: &str = "rev4";
+const BUILD_REVISION: &str = "rev5";
 
 /// Release tag / tarball / cache-dir name (#203). Fields are separated by `-` and
 /// characters within a field by `_`, so the name parses by splitting on `-` (the
@@ -58,10 +58,12 @@ fn main() {
 
 	// Prebuilt tarball 作成時のみ host toolchain runtime を OCCT lib dir に同梱 (#89 / #147 対策)。
 	// gate を切らないと source user 全員のホストランタイムが静的取り込みされてしまう。
-	// 現 policy: mingw / Linux GNU で GCC runtime を対象 (Windows MSVC は MSVC ランタイム、Mac は別系統)。
+	// 現 policy: mingw のみ GCC runtime を同梱 (Windows には安定した system libstdc++ が無い)。
+	// Linux GNU は manylinux base gcc で古いシンボルのみ参照するので消費者の system libstdc++ に
+	// 動的リンクさせ非同梱 (#147)。Windows MSVC は MSVC ランタイム、Mac は別系統。
 	#[cfg(feature = "source")]
 	if env::var("CADRUM_BUNDLE_RUNTIME").is_ok() {
-		if target.ends_with("windows-gnu") || target.contains("linux-gnu") {
+		if target.ends_with("windows-gnu") {
 			bundle_runtime_libs(&occt_lib_dir, &["libstdc++.a", "libgcc.a", "libgcc_eh.a"], true);
 		} else if target.starts_with("wasm32") {
 			// -fwasm-exceptions ビルドの OCCT/libc++ が要求する eh 版ランタイムを同梱し prebuilt を

--- a/docker/Dockerfile_aarch64-unknown-linux-gnu
+++ b/docker/Dockerfile_aarch64-unknown-linux-gnu
@@ -9,16 +9,20 @@
 #   `ubuntu-24.04-arm` runner (free for public repositories).
 FROM quay.io/pypa/manylinux_2_28_aarch64
 
+# Base gcc-c++ (g++ 8.5). The image has /usr/bin/gcc but no base /usr/bin/g++;
+# without this, CXX=/usr/bin/g++ would be missing and cmake's C++ compiler probe fails.
+RUN dnf install -y gcc-c++ && dnf clean all
+
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
 ENV PATH=/root/.cargo/bin:$PATH
 
-# control cc crate and cargo command
-# target == host (container runs as aarch64 via QEMU or on a native arm64
-# runner), so the image's default gcc/g++/ar cover both host build
-# dependencies and the OCCT cmake build.
-# ENV CC=gcc
-# ENV CXX=g++
-# ENV AR=ar
+# Pin to the AlmaLinux 8 base gcc (~8.5), NOT the PATH-default gcc-toolset. The base
+# gcc references only old libstdc++/libgcc symbols, so the prebuilt links against any
+# newer consumer runtime (e.g. Amazon Linux 2023 / gcc 11.4.1) with no bundling (#147).
+# build.rs forwards CC/CXX to CMAKE_C/CXX_COMPILER for the OCCT source build.
+ENV CC=/usr/bin/gcc
+ENV CXX=/usr/bin/g++
+ENV AR=/usr/bin/ar
 ENV CARGO_BUILD_TARGET=aarch64-unknown-linux-gnu
 
 # add cargo target

--- a/docker/Dockerfile_x86_64-unknown-linux-gnu
+++ b/docker/Dockerfile_x86_64-unknown-linux-gnu
@@ -4,19 +4,25 @@
 # 18.10+, Debian 10+, RHEL/Rocky/AlmaLinux 8+, Fedora 29+, Arch, openSUSE
 # Leap 15.1+). Same portability strategy Python wheels use.
 #
-# The image ships gcc (C++17 capable), cmake, make, curl, and git out of the
-# box. Rust is NOT bundled, so we install it via rustup.
+# The image ships the base gcc (/usr/bin/gcc 8.5, C++17 capable), cmake, make,
+# curl, and git. Base g++ is NOT installed (only gcc-toolset's), so we add it
+# below. Rust is NOT bundled, so we install it via rustup.
 FROM quay.io/pypa/manylinux_2_28_x86_64
+
+# Base gcc-c++ (g++ 8.5). The image has /usr/bin/gcc but no base /usr/bin/g++;
+# without this, CXX=/usr/bin/g++ would be missing and cmake's C++ compiler probe fails.
+RUN dnf install -y gcc-c++ && dnf clean all
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
 ENV PATH=/root/.cargo/bin:$PATH
 
-# control cc crate and cargo command
-# target == host, so the image's default gcc/g++/ar cover both host build
-# dependencies and the OCCT cmake build.
-# ENV CC=gcc
-# ENV CXX=g++
-# ENV AR=ar
+# Pin to the AlmaLinux 8 base gcc (~8.5), NOT the PATH-default gcc-toolset. The base
+# gcc references only old libstdc++/libgcc symbols, so the prebuilt links against any
+# newer consumer runtime (e.g. Amazon Linux 2023 / gcc 11.4.1) with no bundling (#147).
+# build.rs forwards CC/CXX to CMAKE_C/CXX_COMPILER for the OCCT source build.
+ENV CC=/usr/bin/gcc
+ENV CXX=/usr/bin/g++
+ENV AR=/usr/bin/ar
 ENV CARGO_BUILD_TARGET=x86_64-unknown-linux-gnu
 
 # add cargo target

--- a/makefile
+++ b/makefile
@@ -29,7 +29,7 @@ publish: update publish-ready # publish to crates.io
 	cargo publish
 occt: generate # output out/occt-<rev>-<target>.tar.gz from source natively
 	cargo clean
-	# CADRUM_BUNDLE_RUNTIME=1 で OCCT lib dir に libstdc++.a / libgcc.a / libgcc_eh.a を libcadrum_* として同梱し、ホスト側 GCC との ABI 不整合を回避する (#89 / #147 対策)。
+	# CADRUM_BUNDLE_RUNTIME=1 は windows-gnu / wasm でのみランタイムを同梱する (#89)。native linux-gnu は base gcc ビルドで古いシンボルのみ参照し消費者の system libstdc++ に動的リンクするので no-op (#147)。
 	# pipefail is required so tee's exit code does not mask a cargo build failure
 	bash -c "set -o pipefail && CADRUM_BUNDLE_RUNTIME=1 cargo build --example 01_primitives --release --features source 2>&1 | tee out/log.txt"
 	find $(or $(CARGO_TARGET_DIR),target) -maxdepth 1 -type d -name 'occt*' | xargs -IX sh -c 'tar -czf out/$$(basename X).tar.gz -C $$(dirname X) $$(basename X)'


### PR DESCRIPTION
## Why

Issue #147: the linux prebuilt OCCT was built with manylinux's **gcc-toolset** (new gcc, currently 14). Its static archives reference `__cxa_call_terminate`, a libstdc++ exception-ABI helper absent from older consumers' libstdc++ — e.g. Amazon Linux 2023 (gcc 11.x) — producing 500+ `undefined symbol` errors at the consumer's link step. The current mitigation bundles `libstdc++.a` / `libgcc.a` / `libgcc_eh.a` into the tarball.

Root cause is an ABI-direction mismatch: **build gcc newer than consumer gcc**. libstdc++/libgcc are *forward*-compatible, so an artifact that references only *old* symbols links against any *newer* system runtime. manylinux_2_28 already ships an old base gcc (8.5 at `/usr/bin/gcc`); the toolset is only the PATH default.

## What

- **Dockerfiles** (`docker/Dockerfile_{x86_64,aarch64}-unknown-linux-gnu`): pin `CC`/`CXX`/`AR` to the base toolchain (`/usr/bin/gcc` 8.5), and `dnf install` the base `gcc-c++` (the image ships base `gcc` but not base `g++`; only the toolset's). `build.rs` forwards `CC`/`CXX` to `CMAKE_C/CXX_COMPILER`, so this drives the OCCT source build.
- **build.rs**: drop `linux-gnu` from the runtime-bundle arm — the base-gcc build references only old symbols, resolved dynamically against the consumer's system libstdc++. `windows-gnu` keeps its bundle (no stable Windows system libstdc++); wasm keeps its libc++ bundle. Bump `BUILD_REVISION` `rev4` → `rev5` (tarball contents change → cache invalidation).
- **prebuilt.yaml**: release tag/name `rev4` → `rev5`.
- **makefile** / **CHANGELOG**: doc accuracy.

## Verification

Built the x86_64 prebuilt with gcc 8.5 (`make cross-x86_64-unknown-linux-gnu GOAL=occt`) — OCCT 8.0 compiles cleanly. Then consumed it (via `CADRUM_PREBUILT_URL=file://…`) in consumer containers and ran `cargo run --example 01_primitives`:

| target | consumer | gcc | `__cxa_call_terminate` refs | result |
|---|---|---|---|---|
| x86_64 | amazonlinux:2023 | 11.5.0 | 0 | ✅ links + runs |
| x86_64 | ubuntu:latest (26.04) | 15.2.0 | 0 | ✅ links + runs |
| aarch64 | amazonlinux:2023 / ubuntu | — | — | ⏳ prebuilt building under QEMU |

amazonlinux:2023 is the exact #147 repro and now passes. The prebuilt archives reference `__cxa_call_terminate` **0** times. aarch64 verification (QEMU build + consumer link) is still in progress and will be reported on the PR.