### PR TITLE
Vendor upstream-bound OCCT fixes as patch files

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -346,9 +346,7 @@ mod source {
 	use std::env;
 	use std::path::{Path, PathBuf};
 
-	/// Provide OCCT into `effective_root`: download source, patch, build with CMake,
-	/// then remove non-patched source files (LGPL 2.1 §2: keep only the modified files).
-	/// Paired with `occt_from_prebuilt` (selected by the `source` feature) in `resolve_occt`.
+	/// Provide OCCT into `effective_root`: download source, patch, build with CMake, paired with `occt_from_prebuilt` (selected by the `source` feature) in `resolve_occt`.
 	pub fn occt_from_source(effective_root: &Path) -> Option<[PathBuf; 2]> {
 		if let Some(dirs) = find_occt_dirs(effective_root) {
 			return Some(dirs);
@@ -380,16 +378,15 @@ mod source {
 		}
 
 		let source_dir = std::fs::read_dir(effective_root).expect("Failed to read effective_root directory").flatten().find(|e| e.file_name().to_string_lossy().starts_with("OCCT") && e.path().is_dir()).map(|e| e.path()).expect("OCCT source directory not found after extraction");
-		let mut patches: Map<PathBuf, String>=Default::default();
-		// Apply patches
-		patches.update(patch_from_file(&source_dir, include_str!("patches/pr1.patch")));
+		let mut patches = patch_from_files(&source_dir, &[include_str!("patches/pr1.patch"), include_str!("patches/pr2.patch")]);
 		walk_occt_sources(&source_dir, |path| {
 			if let Some(patched) = patch_or_none(path) {
-				patches.insert(path, patched);
+				patches.insert(path.strip_prefix(&source_dir).expect("walked path escapes source_dir").to_path_buf(), patched);
 			}
 		});
-		for (path, contents) in patches{
-			std::fs::write(source_dir.join(path), contents)
+		for (path, contents) in &patches {
+			std::fs::write(source_dir.join(path), contents).expect("patch write failed");
+			eprintln!("Patched {}", path.display());
 		}
 
 		eprintln!("Building OCCT with CMake (this may take a while)...");
@@ -462,10 +459,6 @@ mod source {
 			let _ = std::fs::remove_dir_all(effective_root.join(d));
 		}
 
-		// lib/ からリンク対象(OCC_LIBS)以外を削除。cmake/pkgconfig も対象だが cadrum は build.rs で
-		// 直リンクし cmake/pkgconfig を消費しないので実害なし。min_depth(1) で lib root 自身は消さない。
-		// 拡張子を外した basename(file_stem)が OCC_LIBS のいずれかで終わるものだけ残す。contains だと
-		// "TKDE" が TKDEIGES 等を巻き込むので suffix 判定にする（libcadrum_* は後段で同梱され無関係）。
 		if let Some([_include_dir, lib_dir]) = find_occt_dirs(effective_root) {
 			for child in walkdir::WalkDir::new(&lib_dir).min_depth(1).into_iter().flatten() {
 				let stem = child.path().file_stem().and_then(|s| s.to_str()).unwrap_or_default();
@@ -478,13 +471,81 @@ mod source {
 				}
 			}
 		}
-		// LGPL 2.1 §2: keep only patched files; remove everything else
-		std::fs::remove_dir_all(&source_dir);
-    	std::fs::create_dir(&source_dir);
-		for (path, contents) in patches{
-			std::fs::write(source_dir.join(path), contents)
+		// LGPL 2.1 §2: keep only patched files; remove everything else.
+		std::fs::remove_dir_all(&source_dir).expect("failed to clear OCCT source tree");
+		for (path, contents) in &patches {
+			let path = source_dir.join(path);
+			std::fs::create_dir_all(path.parent().unwrap()).expect("failed to create patched source dir");
+			std::fs::write(&path, contents).expect("patched source write failed");
 		}
 		find_occt_dirs(effective_root)
+	}
+
+	/// unified diff 群を `source_dir` 下のソースに順に当て、(source_dir 相対パス, 適用後の内容)
+	/// を返す。同じファイルを触る diff が続けば前の適用結果に重ねるので、上流でスタックした
+	/// PR をそのまま並べられる。当たらなければ panic する: 黙って未適用の prebuilt を配ると
+	/// 原因の切り分けができない。上流に取り込まれたら該当の一行を消すだけで撤退できる。
+	fn patch_from_files(source_dir: &Path, diffs: &[&str]) -> std::collections::HashMap<PathBuf, String> {
+		let mut patches = std::collections::HashMap::new();
+		for chunk in diffs.iter().flat_map(|diff| diff.split("\ndiff --git ")) {
+			let Some(head) = chunk.lines().find(|line| line.starts_with("+++ ")) else { continue };
+			let target = head[4..].split('\t').next().unwrap_or_default().trim();
+			let target = PathBuf::from(target.strip_prefix("b/").unwrap_or(target));
+			let base = match patches.get(&target) {
+				Some(patched) => String::clone(patched),
+				None => std::fs::read_to_string(source_dir.join(&target)).unwrap_or_else(|e| panic!("patch target {} unreadable: {e}", target.display())),
+			};
+			let patched = diff_apply(&base, chunk).unwrap_or_else(|| panic!("patch does not apply to {}", target.display()));
+			patches.insert(target, patched);
+		}
+		patches
+	}
+
+	/// unified diff を `content` に適用する。どれか一つでもハンクが当たらなければ `None`。
+	/// ハンクの行番号は目安として扱い、位置がずれていれば近傍を探し直す(GNU patch 相当)。
+	fn diff_apply(content: &str, diff: &str) -> Option<String> {
+		let lines: Vec<&str> = content.lines().collect();
+		let mut out: Vec<&str> = Vec::new();
+		let mut cur = 0usize;
+		let mut it = diff.lines().peekable();
+
+		while let Some(header) = it.next() {
+			let Some(rest) = header.strip_prefix("@@ -") else { continue };
+			let hint: usize = rest.split([',', ' ']).next()?.parse().ok()?;
+
+			let (mut old, mut new) = (Vec::new(), Vec::new());
+			while let Some(body) = it.peek() {
+				match body.as_bytes().first() {
+					Some(b'-') => old.push(&body[1..]),
+					Some(b'+') => new.push(&body[1..]),
+					// 文脈行。git は末尾空白を落とすので長さ 0 の行も空の文脈行として扱う。
+					Some(b' ') | None => {
+						old.push(body.get(1..).unwrap_or(""));
+						new.push(body.get(1..).unwrap_or(""));
+					}
+					Some(b'\\') => {} // "\ No newline at end of file"
+					_ => break,
+				}
+				it.next();
+			}
+
+			// hint 位置から外側へ探す。直前のハンクの終端 `cur` より前には戻らず、
+			// `old` が残り行数より長ければその時点で不一致。
+			let last = lines.len().checked_sub(old.len()).filter(|last| *last >= cur)?;
+			let hint = hint.saturating_sub(1).clamp(cur, last);
+			let at = (0..=last - cur).flat_map(|d| [hint + d, hint.wrapping_sub(d)]).find(|&i| (cur..=last).contains(&i) && lines[i..i + old.len()] == old[..])?;
+
+			out.extend_from_slice(&lines[cur..at]);
+			out.extend_from_slice(&new);
+			cur = at + old.len();
+		}
+
+		out.extend_from_slice(&lines[cur..]);
+		let mut patched = out.join("\n");
+		if content.ends_with('\n') {
+			patched.push('\n');
+		}
+		Some(patched)
 	}
 
 	/// Walk the OCCT source tree.

--- a/build.rs
+++ b/build.rs
@@ -380,14 +380,17 @@ mod source {
 		}
 
 		let source_dir = std::fs::read_dir(effective_root).expect("Failed to read effective_root directory").flatten().find(|e| e.file_name().to_string_lossy().starts_with("OCCT") && e.path().is_dir()).map(|e| e.path()).expect("OCCT source directory not found after extraction");
-
+		let mut patches: Map<PathBuf, String>=Default::default();
 		// Apply patches
+		patches.update(patch_from_file(&source_dir, include_str!("patches/pr1.patch")));
 		walk_occt_sources(&source_dir, |path| {
 			if let Some(patched) = patch_or_none(path) {
-				std::fs::write(path, patched).expect("patch write failed");
-				eprintln!("Patched {}", path.file_name().unwrap().to_string_lossy());
+				patches.insert(path, patched);
 			}
 		});
+		for (path, contents) in patches{
+			std::fs::write(source_dir.join(path), contents)
+		}
 
 		eprintln!("Building OCCT with CMake (this may take a while)...");
 
@@ -475,15 +478,12 @@ mod source {
 				}
 			}
 		}
-
 		// LGPL 2.1 §2: keep only patched files; remove everything else
-		walk_occt_sources(&source_dir, |path| {
-			if path.is_dir() {
-				let _ = std::fs::remove_dir_all(path);
-			} else if patch_or_none(path).is_none() {
-				let _ = std::fs::remove_file(path);
-			}
-		});
+		std::fs::remove_dir_all(&source_dir);
+    	std::fs::create_dir(&source_dir);
+		for (path, contents) in patches{
+			std::fs::write(source_dir.join(path), contents)
+		}
 		find_occt_dirs(effective_root)
 	}
 

--- a/patches/pr1.patch
+++ b/patches/pr1.patch
@@ -1,0 +1,74 @@
+diff --git a/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_PipeShell.cxx b/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_PipeShell.cxx
+index 7fe332236c..7414680445 100644
+--- a/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_PipeShell.cxx
++++ b/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_PipeShell.cxx
+@@ -28,6 +28,9 @@
+ #include <BRepFill_LocationLaw.hxx>
+ #include <BRepFill_NSections.hxx>
+ #include <BRepFill_PipeShell.hxx>
++#include <GeomAdaptor_Curve.hxx>
++#include <cstdio>
++#include <cstdlib>
+ #include <BRepFill_Section.hxx>
+ #include <BRepFill_SectionLaw.hxx>
+ #include <BRepFill_SectionPlacement.hxx>
+@@ -370,6 +373,38 @@ void BRepFill_PipeShell::Set(const TopoDS_Wire&           AuxiliarySpine,
+     }
+     TheGuide = TopoDS::Wire(CW.Shape().Value(2));
+   }
++  // cadrum fix D: a closed guide made of one periodic curve should stay one periodic
++  // curve. SearchOrigin below re-origins the closed wire by splitting it at the point
++  // facing the spine origin; when that point falls near the wire's own seam vertex the
++  // split leaves a sliver edge, and BRepAdaptor_CompCurve then maps every edge onto a
++  // unit parameter span - the guide adaptor loses IsPeriodic(), gets a violent speed
++  // discontinuity at the seam, and the trihedron laws break down there. For the plane
++  // mode (origin- and orientation-independent) keep the periodic curve as-is instead.
++  occ::handle<Adaptor3d_Curve> aPeriodicGuide;
++  if (GuideClose && !CurvilinearEquivalence)
++  {
++    TopoDS_Edge     aSingleEdge;
++    TopoDS_Iterator anIt(TheGuide);
++    if (anIt.More())
++    {
++      aSingleEdge = TopoDS::Edge(anIt.Value());
++      anIt.Next();
++      if (anIt.More())
++        aSingleEdge.Nullify(); // more than one edge
++    }
++    if (!aSingleEdge.IsNull())
++    {
++      double                  aF, aL;
++      occ::handle<Geom_Curve> aCurve = BRep_Tool::Curve(aSingleEdge, aF, aL);
++      if (!aCurve.IsNull() && aCurve->IsPeriodic())
++        aPeriodicGuide = new GeomAdaptor_Curve(aCurve);
++    }
++  }
++
++  if (!aPeriodicGuide.IsNull())
++  {
++    // No re-origin needed: the plane mode searches the guide geometrically.
++  }
+   else if (GuideClose)
+   {
+     // Case guide closed : Determination of the origin
+@@ -396,7 +431,11 @@ void BRepFill_PipeShell::Set(const TopoDS_Wire&           AuxiliarySpine,
+   }
+ 
+   // transform the guide in a single curve
+-  occ::handle<BRepAdaptor_CompCurve> Guide = new (BRepAdaptor_CompCurve)(TheGuide);
++  occ::handle<Adaptor3d_Curve> Guide;
++  if (!aPeriodicGuide.IsNull())
++    Guide = aPeriodicGuide;
++  else
++    Guide = new (BRepAdaptor_CompCurve)(TheGuide);
+ 
+   if (CurvilinearEquivalence)
+   { // trihedron by curvilinear reduced abscissa
+@@ -711,6 +750,7 @@ bool BRepFill_PipeShell::Build()
+   // 1) Preparation
+   Prepare();
+ 
++
+   if (myStatus != GeomFill_PipeOk)
+   {
+     BRep_Builder B;

--- a/patches/pr2.patch
+++ b/patches/pr2.patch
@@ -1,0 +1,183 @@
+diff --git a/src/ModelingAlgorithms/TKGeomAlgo/GeomFill/GeomFill_GuideTrihedronPlan.cxx b/src/ModelingAlgorithms/TKGeomAlgo/GeomFill/GeomFill_GuideTrihedronPlan.cxx
+index f8bd6beb5e..98a993eaf6 100644
+--- a/src/ModelingAlgorithms/TKGeomAlgo/GeomFill/GeomFill_GuideTrihedronPlan.cxx
++++ b/src/ModelingAlgorithms/TKGeomAlgo/GeomFill/GeomFill_GuideTrihedronPlan.cxx
+@@ -36,6 +36,20 @@
+ 
+ IMPLEMENT_STANDARD_RTTIEXT(GeomFill_GuideTrihedronPlan, GeomFill_TrihedronWithGuide)
+ 
++// cadrum fix A: the guide reaching this law is often a BRepAdaptor_CompCurve that has
++// lost the periodicity of its underlying closed curve (a closed wire is split into
++// unit-parameter edge spans). Detect closure geometrically so seam handling works for
++// both truly periodic adaptors and closed composite ones.
++static bool cadrumGuideClosed(const occ::handle<Adaptor3d_Curve>& theGuide, double& thePeriod)
++{
++  thePeriod = theGuide->LastParameter() - theGuide->FirstParameter();
++  if (theGuide->IsPeriodic())
++    return true;
++  const gp_Pnt aP1 = theGuide->Value(theGuide->FirstParameter());
++  const gp_Pnt aP2 = theGuide->Value(theGuide->LastParameter());
++  return aP1.Distance(aP2) < 1.e-4 * thePeriod;
++}
++
+ // #include <gp_Trsf2d.hxx>
+ // #include <Bnd_Box2d.hxx>
+ 
+@@ -138,15 +152,23 @@ void GeomFill_GuideTrihedronPlan::Init()
+ #ifdef OCCT_DEBUG
+       TracePlan(Plan);
+ #endif
+-      w = (fabs(myGuide->LastParameter() - w) > fabs(myGuide->FirstParameter() - w)
+-             ? myGuide->FirstParameter()
+-             : myGuide->LastParameter());
+-
+-      myStatus = GeomFill_PlaneNotIntersectGuide;
+-      // return;
++      // cadrum fix A: a missed intersection at one sample used to poison the seed
++      // table with First/Last and flag a global error. Extrapolate from the previous
++      // samples and let the per-evaluation root search decide; keep the error only
++      // when the very first sample fails (no history to extrapolate from).
++      if (ii > 2)
++        w = 2.0 * Pole->Value(1, ii - 1).Y() - Pole->Value(1, ii - 2).Y();
++      else if (ii == 2)
++        w = Pole->Value(1, ii - 1).Y();
++      else
++      {
++        w = myGuide->FirstParameter();
++        myStatus = GeomFill_PlaneNotIntersectGuide;
++      }
+     }
+-    else
++    else if (ii == 1)
+     {
++      // First sample: nearest intersection in space.
+       gp_Pnt Pmin;
+       PInt        = Int.Point(1);
+       Pmin        = PInt.Pnt();
+@@ -163,25 +185,28 @@ void GeomFill_GuideTrihedronPlan::Init()
+ 
+       w = PInt.W();
+     }
+-    if (ii > 1)
++    else
+     {
+-      double Diff = w - Pole->Value(1, ii - 1).Y();
+-      if (std::abs(Diff) > DeltaG)
++      // cadrum fix A: subsequent samples continue the branch of the previous one.
++      // Spatial-nearest selection can hop to the antipodal branch of a closed guide
++      // near its seam; parameter continuity (with closure-aware unrolling) cannot.
++      double aGPeriod = 0.;
++      const bool isGClosed = cadrumGuideClosed(myGuide, aGPeriod);
++      const double aPrev = Pole->Value(1, ii - 1).Y();
++      bool   aFirstCand = true;
++      double aBest      = 0.;
++      for (int jj = 1; jj <= Int.NbPoints(); jj++)
+       {
+-        if (myGuide->IsPeriodic())
++        double aW = Int.Point(jj).W();
++        if (isGClosed)
++          InGoodPeriod(aPrev, aGPeriod, aW);
++        if (aFirstCand || std::abs(aW - aPrev) < std::abs(aBest - aPrev))
+         {
+-          InGoodPeriod(Pole->Value(1, ii - 1).Y(), myGuide->Period(), w);
+-
+-          Diff = w - Pole->Value(1, ii - 1).Y();
++          aBest      = aW;
++          aFirstCand = false;
+         }
+       }
+-
+-#ifdef OCCT_DEBUG
+-      if (std::abs(Diff) > DeltaG)
+-      {
+-        std::cout << "Trihedron Plan Diff on Guide : " << Diff << std::endl;
+-      }
+-#endif
++      w = aBest;
+     }
+ 
+     gp_Pnt2d p1(t, w); // on stocke les parametres
+@@ -232,11 +257,31 @@ bool GeomFill_GuideTrihedronPlan::D0(const double Param,
+   GeomFill_PlanFunc E(P, Tangent, myGuide);
+ 
+   // resolution
+-  math_FunctionRoot Result(E, X(1), XTol(1), Inf(1), Sup(1), Iter);
++  // cadrum fix A: search a local trust region around the interpolated seed instead of
++  // the member bounds spanning twice the guide range. On a closed guide the normal
++  // plane always cuts a second, antipodal branch and the wide bracket let the solver
++  // capture it, flipping the trihedron normal. Near the seam the true root may sit
++  // just past the wrap, so retry once from the seed's other periodic image.
++  double aGPeriod = 0.;
++  const bool   isGClosed = cadrumGuideClosed(myGuide, aGPeriod);
++  const double aTrust    = aGPeriod / 6.0;
++  math_FunctionRoot Result(E, X(1), XTol(1), X(1) - aTrust, X(1) + aTrust, Iter);
++  bool   aRootDone = Result.IsDone();
++  double aRootVal  = aRootDone ? Result.Root() : 0.;
++  if (!aRootDone && isGClosed)
++  {
++    const double aXAlt = (X(1) - myGuide->FirstParameter() > aGPeriod / 2.) ? X(1) - aGPeriod : X(1) + aGPeriod;
++    math_FunctionRoot ResultAlt(E, aXAlt, XTol(1), aXAlt - aTrust, aXAlt + aTrust, Iter);
++    if (ResultAlt.IsDone())
++    {
++      aRootDone = true;
++      aRootVal  = ResultAlt.Root();
++    }
++  }
+ 
+-  if (Result.IsDone())
++  if (aRootDone)
+   {
+-    double Res = Result.Root();
++    double Res = aRootVal;
+     //      R = Result.Root();    // solution
+ 
+     Pprime = myTrimG->Value(Res); // pt sur courbe guide
+@@ -289,11 +334,31 @@ bool GeomFill_GuideTrihedronPlan::D1(const double Param,
+   GeomFill_PlanFunc E(P, Tangent, myGuide);
+ 
+   // resolution
+-  math_FunctionRoot Result(E, X(1), XTol(1), Inf(1), Sup(1), Iter);
++  // cadrum fix A: search a local trust region around the interpolated seed instead of
++  // the member bounds spanning twice the guide range. On a closed guide the normal
++  // plane always cuts a second, antipodal branch and the wide bracket let the solver
++  // capture it, flipping the trihedron normal. Near the seam the true root may sit
++  // just past the wrap, so retry once from the seed's other periodic image.
++  double aGPeriod = 0.;
++  const bool   isGClosed = cadrumGuideClosed(myGuide, aGPeriod);
++  const double aTrust    = aGPeriod / 6.0;
++  math_FunctionRoot Result(E, X(1), XTol(1), X(1) - aTrust, X(1) + aTrust, Iter);
++  bool   aRootDone = Result.IsDone();
++  double aRootVal  = aRootDone ? Result.Root() : 0.;
++  if (!aRootDone && isGClosed)
++  {
++    const double aXAlt = (X(1) - myGuide->FirstParameter() > aGPeriod / 2.) ? X(1) - aGPeriod : X(1) + aGPeriod;
++    math_FunctionRoot ResultAlt(E, aXAlt, XTol(1), aXAlt - aTrust, aXAlt + aTrust, Iter);
++    if (ResultAlt.IsDone())
++    {
++      aRootDone = true;
++      aRootVal  = ResultAlt.Root();
++    }
++  }
+ 
+-  if (Result.IsDone())
++  if (aRootDone)
+   {
+-    double Res = Result.Root();
++    double Res = aRootVal;
+     //      R = Result.Root();    // solution
+     myTrimG->D1(Res, PG, TG);
+     gp_Vec n(P, PG), dn; // vecteur definissant la normale du triedre
+@@ -575,7 +640,12 @@ void GeomFill_GuideTrihedronPlan::InitX(const double Param)
+   {
+     X(1) = (Pole->Value(1, Ideb).Coord(2) + Pole->Value(1, Ifin).Coord(2)) / 2;
+   }
+-  if (myGuide->IsPeriodic())
++  // cadrum fix A: the seed table is unrolled across the guide seam, so a seed that
++  // was interpolated past the seam must fold back into the evaluable range. Generalize
++  // the fold from IsPeriodic() to geometric closure: composite adaptors of a closed
++  // wire report IsPeriodic()=false while still wrapping at LastParameter.
++  double aGPeriod = 0.;
++  if (cadrumGuideClosed(myGuide, aGPeriod))
+   {
+     X(1) = ElCLib::InPeriod(X(1), myGuide->FirstParameter(), myGuide->LastParameter());
+   }


### PR DESCRIPTION
上流 OCCT へ投げた修正を、マージを待つ間 cadrum 側で先に取り込む。

## 方針

`patch_or_none` は「OCCT 全ソースに対して当てる／当てないを決める一個の巨大なパッチ」で、walker が全ファイルを列挙して問い合わせる push 型。対して patch ファイルは自分で行き先パス (`+++ b/<path>`) を持つ pull 型で、駆動方向が逆なので同じ枠組みに載せると噛み合わない。よって `patch_from_files` を並列に置く。

両者の結果は `patches: HashMap<PathBuf, String>` に集約する。このマップがそのまま「改変したファイルの集合」になるので、LGPL 2.1 §2 の後始末は source_dir をツリーごと消してマップを書き戻すだけで済み、`patch_or_none` を削除述語として二度呼ぶ必要がなくなった。副作用（`fs::write` / `remove_dir_all` / `create_dir_all`）は `occt_from_source` に直書きし、ヘルパは読み取りと変換だけを行う。

## 取り込む差分

| ファイル | 上流 PR | 対象 |
|---|---|---|
| `patches/pr1.patch` | [lzpel/OCCT#1](https://github.com/lzpel/OCCT/pull/1) | `BRepFill_PipeShell.cxx` +41/-1 |
| `patches/pr2.patch` | [lzpel/OCCT#2](https://github.com/lzpel/OCCT/pull/2) | `GeomFill_GuideTrihedronPlan.cxx` +98/-28 |

PR#2 のベースは master ではなく PR#1 のブランチなので、#2 を取り込むには #1 が要る。上流にマージされ次第、`patches/` の該当ファイルと `patch_from_files` の引数一つを消すだけで撤退できる。

## unified diff の適用

依存は追加していない。`diff_apply` が unified diff を適用し、`patch_from_files` が複数の diff を順に重ねる。同じファイルを触る diff が続いた場合はディスクではなく**マップ内の適用済み内容をベースにする**ので、上流でスタックした PR をそのまま並べられる。ハンクの行番号は目安として扱い、位置がずれていれば近傍を探し直す (GNU patch 相当)。当たらなければ panic する — 黙って未適用の prebuilt を配ると原因の切り分けができないため。

出力が `diffy` クレートとバイト一致すること、適用済みへの再適用が正しく失敗することを実ソースで確認済み。

## 検証

`--features source` でエンドツーエンド:

| 段階 | 結果 |
|---|---|
| 展開 → パッチ適用 | 24 ファイル (`patch_or_none` 22 + patch ファイル 2) |
| CMake ビルド | 21m31s で完走 |
| テスト | 109 passed / 0 failed / 3 ignored |
| LGPL 2.1 §2 の残置 | 改変した 24 ファイルのみ。両対象に `cadrum fix` が入っていることを確認 |

## BUILD_REVISION は rev1 のまま

`occt-8_0_1_rev1` はまだ誰も使っていないため据え置き。ただしリリース資産 (7 ターゲット分の tarball) は公開済みなので、パッチを prebuilt 利用者に届けるには `prebuilt` ブランチから同タグのリリースを作り直す必要がある。ローカルの既存キャッシュも同名なので、手元では一度消してから再ビルドすること。

## 既知の穴

パッチ適用後・CMake 成功前に落ちると、`.occt_extraction_done` が残ったまま適用済みのソースが残るため、次回の `patch_from_files` が再適用に失敗して panic する。復旧にはキャッシュディレクトリごと削除して再ダウンロードが要る。sentinel をパッチ適用後に書く案と、`patch -N` 相当の「適用済みなら現状維持」判定を入れる案があり、本 PR では未着手。