### PR TITLE
Stream the OCCT download and make patch application idempotent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +112,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -222,6 +247,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +311,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +325,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
 ]
 
 [[package]]
@@ -315,6 +363,16 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
 ]
 
 [[package]]
@@ -398,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "minreq"
-version = "2.14.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05015102dad0f7d61691ca347e9d9d9006685a64aefb3d79eecf62665de2153d"
+checksum = "659579df697b372ef9e36f02fcbb41f6d6f157dcec7db9c9618fa0f23cf0fc20"
 dependencies = [
  "rustls",
  "rustls-webpki",
@@ -415,6 +473,18 @@ checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plain"
@@ -452,6 +522,12 @@ checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "redox_syscall"
@@ -499,7 +575,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -526,23 +602,37 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
+ "aws-lc-rs",
  "log",
- "ring",
+ "once_cell",
+ "rustls-pki-types",
  "rustls-webpki",
- "sct",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
+ "aws-lc-rs",
  "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -560,16 +650,6 @@ name = "scratch"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "serde"
@@ -624,6 +704,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -718,9 +804,12 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "winapi-util"
@@ -828,3 +917,9 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ tiny-skia = { version = "0.11", optional = true }
 [build-dependencies]
 cxx-build = "1"
 # download and extract prebuilt OCCT tarball
-minreq = { version = "2", features = ["https-rustls"] }
+minreq = { version = "3", features = ["https-rustls"] }
 libflate = "2"
 tar = "0.4"
 walkdir = "2"

--- a/build.rs
+++ b/build.rs
@@ -279,19 +279,17 @@ fn occt_from_prebuilt(effective_root: &Path, target: &str) -> Option<[PathBuf; 2
 }
 
 fn download_and_extract_tar_gz(url: &str, dest: &Path) -> Result<(), String> {
-	let bytes = fetch_bytes(url)?;
-	let gz = libflate::gzip::Decoder::new(&bytes[..]).map_err(|e| format!("gzip decode failed: {e}"))?;
-	tar::Archive::new(gz).unpack(dest).map_err(|e| format!("tar unpack failed: {e}"))?;
-	Ok(())
+	let gz = libflate::gzip::Decoder::new(fetch(url)?).map_err(|e| format!("gzip decode failed: {e}"))?;
+	tar::Archive::new(gz).unpack(dest).map_err(|e| format!("tar unpack failed: {e}"))
 }
 
-fn fetch_bytes(url: &str) -> Result<Vec<u8>, String> {
-	if let Some(rest) = url.strip_prefix("file://") {
-		let path: PathBuf = if rest.len() >= 3 && rest.starts_with('/') && rest.as_bytes()[2] == b':' { PathBuf::from(&rest[1..]) } else { PathBuf::from(rest) };
-		std::fs::read(&path).map_err(|e| format!("read {}: {}", path.display(), e))
-	} else {
-		let resp = minreq::get(url).send().map_err(|e| e.to_string())?;
-		Ok(resp.into_bytes())
+fn fetch(url: &str) -> Result<Box<dyn std::io::Read>, String> {
+	match url.strip_prefix("file://") {
+		Some(rest) => {
+			let path: PathBuf = if rest.len() >= 3 && rest.starts_with('/') && rest.as_bytes()[2] == b':' { PathBuf::from(&rest[1..]) } else { PathBuf::from(rest) };
+			Ok(Box::new(std::fs::File::open(&path).map_err(|e| format!("read {}: {}", path.display(), e))?))
+		}
+		None => Ok(Box::new(minreq::get(url).send_lazy().map_err(|e| e.to_string())?)),
 	}
 }
 
@@ -355,25 +353,9 @@ mod source {
 		let occt_version = OCCT_VERSION;
 		let occt_url = format!("https://github.com/Open-Cascade-SAS/OCCT/archive/refs/tags/{}.tar.gz", occt_version);
 
-		let extraction_sentinel = effective_root.join(".occt_extraction_done");
-
-		if !extraction_sentinel.exists() {
-			std::fs::create_dir_all(effective_root).unwrap();
-
-			if let Ok(entries) = std::fs::read_dir(effective_root) {
-				for entry in entries.flatten() {
-					let name = entry.file_name();
-					if name.to_string_lossy().starts_with("OCCT") && entry.path().is_dir() {
-						eprintln!("Removing partial OCCT extraction: {:?}", name);
-						let _ = std::fs::remove_dir_all(entry.path());
-					}
-				}
-			}
-
+		if !WalkDir::new(effective_root).max_depth(2).iter().any(|e| e.ok().is_some_and(|e| e.file_name() == "OCCT_LGPL_EXCEPTION.txt")){
 			eprintln!("Downloading OCCT {} from {} ...", occt_version, occt_url);
 			download_and_extract_tar_gz(&occt_url, effective_root).expect("Failed to download/extract OCCT source tarball");
-
-			std::fs::write(&extraction_sentinel, "done").unwrap();
 			eprintln!("OCCT source extracted successfully.");
 		}
 
@@ -529,15 +511,22 @@ mod source {
 				it.next();
 			}
 
-			// hint 位置から外側へ探す。直前のハンクの終端 `cur` より前には戻らず、
-			// `old` が残り行数より長ければその時点で不一致。
-			let last = lines.len().checked_sub(old.len()).filter(|last| *last >= cur)?;
-			let hint = hint.saturating_sub(1).clamp(cur, last);
-			let at = (0..=last - cur).flat_map(|d| [hint + d, hint.wrapping_sub(d)]).find(|&i| (cur..=last).contains(&i) && lines[i..i + old.len()] == old[..])?;
+			// hint 位置から外側へ探す。直前のハンクの終端 `cur` より前には戻らない。
+			let hint = hint.saturating_sub(1).max(cur);
+			let find = |needle: &[&str]| {
+				let last = lines.len().checked_sub(needle.len()).filter(|last| *last >= cur)?;
+				let hint = hint.min(last);
+				(0..=last - cur).flat_map(|d| [hint + d, hint.wrapping_sub(d)]).find(|&i| (cur..=last).contains(&i) && lines[i..i + needle.len()] == needle[..])
+			};
+			// `old` が無く `new` があるハンクは適用済み。読み飛ばして冪等にする(patch -N 相当)。
+			let (at, taken) = match find(&old) {
+				Some(at) => (at, old.len()),
+				None => (find(&new)?, new.len()),
+			};
 
 			out.extend_from_slice(&lines[cur..at]);
 			out.extend_from_slice(&new);
-			cur = at + old.len();
+			cur = at + taken;
 		}
 
 		out.extend_from_slice(&lines[cur..]);

--- a/build.rs
+++ b/build.rs
@@ -353,7 +353,7 @@ mod source {
 		let occt_version = OCCT_VERSION;
 		let occt_url = format!("https://github.com/Open-Cascade-SAS/OCCT/archive/refs/tags/{}.tar.gz", occt_version);
 
-		if !WalkDir::new(effective_root).max_depth(2).iter().any(|e| e.ok().is_some_and(|e| e.file_name() == "OCCT_LGPL_EXCEPTION.txt")){
+		if !walkdir::WalkDir::new(effective_root).max_depth(2).into_iter().any(|e| e.ok().is_some_and(|e| e.file_name() == "OCCT_LGPL_EXCEPTION.txt")) {
 			eprintln!("Downloading OCCT {} from {} ...", occt_version, occt_url);
 			download_and_extract_tar_gz(&occt_url, effective_root).expect("Failed to download/extract OCCT source tarball");
 			eprintln!("OCCT source extracted successfully.");


### PR DESCRIPTION
`--features source` の経路を、失敗しても詰まないように整える。**検証前のドラフト**。

## ストリーミング展開

`fetch_bytes` を `fetch` に改め、`Vec<u8>` ではなく `Box<dyn Read>` を返す。`File` と `ResponseLazy` という別々の具象型を `dyn` に隠すことで分岐の両腕が揃う。

```rust
fn download_and_extract_tar_gz(url: &str, dest: &Path) -> Result<(), String> {
	let gz = libflate::gzip::Decoder::new(fetch(url)?).map_err(|e| format!("gzip decode failed: {e}"))?;
	tar::Archive::new(gz).unpack(dest).map_err(|e| format!("tar unpack failed: {e}"))
}
```

HTTP レスポンスが gzip デコーダに直結して tar 展開へ流れる。45MB の OCCT ソース tarball を丸ごとメモリに載せる必要がなくなり、ピークメモリが定数になった。`minreq` を 3 に上げたのは `send_lazy()` を使うため（`https-rustls` フィーチャ名と `get`/`send` の API は 3.0.0 でも同一、`webpki-roots` が 0.25 → 1.0 に上がる）。

## パッチ適用の冪等化

`patch_or_none` は元から再実行に耐える作りだった（スタブ済みの再スタブは同結果、コメント済みの `#include` は `replace` が空振り、`occt_defs_flags.cmake` には `already patched` 分岐がある）。そこに #262 で非冪等な unified diff 適用を並べたため、層全体の再実行可能性が失われていた。

具体的な症状として、CMake が失敗するとキャッシュが**恒久的に使用不能**になっていた。展開済みの印は残り、ソース木はパッチ適用済み、`inc`/`lib` は無い、という状態で終わるため、次回実行は再展開をスキップしたうえで適用済みのファイルにパッチを当て直そうとして panic する。復旧はキャッシュディレクトリの手動削除しかなく、45MB の再ダウンロードが必要だった。

`diff_apply` に GNU `patch -N` 相当の判定を入れた。`old` が見つからず `new` が見つかるハンクは適用済みとみなして読み飛ばす。

## 検証すること

- キャッシュを消した状態からの `--features source` フルビルド
- LGPL 2.1 §2 のスリム結果が改変 24 ファイルのみであること

## 既知の論点

展開済み判定を `OCCT_LGPL_EXCEPTION.txt` の存在で行っているが、このファイルはアーカイブ 36502 エントリ中 **77 番目**に展開されるため、「展開が完了した」ではなく「展開が始まった」を意味する。中断した木を完了と誤判定する。ストリーミング化により通信断で半端な木が残る失敗モードが現実的になった分、この判定は弱い。

判定を残す理由は、ユーザーが手で OCCT ソースを書き換える道を再展開で潰さないため。ただし現状は LGPL スリム段がビルド成功のたびにソース木を 24 ファイルまで削るので、その道は判定より手前で塞がっている。スリム化は配布物にのみ必要な処理なので、`CADRUM_BUNDLE_RUNTIME` で包めば手元では木が残る。別 PR の題材。