### PR TITLE
Stop leaking STEPControl_Reader in read_step_stream

### DIFF
--- a/src/ffi.cpp
+++ b/src/ffi.cpp
@@ -2001,22 +2001,16 @@ std::unique_ptr<TopoDS_Shape> read_step_stream(RustReader& reader) {
     RustReadStreambuf sbuf(reader);
     std::istream is(&sbuf);
 
-    // OCCT 7.x bug workaround: STEPControl_Reader::~STEPControl_Reader()
-    // crashes when the reader was constructed on the stack and destroyed
-    // after a successful TransferRoots(). Allocating on the heap and never
-    // freeing avoids the destructor path entirely. The leaked memory is
-    // bounded (one reader per STEP read) and accepted as a known cost.
-    auto* step_reader = new STEPControl_Reader();
-    IFSelect_ReturnStatus status = step_reader->ReadStream("stream", is);
+    STEPControl_Reader step_reader;
+    IFSelect_ReturnStatus status = step_reader.ReadStream("stream", is);
 
     if (status != IFSelect_RetDone) {
         return nullptr;
     }
 
-    step_reader->TransferRoots(Message_ProgressRange());
-    // step_reader is intentionally leaked — see comment above.
+    step_reader.TransferRoots(Message_ProgressRange());
     return std::make_unique<TopoDS_Shape>(
-        try_sew_orphan_faces(step_reader->OneShape(), nullptr));
+        try_sew_orphan_faces(step_reader.OneShape(), nullptr));
 }
 
 bool write_step_stream(const TopoDS_Shape& shape, RustWriter& writer) {


### PR DESCRIPTION
`read_step_stream` allocated `STEPControl_Reader` with `new` and never freed it. The comment attributed this to an OCCT 7.x crash in `~STEPControl_Reader()` after a successful `TransferRoots()`. That crash no longer reproduces on OCCT 8.0.0, so only the leak remained.

`STEPControl_Reader` holds the parsed STEP model, so the leaked amount scales with input size — it is one reader per read, not a small fixed block.

## Measurements

Reading `steps/multicolor_solvespace.step` (35 KB) in a loop, `--no-default-features`, resident working set:

| | after 200 reads | after 2000 reads | per read |
|---|---|---|---|
| before | +84.7 MB | — | ~390 KB |
| after | +10.9 MB | +12.0 MB | flat |

No crash in 2000 iterations with the reader back on the stack.

## Scope

Only builds without the `color` feature reach this function; it sits behind `#ifndef FEATURE_COLOR`. With the default features, STEP goes through `read_step_color_stream`, which stack-allocates `STEPCAFControl_Reader` and never had the workaround — measured flat there as well.

A side effect of that gating is that the `#ifndef FEATURE_COLOR` block is not compiled by any default build, and no CI job builds `--no-default-features`, so nothing caught the workaround going stale after the OCCT 8.0.0 upgrade. Adding such a job would be a reasonable follow-up.

The rest of the C++ layer was checked for the same pattern: of the 13 `new` sites in `src/ffi.cpp`, the other 12 are `Handle()`-managed or a comment, and there are no `malloc` / `new[]` / `.release()` / `fopen` uses.

## Tests

- `cargo test` — all green
- `cargo test --no-default-features --lib --tests` — all green (examples require `color`/`png` and cannot build in that configuration, unchanged by this PR)