### PR TITLE
Bump OCCT to 8.0.1

### DIFF
--- a/.github/workflows/prebuilt.yaml
+++ b/.github/workflows/prebuilt.yaml
@@ -132,10 +132,10 @@ jobs:
           merge-multiple: true
 
       # NOTE: tag_name must match build.rs `release_name(None, false)` =
-      # `occt-<occt_version>_<BUILD_REVISION>` (e.g. `occt-8_0_0_rev3`). Bump this in
+      # `occt-<occt_version>_<BUILD_REVISION>` (e.g. `occt-8_0_1_rev1`). Bump this in
       # lockstep with OCCT_VERSION / BUILD_REVISION in build.rs.
       - uses: softprops/action-gh-release@v2
         with:
-          tag_name: occt-8_0_0_rev5
-          name: OCCT prebuilt v8.0.0 (rev5)
+          tag_name: occt-8_0_1_rev1
+          name: OCCT prebuilt v8.0.1 (rev1)
           files: dist/*.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ changes until `1.0`.
 
 #### Changes
 
+- **OCCT bumped to 8.0.1** (patch release; was 8.0.0). No cadrum source changes
+  required — of the OCCT files `build.rs` patches only
+  `STEPConstruct_AP203Context.cxx` changed, and it is body-stubbed anyway. The
+  toolkit list is unchanged. Prebuilt tarballs move to tag `occt-8_0_1_rev1`.
 - **`Mesh.normals`.** One unit outward normal per vertex, evaluated on the B-rep
   surface rather than averaged from the triangles, and emitted as glTF `NORMAL`.
   Faces never share vertices, so each is its own smoothing group. (#243, #244)
@@ -47,7 +51,7 @@ changes until `1.0`.
   than flattened onto its faces. (#247)
 - **New prebuilt artifact naming scheme.** `occt-<version>_<rev>-<target>`, e.g.
   `occt-8_0_0_rev2-wasm32_unknown_unknown.tar.gz` under tag `occt-8_0_0_rev2`;
-  `BUILD_REVISION` is now `rev5`. (#203)
+  `BUILD_REVISION` is now `rev1`. (#203)
 - **Linux prebuilts are built with the manylinux base gcc (~8.5), not the
   gcc-toolset.** The tarball then references only old libstdc++/libgcc symbols,
   which resolve against any newer consumer runtime (Amazon Linux 2023 / gcc 11.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,13 +37,10 @@ changes until `1.0`.
   found where the payload ended instead of by scanning the last four bytes, and
   keyed by solid as well as by face. Older files load with their colours dropped. (#247)
 - **Renamed the `source-build` feature to `source`.** (#182)
+- **OCCT bumped to 8.0.1** (patch release; was 8.0.0).
 
 #### Changes
 
-- **OCCT bumped to 8.0.1** (patch release; was 8.0.0). No cadrum source changes
-  required — of the OCCT files `build.rs` patches only
-  `STEPConstruct_AP203Context.cxx` changed, and it is body-stubbed anyway. The
-  toolkit list is unchanged. Prebuilt tarballs move to tag `occt-8_0_1_rev1`.
 - **`Mesh.normals`.** One unit outward normal per vertex, evaluated on the B-rep
   surface rather than averaged from the triangles, and emitted as glTF `NORMAL`.
   Faces never share vertices, so each is its own smoothing group. (#243, #244)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ out with anything you need.
 ## Preconditions
 
 You should be comfortable with `cargo` and the basics of building Rust
-projects. The first build downloads a prebuilt OCCT 8.0.0 tarball for
+projects. The first build downloads a prebuilt OCCT 8.0.1 tarball for
 supported targets and links it statically; on unsupported targets you will
 need CMake plus a C++17 compiler and `cargo build --features source`.
 See the [README](./README.md#build) for the full build matrix.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Add this to your `Cargo.toml`:
 cadrum = "^0.8"
 ```
 
-`cargo build` automatically downloads a prebuilt OCCT 8.0.0 binary for these targets:
+`cargo build` automatically downloads a prebuilt OCCT 8.0.1 binary for these targets:
 
 | | Target | Prebuilt OCCT |
 |--|--------|----------|

--- a/build.rs
+++ b/build.rs
@@ -4,19 +4,19 @@ use std::path::{Path, PathBuf};
 /// OCCT release used by cadrum. Update this tag when bumping OCCT versions.
 /// `release_name()` derives the GitHub Release tag, the prebuilt tarball, and the
 /// cache directory name from this.
-const OCCT_VERSION: &str = "V8_0_0";
+const OCCT_VERSION: &str = "V8_0_1";
 
 /// Build revision for prebuilt tarballs. Update this when making non-OCCT-breaking changes that require cache invalidation (e.g. patch updates, build script changes, EH encoding changes, etc).
-const BUILD_REVISION: &str = "rev5";
+const BUILD_REVISION: &str = "rev1";
 
 /// Release tag / tarball / cache-dir name (#203). Fields are separated by `-` and
 /// characters within a field by `_`, so the name parses by splitting on `-` (the
 /// target's hyphens are underscored too). `has_version` appends the cadrum crate
 /// version for the per-crate FFI artifact.
 ///
-/// - `release_name(None, false)`    → `occt-8_0_0_rev4`                              (GitHub Release タグ)
-/// - `release_name(Some(t), false)` → `occt-8_0_0_rev4-wasm32_unknown_unknown`       (OCCT tarball / cache dir)
-/// - `release_name(Some(t), true)`  → `occt-8_0_0_rev4-wasm32_unknown_unknown-cadrum-0_8_13` (FFI tarball)
+/// - `release_name(None, false)`    → `occt-8_0_1_rev1`                              (GitHub Release タグ)
+/// - `release_name(Some(t), false)` → `occt-8_0_1_rev1-wasm32_unknown_unknown`       (OCCT tarball / cache dir)
+/// - `release_name(Some(t), true)`  → `occt-8_0_1_rev1-wasm32_unknown_unknown-cadrum-0_8_13` (FFI tarball)
 fn release_name(target: Option<&str>, has_version: bool) -> String {
 	let occt = OCCT_VERSION.trim_start_matches(['V', 'v']);
 	let mut name = format!("occt-{}_{}", occt, BUILD_REVISION);
@@ -454,7 +454,7 @@ mod source {
 		eprintln!("OCCT built at: {}", built.display());
 
 		// tarball を slim 化: cadrum は include/lib しか使わない。share/(doc・resource) と
-		// bin/(OCCT スクリプト) を削除。OCCT-8_0_0/(改変ソース) は LGPL 2.1 §2 のため下で残す。
+		// bin/(OCCT スクリプト) を削除。OCCT-8_0_1/(改変ソース) は LGPL 2.1 §2 のため下で残す。
 		for d in ["share", "bin"] {
 			let _ = std::fs::remove_dir_all(effective_root.join(d));
 		}
@@ -547,7 +547,7 @@ mod source {
 
 			// OCC_CONVERT_SIGNALS(signal→例外変換) を全 target で無効化。OSD_signal スタブ化と整合。
 			//
-			// このアームは「dead」ではなく実際に生きている: occt_defs_flags.cmake は OCCT 8.0.0 に
+			// このアームは「dead」ではなく実際に生きている: occt_defs_flags.cmake は OCCT 8.0.1 に
 			// 存在し `add_definitions(-DOCC_CONVERT_SIGNALS)` を含むため、ここで実際にコメントアウトされる。
 			// #209 はこれを dead と判断して削除したが、検証が wasm のみで、windows-gnu (mingw) ビルドでは
 			// 経路が生きていた。外すと OCCT が setjmp/longjmp ベースの Standard_ErrorHandler を使い、


### PR DESCRIPTION
OCCT を 8.0.0 → 8.0.1 (上流タグ `V8_0_1`、8.0.0 から 40 commits / 300 files) に引き上げる。

## 変更

- `build.rs`: `OCCT_VERSION` `V8_0_0` → `V8_0_1`、`BUILD_REVISION` `rev5` → `rev1`
  (rev は OCCT バージョン内の改訂番号なので新バージョンで 1 に戻す)。`release_name()` の
  doc 例と展開ディレクトリ名のコメントも追従。
- `.github/workflows/prebuilt.yaml`: リリースタグ `occt-8_0_1_rev1` / 名称 `OCCT prebuilt v8.0.1 (rev1)`。
- `README.md` / `CONTRIBUTING.md` / `CHANGELOG.md`: バージョン表記と Unreleased エントリ。

cadrum 側のソース変更は不要だった。`build.rs` がパッチする OCCT ファイルのうち 8.0.1 で
変更されたのは `STEPConstruct_AP203Context.cxx` のみ (FreeBSD 向け `#if` の追加) で、
これは body-stub 化しているので影響なし。toolkit 一覧も不変。

## 検証

`x86_64-pc-windows-gnu` で `cargo test --features source` — OCCT 8.0.1 をソースから
ビルド (15m31s) して **109 passed / 0 failed / 3 ignored**。`occt_defs_flags.cmake` の
`OCC_CONVERT_SIGNALS` 無効化パッチも効いており mingw のリンクは通る。

## マージ後にやること

prebuilt tarball `occt-8_0_1_rev1-*` は未公開なので、`source` feature なしの既定ビルドは
prebuilt workflow (`prebuilt` ブランチへの push か workflow_dispatch) を回して
`occt-8_0_1_rev1` リリースを発行するまで失敗する。