### PR TITLE
Publish dated cross-image tags and document --pull=always against stale-latest EH mixups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+- #265 Publish dated cross-image tags and document --pull=always against stale-latest EH mixups
+
 ### 0.8.17
 
 - #263 Stream the OCCT download and make patch application idempotent

--- a/README.md
+++ b/README.md
@@ -77,9 +77,15 @@ We ship the wasi-sdk toolchain as a ready-to-use Docker image,
 — so you don't install wasi-sdk locally. Mount your project and build as usual:
 
 ```sh
-docker run --rm -v "$PWD":/work -w /work ghcr.io/lzpel/cross-wasm32-unknown-unknown cargo build --release
+docker run --rm --pull=always -v "$PWD":/work -w /work ghcr.io/lzpel/cross-wasm32-unknown-unknown cargo build --release
 # → target/wasm32-unknown-unknown/release/<your-crate>.wasm
 ```
+
+Keep `--pull=always`: without it docker silently reuses a locally cached `latest`,
+and an outdated image carries a wasm-EH sysroot that no longer matches the prebuilt
+OCCT — the linked module then mixes legacy and new EH instructions and every engine
+rejects it with `module uses a mix of legacy and new exception handling instructions`.
+Dated tags (e.g. `:20260824`) are also published if you need a pinned image.
 
 The image cross-compiles to `wasm32-unknown-unknown` by default; you get a `.wasm`
 from a binary or a `crate-type = ["cdylib"]` crate (a plain `lib` produces an `.rlib`).

--- a/makefile
+++ b/makefile
@@ -23,8 +23,12 @@ publish: update publish-ready # publish to crates.io
 	# cross-wasm32-unknown-unknown step) so users can run
 	# `docker run ghcr.io/lzpel/cross-wasm32-unknown-unknown cargo build` without installing wasi-sdk.
 	# Requires a one-time `docker login ghcr.io -u lzpel` beforehand (token cached).
+	# Push a dated tag alongside latest: docker run silently reuses a stale local `latest`
+	# (a pre-#233 cache has an exnref sysroot -> mixed-EH module that engines reject).
 	docker tag cross-wasm32-unknown-unknown ghcr.io/lzpel/cross-wasm32-unknown-unknown:latest
+	docker tag cross-wasm32-unknown-unknown ghcr.io/lzpel/cross-wasm32-unknown-unknown:$$(date +%Y%m%d)
 	docker push ghcr.io/lzpel/cross-wasm32-unknown-unknown:latest
+	docker push ghcr.io/lzpel/cross-wasm32-unknown-unknown:$$(date +%Y%m%d)
 	# publish the crate sources to crates.io
 	cargo publish
 occt: generate # output out/occt-<rev>-<target>.tar.gz from source natively


### PR DESCRIPTION
## Problem

A consumer build of cadrum 0.8.17 for `wasm32-unknown-unknown` (lzpel/opencascade-wasm32-unknown-unknown-example#9) failed at instantiation in both Chrome and Node:

```
CompileError: Compiling function #353 failed:
module uses a mix of legacy and new exception handling instructions
```

The prebuilt OCCT and cadrum itself were innocent. The machine had a **stale local cache of `ghcr.io/lzpel/cross-wasm32-unknown-unknown:latest`** (created 2026-06-16, i.e. pre-#233), and `docker run` reuses a locally cached tag without checking the registry. That image's sysroot predates the legacy-EH rollback:

| image | created | `libc++abi.a` (eh) instructions |
|---|---|---|
| stale local `latest` (`8b77caa…`) | 2026-06-16 | `try_table` ×91, `throw_ref` ×42 → **exnref** |
| current ghcr `latest` (`4dc88df…`) | 2026-07-12 (#233) | `delegate`/`rethrow`, no exnref → **legacy** |

Linking the legacy-EH prebuilt OCCT against the stale image's exnref `libc++abi`/`libunwind` produces exactly the mixed-EH module engines reject. After `docker pull`, the same 0.8.17 build compiles and runs cleanly.

## Change

- `makefile` (publish): push an immutable dated tag (e.g. `:20260824`) alongside `latest`, so a specific image can be pinned and a stale cache identified.
- `README.md`: add `--pull=always` to the documented `docker run` line and explain the failure mode.

Since #233 made the sysroot encoding a hard ABI axis between the image and the prebuilt, any cached pre-#233 `latest` is silently fatal — hence defaulting the documented invocation to `--pull=always`.

## Verification

- Repro + fix verified locally on Windows/Docker: stale image → mixed-EH `CompileError`; after `docker pull` (digest `4dc88df…`) the example builds and `WebAssembly.compile` passes in Node 24.
- Instruction evidence extracted with `llvm-objdump -d` on each image's `wasm32-wasip1/eh/libc++abi.a` (counts above).