### PR TITLE
Add From<std::io::Error> for Error so `?` composes with cadrum::Error

### DIFF
--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -96,6 +96,10 @@ pub enum Error {
 	/// Invalid color string (unrecognized name or invalid hex format).
 	InvalidColor(String),
 
+	/// I/O failure from the caller's reader/writer, so `File::create(..)?`
+	/// composes inside a `Result<_, cadrum::Error>` function.
+	Io(std::io::Error),
+
 	/// Unknown error.
 	Unknown(String),
 }
@@ -127,9 +131,23 @@ impl std::fmt::Display for Error {
 			Error::StlWriteFailed => write!(f, "STL write failed"),
 			Error::GltfWriteFailed => write!(f, "glTF write failed"),
 			Error::InvalidColor(s) => write!(f, "Invalid color: \"{}\"", s),
+			Error::Io(error) => write!(f, "I/O error: {}", error),
 			Error::Unknown(msg) => write!(f, "Unknown error: {}", msg),
 		}
 	}
 }
 
-impl std::error::Error for Error {}
+impl std::error::Error for Error {
+	fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+		match self {
+			Error::Io(error) => Some(error),
+			_ => None,
+		}
+	}
+}
+
+impl From<std::io::Error> for Error {
+	fn from(error: std::io::Error) -> Self {
+		Error::Io(error)
+	}
+}

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -1,0 +1,35 @@
+//! `Error` が `std::io::Error` を吸収することの検証。これがないと
+//! `File::create(..)?` を `Result<_, cadrum::Error>` の関数内で書けない。
+
+use cadrum::{DVec3, Error, Solid};
+use std::error::Error as _;
+use std::fs::File;
+
+/// `?` だけで io と cadrum のエラーを混ぜられることを型で示す。
+fn write_step_to(path: &std::path::Path) -> Result<u64, Error> {
+	let solid = Solid::cube(DVec3::ZERO, DVec3::splat(2.0));
+	Solid::write_step([&solid], &mut File::create(path)?)?;
+	Ok(std::fs::metadata(path)?.len())
+}
+
+#[test]
+fn test_io_error_composes_with_question_mark() {
+	let path = std::env::temp_dir().join("cadrum_test_error_io.step");
+	let size = write_step_to(&path).unwrap();
+	assert!(size > 0, "STEP written through `?` should be non-empty");
+	std::fs::remove_file(&path).unwrap();
+}
+
+#[test]
+fn test_io_error_is_converted_and_kept() {
+	// 存在しないディレクトリ配下なので File::create が NotFound を返す。
+	let path = std::env::temp_dir().join("cadrum_no_such_dir_xyz").join("a.step");
+	let error = write_step_to(&path).unwrap_err();
+
+	let Error::Io(inner) = &error else {
+		panic!("expected Error::Io, got {error:?}");
+	};
+	assert_eq!(inner.kind(), std::io::ErrorKind::NotFound);
+	assert!(error.to_string().starts_with("I/O error: "), "unexpected Display: {error}");
+	assert!(error.source().is_some(), "source() should expose the io::Error");
+}


### PR DESCRIPTION
## 何が問題か

モデルをファイルに書き出すのは cadrum のほぼ全ユースケースなのに、`cadrum::Error` が `std::io::Error` を吸収しないため `File::create(..)?` を `-> Result<_, cadrum::Error>` の関数の中に書けません。

```rust
fn main() -> Result<(), cadrum::Error> {
	let part = Solid::cube(DVec3::ZERO, DVec3::splat(10.0));
	Solid::write_step([&part], &mut File::create("part.step")?)?;
	//                                                      ^ E0277
	//   the trait `From<std::io::Error>` is not implemented for `cadrum::Error`
	Ok(())
}
```

`examples/*.rs` が例外なく `File::create(...).unwrap()` になっているのはこのためで、README の Examples 節経由でその書き方がそのまま利用者に伝播しています。Linux 環境で `cargo add cadrum` して最初に書いたコードがこれで落ちたのが発端です。

## 変更

`src/common/error.rs` に `Io(std::io::Error)` を追加し、`Display` / `source()` / `From` を実装しました。

`Unknown(String)` に `e.to_string()` で畳む案もありますが、それだと `ErrorKind` が消えて "Unknown error: No such file or directory" という表示になります。`NotFound` と `PermissionDenied` の区別は呼び出し側が普通に必要とするので、専用 variant にして中身を保持し、`source()` から辿れるようにしています。

crate 内部のライタは既存どおりです。`write_stl` などが io 失敗を `StlWriteFailed` 等の形式別 variant にマップしているのは意図的な設計と読んだので、そこは触っていません。この PR が変えるのは **利用者側のコードで `?` が通るようになる** という一点だけです。

## テスト

`tests/error.rs` を追加（2 件）。

- `test_io_error_composes_with_question_mark` — `Result<_, cadrum::Error>` を返す関数の中で `File::create(..)?` と `write_step(..)?` を混在させて STEP が書けること
- `test_io_error_is_converted_and_kept` — 存在しないディレクトリ配下への書き込みで `Error::Io` になり、`ErrorKind::NotFound` と `source()` が保たれること

Debian 12 / x86_64 のコンテナ (`rust:1-bookworm`, rustc 1.98.0) で `cargo test` 全スイート green を確認しています。

```
running 2 tests
test test_io_error_is_converted_and_kept ... ok
test test_io_error_composes_with_question_mark ... ok
test result: ok. 2 passed; 0 failed
```

## 備考

- `traits.rs` にも `examples/` にも触れていないので、`make update` が生成する README / codegen の出力は変わりません。
- enum への variant 追加なので、`cadrum::Error` を網羅的に `match` している下流コードは非網羅になります。0.8.x で variant は継続的に増えているため許容範囲と判断しましたが、気になるようなら `#[non_exhaustive]` を併せて付けるか、`Unknown(String)` に畳む版に差し替えます。
- 追随して `examples/*.rs` の `.unwrap()` を `?` に寄せる変更も書けますが、README 再生成を伴うので別 PR にしました。必要なら言ってください。
