### PR TITLE
Collapse the Error enum from 25 variants to 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+Format: ^(### \d+\.\d+\.\d+)|(- #\d+ .*)$
+
 ### 0.8.17
 
+- #270 Collapse the Error enum from 25 variants to 16, add From<std::io::Error>, and route I/O and export failures through Error::Io
 - #268 Add solid_sweep tests for a closed periodic spine with an auxiliary guide
 - #267 Reorganize tests under a solid_* prefix and drop the integration test files
 - #263 Stream the OCCT download and make patch application idempotent

--- a/src/common/boolean.rs
+++ b/src/common/boolean.rs
@@ -30,19 +30,19 @@ impl<S: SolidStruct> Boolean<S> {
 		&self.clauses
 	}
 
-	/// FFI を呼んで結果が単一 Solid なら返す。複数または 0 個なら `OneFailed(n)`。
+	/// FFI を呼んで結果が単一 Solid なら返す。複数または 0 個なら `NotOne(n)`。
 	pub fn build(self) -> Result<S, Error> {
 		let mut v = self.build_vec()?;
 		match v.len() {
 			1 => Ok(v.pop().unwrap()),
-			n => Err(Error::OneFailed(n)),
+			n => Err(Error::NotOne(n)),
 		}
 	}
 
-	/// FFI を呼んで全ピースを返す。空式は `OneFailed(0)`。
+	/// FFI を呼んで全ピースを返す。空式は `NotOne(0)`。
 	pub fn build_vec(self) -> Result<Vec<S>, Error> {
 		if self.solids.is_empty() || self.clauses.is_empty() {
-			return Err(Error::OneFailed(0));
+			return Err(Error::NotOne(0));
 		}
 		S::boolean_build(&self)
 	}
@@ -194,7 +194,7 @@ boolean_lhs_ops!(&S);
 
 // ==================== Default (= ⊥ / union の単位元) ====================
 //
-// 空式 = ⊥ (空集合 / 何も選択していない)。`build()` は `OneFailed(0)`。
+// 空式 = ⊥ (空集合 / 何も選択していない)。`build()` は `NotOne(0)`。
 // union を fold で畳むときの init に使う: `iter.fold(Boolean::default(), |a, s| a + s)`。
 // `dnf_union(default(), b) == b` なので union の単位元として正しい。
 // intersect では零元 (annihilator) になるため init に使ってはいけない — intersect の集約は

--- a/src/common/color.rs
+++ b/src/common/color.rs
@@ -57,7 +57,7 @@ impl Color {
 			"brown" => "#a52a2a",
 			"tan" => "#d2b48c",
 			"skyblue" => "#87ceeb",
-			_ => return Err(super::error::Error::InvalidColor(s.to_string())),
+			_ => return Err(super::error::Error::Validation(s.to_string())),
 		};
 		Self::from_hex(hex)
 	}
@@ -67,10 +67,10 @@ impl Color {
 	/// The leading `#` is required. The remaining characters must be hex digits,
 	/// either 6 (RRGGBB) or 3 (RGB, each digit is doubled).
 	fn from_hex(s: &str) -> Result<Self, super::error::Error> {
-		let err = || super::error::Error::InvalidColor(s.to_string());
+		let err = || super::error::Error::Validation(s.to_string());
 		let hex = s.strip_prefix('#').ok_or_else(err)?;
 		if !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
-			return Err(super::error::Error::InvalidColor(s.to_string()));
+			return Err(super::error::Error::Validation(s.to_string()));
 		}
 		let (r, g, b) = match hex.len() {
 			6 => {
@@ -85,7 +85,7 @@ impl Color {
 				let b = u8::from_str_radix(&hex[2..3], 16).unwrap() * 17;
 				(r, g, b)
 			}
-			_ => return Err(super::error::Error::InvalidColor(s.to_string())),
+			_ => return Err(super::error::Error::Validation(s.to_string())),
 		};
 		Ok(Color { r: r as f32 / 255.0, g: g as f32 / 255.0, b: b as f32 / 255.0 })
 	}

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -1,135 +1,82 @@
 /// Errors that can occur during CAD operations.
 #[derive(Debug)]
 pub enum Error {
-	/// STEP file read failed (invalid format or corrupted data).
-	StepReadFailed,
+	/// Caller-side misuse: an argument that cannot be interpreted, such as an invalid color string.
+	Validation(String),
 
-	/// BRep file read failed (invalid format or corrupted data).
-	BrepReadFailed,
-
-	/// STEP file write failed.
-	StepWriteFailed,
-
-	/// BRep file write failed.
-	BrepWriteFailed,
+	/// Read/Writel step brep gltf etc
+	Io(std::io::Error),
 
 	/// Triangulation/meshing failed.
-	TriangulationFailed,
+	Tesselation,
 
 	/// Boolean operation (fuse/cut/common) failed.
-	BooleanOperationFailed,
+	Boolean,
 
-	/// 単一 Solid を期待する演算 (`+`/`-`/`*` 演算子) で結果の Solid 数が 1 でなかった。
-	/// `usize` は実際の結果 Solid 数 (0 = 非交差/全削除、2+ = 結果が複数ピースに分割)。
-	/// 戻り値が複数ピースになりうる場合は `Solid::boolean_union/subtract/intersect` を
-	/// 直接使い `Vec<Solid>` を受け取ること。
-	OneFailed(usize),
+	/// Got not one solids although expecting one solid, typically as a result of boolean operation.
+	NotOne(usize),
+
+	/// Edge construction failed on degenerate input (collinear arc points, zero-length line, negative radius).
+	Edge(String),
 
 	/// Shape cleaning (UnifySameDomain) failed.
-	CleanFailed,
+	Clean,
 
-	/// Helix edge construction failed (e.g. degenerate parameters).
-	HelixFailed,
+	/// Extrusion (`Solid::extrude`) failed: empty profile, zero-length direction, or profile not closed.
+	Extrude,
 
-	/// Extrusion (`Solid::extrude`) failed: empty profile, zero-length
-	/// direction, or profile not closed.
-	ExtrudeFailed,
+	/// Pipe sweep (`Solid::sweep`) failed: profile not closed, or edges not connectable into a wire.
+	Sweep(String),
 
-	/// Pipe sweep (`Solid::sweep`) failed: profile not closed, edges not
-	/// connectable into a wire, or `BRepOffsetAPI_MakePipe` returned no shape.
-	SweepFailed,
+	/// Shell (`Solid::shell`) failed: thickness incompatible with the geometry, or self-intersecting offset.
+	Shell(String),
 
-	/// Shell / hollow (`Solid::shell` via `BRepOffsetAPI_MakeThickSolid`)
-	/// failed: thickness sign incompatible with geometry, sharp corners
-	/// yielding a self-intersecting offset surface, or OCCT internal failure.
-	ShellFailed,
+	/// Fillet (`Solid::fillet_edges`) failed: radius too large, tangent discontinuity, or foreign edge.
+	Fillet(String),
 
-	/// Fillet (`Solid::fillet_edges` via `BRepFilletAPI_MakeFillet`) failed:
-	/// radius too large for the local geometry, tangent discontinuity along
-	/// the selected edge chain, or an edge not belonging to `self` was passed.
-	FilletFailed,
+	/// Chamfer (`Solid::chamfer_edges`) failed: distance too large, tangent discontinuity, or foreign edge.
+	Chamfer(String),
 
-	/// Chamfer (`Solid::chamfer_edges` via `BRepFilletAPI_MakeChamfer`) failed:
-	/// distance too large for the local geometry, tangent discontinuity along
-	/// the selected edge chain, or an edge not belonging to `self` was passed.
-	ChamferFailed,
+	/// Loft (`Solid::loft`) failed: too few sections, or an ill-formed section wire.
+	Loft(String),
 
-	/// Lofting (`Solid::loft` / `BRepOffsetAPI_ThruSections`) failed: section
-	/// count too low, section wire ill-formed, or OCCT internal failure.
-	/// The string identifies which precondition or stage failed.
-	LoftFailed(String),
+	/// Sewing (`Solid::sew`) failed: the faces do not form exactly one closed shell within the tolerance.
+	Sew(String),
 
-	/// Sewing (`Solid::sew` / `BRepBuilderAPI_Sewing`) failed: the faces do
-	/// not form exactly one closed shell within the given tolerance (gaps,
-	/// overlaps, multiple disconnected shells, or stray faces). The string
-	/// identifies which precondition or stage failed.
-	SewFailed(String),
+	/// Surface offset (`Solid::offset_surface`) failed: the offset surfaces self-intersect.
+	Offset(String),
 
-	/// Surface offset (`Solid::offset_surface` / `BRepOffsetAPI_MakeOffsetShape`)
-	/// failed: the offset surfaces self-intersect (thin walls/slots thinner
-	/// than 2x the offset magnitude) or OCCT rejected the join. The string
-	/// carries the offending parameters.
-	OffsetFailed(String),
-
-	/// B-spline solid (`Solid::bspline`) construction failed: grid too small,
-	/// surface interpolation rejected the input, or sewing/capping failed.
-	/// The string identifies which stage failed and with what parameters.
-	BsplineFailed(String),
-
-	/// Edge construction failed due to degenerate input (e.g. collinear arc
-	/// points, zero-length line, negative radius). The string describes which
-	/// constructor failed and with which parameters.
-	InvalidEdge(String),
-
-	/// SVG export (HLR projection) failed.
-	SvgExportFailed,
-
-	/// PNG export failed (rasterizer / encoder / writer).
-	PngExportFailed,
-
-	/// STL write failed.
-	StlWriteFailed,
-
-	/// glTF (GLB binary) write failed.
-	GltfWriteFailed,
-
-	/// Invalid color string (unrecognized name or invalid hex format).
-	InvalidColor(String),
-
-	/// Unknown error.
-	Unknown(String),
+	/// B-spline solid (`Solid::bspline`) failed: grid too small, or interpolation/sewing rejected the input.
+	Bspline(String),
 }
 
 impl std::fmt::Display for Error {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {
-			Error::StepReadFailed => write!(f, "STEP read failed"),
-			Error::BrepReadFailed => write!(f, "BRep read failed"),
-			Error::StepWriteFailed => write!(f, "STEP write failed"),
-			Error::BrepWriteFailed => write!(f, "BRep write failed"),
-			Error::TriangulationFailed => write!(f, "Triangulation failed"),
-			Error::BooleanOperationFailed => write!(f, "Boolean operation failed"),
-			Error::OneFailed(n) => write!(f, "Expected exactly one resulting Solid, got {}", n),
-			Error::CleanFailed => write!(f, "Shape clean failed"),
-			Error::HelixFailed => write!(f, "Helix failed"),
-			Error::ExtrudeFailed => write!(f, "Extrude failed"),
-			Error::SweepFailed => write!(f, "Sweep failed"),
-			Error::ShellFailed => write!(f, "Shell failed"),
-			Error::FilletFailed => write!(f, "Fillet failed"),
-			Error::ChamferFailed => write!(f, "Chamfer failed"),
-			Error::LoftFailed(msg) => write!(f, "Loft failed: {}", msg),
-			Error::SewFailed(msg) => write!(f, "Sew failed: {}", msg),
-			Error::OffsetFailed(msg) => write!(f, "Offset failed: {}", msg),
-			Error::BsplineFailed(msg) => write!(f, "Bspline failed: {}", msg),
-			Error::InvalidEdge(msg) => write!(f, "Invalid edge: {}", msg),
-			Error::SvgExportFailed => write!(f, "SVG export failed"),
-			Error::PngExportFailed => write!(f, "PNG export failed"),
-			Error::StlWriteFailed => write!(f, "STL write failed"),
-			Error::GltfWriteFailed => write!(f, "glTF write failed"),
-			Error::InvalidColor(s) => write!(f, "Invalid color: \"{}\"", s),
-			Error::Unknown(msg) => write!(f, "Unknown error: {}", msg),
+			Error::Validation(msg) => write!(f, "Validation failed: {msg}"),
+			Error::Io(e) => write!(f, "IO failed: {e}"),
+			Error::Tesselation => write!(f, "Tesselation failed"),
+			Error::Boolean => write!(f, "Boolean operation failed"),
+			Error::NotOne(n) => write!(f, "Expected exactly one resulting Solid, got {n}"),
+			Error::Edge(msg) => write!(f, "Edge failed: {msg}"),
+			Error::Clean => write!(f, "Clean failed"),
+			Error::Extrude => write!(f, "Extrude failed"),
+			Error::Sweep(msg) => write!(f, "Sweep failed: {msg}"),
+			Error::Shell(msg) => write!(f, "Shell failed: {msg}"),
+			Error::Fillet(msg) => write!(f, "Fillet failed: {msg}"),
+			Error::Chamfer(msg) => write!(f, "Chamfer failed: {msg}"),
+			Error::Loft(msg) => write!(f, "Loft failed: {msg}"),
+			Error::Sew(msg) => write!(f, "Sew failed: {msg}"),
+			Error::Offset(msg) => write!(f, "Offset failed: {msg}"),
+			Error::Bspline(msg) => write!(f, "Bspline failed: {msg}"),
 		}
 	}
 }
 
 impl std::error::Error for Error {}
+
+impl From<std::io::Error> for Error {
+	fn from(e: std::io::Error) -> Self {
+		Error::Io(e)
+	}
+}

--- a/src/common/mesh.rs
+++ b/src/common/mesh.rs
@@ -88,9 +88,9 @@ impl Mesh {
 	pub fn write_stl<W: std::io::Write>(&self, writer: &mut W) -> Result<(), super::error::Error> {
 		let tri_count = self.indices.len() / 3;
 		// 80-byte header
-		writer.write_all(&[0u8; 80]).map_err(|_| super::error::Error::StlWriteFailed)?;
+		writer.write_all(&[0u8; 80])?;
 		// Triangle count (u32 LE)
-		writer.write_all(&(tri_count as u32).to_le_bytes()).map_err(|_| super::error::Error::StlWriteFailed)?;
+		writer.write_all(&(tri_count as u32).to_le_bytes())?;
 		for ti in 0..tri_count {
 			let i0 = self.indices[ti * 3];
 			let i1 = self.indices[ti * 3 + 1];
@@ -103,12 +103,12 @@ impl Mesh {
 			let n = tri_normal(self, ti).normalize_or_zero();
 			// Normal (3 x f32 LE)
 			for c in [n.x, n.y, n.z] {
-				writer.write_all(&(c as f32).to_le_bytes()).map_err(|_| super::error::Error::StlWriteFailed)?;
+				writer.write_all(&(c as f32).to_le_bytes())?;
 			}
 			// Vertices (3 x 3 x f32 LE)
 			for v in [v0, v1, v2] {
 				for c in [v.x, v.y, v.z] {
-					writer.write_all(&(c as f32).to_le_bytes()).map_err(|_| super::error::Error::StlWriteFailed)?;
+					writer.write_all(&(c as f32).to_le_bytes())?;
 				}
 			}
 			// Attribute byte count — RGB555 color (SolidView/MeshLab convention)
@@ -116,7 +116,7 @@ impl Mesh {
 			let attr = self.colormap.get(&self.face_ids[ti]).map_or(0, Color::as_u16);
 			#[cfg(not(feature = "color"))]
 			let attr = 0u16;
-			writer.write_all(&attr.to_le_bytes()).map_err(|_| super::error::Error::StlWriteFailed)?;
+			writer.write_all(&attr.to_le_bytes())?;
 		}
 		Ok(())
 	}
@@ -207,7 +207,7 @@ impl Mesh {
 			total += 8 + bin.len();
 		}
 
-		let mut w = |b: &[u8]| writer.write_all(b).map_err(|_| Error::GltfWriteFailed);
+		let mut w = |b: &[u8]| writer.write_all(b).map_err(Error::Io);
 		w(&0x46546C67u32.to_le_bytes())?; // magic "glTF"
 		w(&2u32.to_le_bytes())?; // version 2
 		w(&(total as u32).to_le_bytes())?;
@@ -749,7 +749,7 @@ impl Scene2D {
 		polylines_to_svg(&mut svg, &self.edges_hidden, "#bbb", &format!("{dash_len:.4},{dash_gap:.4}"), Some(hidden_sw));
 
 		svg.push_str("</svg>\n");
-		writer.write_all(svg.as_bytes()).map_err(|_| super::error::Error::SvgExportFailed)
+		writer.write_all(svg.as_bytes()).map_err(super::error::Error::Io)
 	}
 }
 
@@ -822,11 +822,11 @@ impl Scene2D {
 		let ty = -(layout.vy as f32) * s + off_y as f32;
 		let transform = Transform::from_row(s, 0.0, 0.0, -s, tx, ty);
 
-		let mut pixmap = Pixmap::new(width as u32, height as u32).ok_or(super::error::Error::PngExportFailed)?;
+		let mut pixmap = Pixmap::new(width as u32, height as u32).ok_or_else(|| super::error::Error::Validation(format!("png: invalid pixmap size {width}x{height}")))?;
 		self.render_to_pixmap(&mut pixmap, transform, layout.stroke_width as f32, layout.hidden_stroke_width as f32, layout.dash_len as f32, layout.dash_gap as f32, layout.anti_alias);
 
-		let png_bytes = pixmap.encode_png().map_err(|_| super::error::Error::PngExportFailed)?;
-		writer.write_all(&png_bytes).map_err(|_| super::error::Error::PngExportFailed)
+		let png_bytes = pixmap.encode_png().map_err(|e| super::error::Error::Io(std::io::Error::other(e.to_string())))?;
+		writer.write_all(&png_bytes).map_err(super::error::Error::Io)
 	}
 
 	/// Render this scene's triangles + edges into an existing pixmap with the
@@ -969,7 +969,7 @@ impl Mesh {
 		let pps = (panel_w.min(panel_h) as f64) / (2.0 * h);
 
 		// 背景は透過。下流で任意色に composite できる。
-		let mut pixmap = Pixmap::new(IMG_SIZE, IMG_SIZE).ok_or(super::error::Error::PngExportFailed)?;
+		let mut pixmap = Pixmap::new(IMG_SIZE, IMG_SIZE).ok_or_else(|| super::error::Error::Validation(format!("png: invalid pixmap size {IMG_SIZE}x{IMG_SIZE}")))?;
 
 		// Per-panel stroke widths in scene units (tiny-skia transform scales them to px).
 		let stroke_px = 1.5_f32;
@@ -1022,8 +1022,8 @@ impl Mesh {
 			draw_text(&mut pixmap, &label, center_x - text_w / 2.0, boundary_y - LABEL_SIZE - 4.0, LABEL_SIZE, 0x1f3a8a);
 		}
 
-		let png_bytes = pixmap.encode_png().map_err(|_| super::error::Error::PngExportFailed)?;
-		writer.write_all(&png_bytes).map_err(|_| super::error::Error::PngExportFailed)
+		let png_bytes = pixmap.encode_png().map_err(|e| super::error::Error::Io(std::io::Error::other(e.to_string())))?;
+		writer.write_all(&png_bytes).map_err(super::error::Error::Io)
 	}
 }
 

--- a/src/occt/edge.rs
+++ b/src/occt/edge.rs
@@ -20,7 +20,7 @@ impl Edge {
 	/// in practice but serves as a defensive marker.
 	pub(crate) fn try_from_ffi(inner: cxx::UniquePtr<ffi::TopoDS_Edge>, msg: String) -> Result<Self, Error> {
 		if inner.is_null() {
-			Err(Error::InvalidEdge(msg))
+			Err(Error::Edge(msg))
 		} else {
 			Ok(Edge { inner })
 		}
@@ -96,14 +96,14 @@ impl EdgeStruct for Edge {
 		let coords: Vec<f64> = points.into_iter().flat_map(|p| [p.x, p.y, p.z]).collect();
 		let cxx_vec = ffi::make_polygon_edges(&coords);
 		// C++ 側は失敗時に空ベクタを返す (null ではない)。点数不足や
-		// OCCT の MakePolygon 失敗で empty になるので、それを InvalidEdge に変換。
+		// OCCT の MakePolygon 失敗で empty になるので、それを Error::Edge に変換。
 		if cxx_vec.is_empty() {
-			return Err(Error::InvalidEdge(format!("polygon: construction failed (point count = {}, need ≥ 3 non-degenerate)", coords.len() / 3)));
+			return Err(Error::Edge(format!("polygon: construction failed (point count = {}, need ≥ 3 non-degenerate)", coords.len() / 3)));
 		}
 		// CxxVector<TopoDS_Edge> → Vec<Edge>: pull each element out into a
 		// UniquePtr<TopoDS_Edge> via deep_copy_edge so we own the topology.
 		// deep_copy_edge は既に有効な edge の複製なので null にはならない想定、
-		// 万一返った場合は InvalidEdge で failfast する。
+		// 万一返った場合は Error::Edge で failfast する。
 		cxx_vec.iter().map(|e| Edge::try_from_ffi(ffi::deep_copy_edge(e), "polygon: deep_copy_edge returned null".into())).collect()
 	}
 
@@ -131,17 +131,17 @@ impl EdgeStruct for Edge {
 			BSplineEnd::NotAKnot | BSplineEnd::Clamped { .. } => 2,
 		};
 		if pts.len() < min_required {
-			return Err(Error::InvalidEdge(format!("bspline: need ≥{} points for {:?}, got {}", min_required, end, pts.len())));
+			return Err(Error::Edge(format!("bspline: need ≥{} points for {:?}, got {}", min_required, end, pts.len())));
 		}
 
 		// Periodic では先頭と末尾が一致してはならない。OCCT は周期性を基底関数に
 		// 組み込むので、ユーザーが点を重複させると行列が特異化して失敗する。
-		// 自動除去はせず InvalidEdge で誤用を明示する (AGENTS.md "誤解 vs 手間" 方針)。
+		// 自動除去はせず Error::Edge で誤用を明示する (AGENTS.md "誤解 vs 手間" 方針)。
 		if matches!(end, BSplineEnd::Periodic) {
 			let first = pts.first().expect("checked above");
 			let last = pts.last().expect("checked above");
 			if first == last {
-				return Err(Error::InvalidEdge(format!("bspline(Periodic): first and last points coincide ({first:?}); periodicity is encoded in the basis, do not duplicate the closing point")));
+				return Err(Error::Edge(format!("bspline(Periodic): first and last points coincide ({first:?}); periodicity is encoded in the basis, do not duplicate the closing point")));
 			}
 		}
 

--- a/src/occt/io.rs
+++ b/src/occt/io.rs
@@ -75,7 +75,7 @@ fn write_color_trailer<W: Write>(compound: &CompoundShape, writer: &mut W) -> Re
 		out.extend_from_slice(&g.to_le_bytes());
 		out.extend_from_slice(&b.to_le_bytes());
 	}
-	writer.write_all(&out).map_err(|_| Error::BrepWriteFailed)
+	writer.write_all(&out).map_err(Error::Io)
 }
 
 // ==================== Reader / writer / mesh helpers ====================
@@ -92,7 +92,7 @@ pub(super) fn read_step<R: Read>(reader: &mut R) -> Result<Vec<Solid>, Error> {
 		let mut rgb: Vec<f32> = Default::default();
 		let inner = ffi::read_step_color_stream(&mut rust_reader, &mut ids, &mut rgb);
 		if inner.is_null() {
-			return Err(Error::StepReadFailed);
+			return Err(Error::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, "step: reader produced no shape (invalid or corrupted input)")));
 		}
 		let colormap: std::collections::HashMap<u64, Color> = ids.into_iter().zip(rgb.chunks_exact(3)).map(|(id, c)| (id, Color { r: c[0], g: c[1], b: c[2] })).collect();
 		Ok(CompoundShape::from_raw(inner, colormap, Default::default()).decompose())
@@ -102,7 +102,7 @@ pub(super) fn read_step<R: Read>(reader: &mut R) -> Result<Vec<Solid>, Error> {
 		let mut rust_reader = RustReader::from_ref(reader);
 		let inner = ffi::read_step_stream(&mut rust_reader);
 		if inner.is_null() {
-			return Err(Error::StepReadFailed);
+			return Err(Error::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, "step: reader produced no shape (invalid or corrupted input)")));
 		}
 		Ok(CompoundShape::from_raw(inner, Default::default()).decompose())
 	}
@@ -112,13 +112,13 @@ pub(super) fn read_brep<R: Read>(reader: &mut R) -> Result<Vec<Solid>, Error> {
 	// Buffered whole: `BinTools::Read` seeks backwards to resolve shared sub-shape
 	// references, so it cannot run off a sequential stream.
 	let mut buf = Vec::new();
-	reader.read_to_end(&mut buf).map_err(|_| Error::BrepReadFailed)?;
+	reader.read_to_end(&mut buf)?;
 
 	// Payload length — where a trailer would begin. Unwritten, and unread, on null.
 	let mut consumed = 0usize;
 	let inner = ffi::read_brep_stream(&buf, &mut consumed);
 	if inner.is_null() {
-		return Err(Error::BrepReadFailed);
+		return Err(Error::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, "brep: reader produced no shape (invalid or corrupted input)")));
 	}
 
 	#[cfg(feature = "color")]
@@ -152,7 +152,7 @@ pub(super) fn write_step<'a, W: Write>(solids: impl IntoIterator<Item = &'a Soli
 		if ffi::write_step_color_stream(compound.inner(), &ids, &rgb, &mut rust_writer) {
 			Ok(())
 		} else {
-			Err(Error::StepWriteFailed)
+			Err(Error::Io(std::io::Error::other("step: OCCT writer reported failure")))
 		}
 	}
 	#[cfg(not(feature = "color"))]
@@ -161,7 +161,7 @@ pub(super) fn write_step<'a, W: Write>(solids: impl IntoIterator<Item = &'a Soli
 		if ffi::write_step_stream(compound.inner(), &mut rust_writer) {
 			Ok(())
 		} else {
-			Err(Error::StepWriteFailed)
+			Err(Error::Io(std::io::Error::other("step: OCCT writer reported failure")))
 		}
 	}
 }
@@ -172,7 +172,7 @@ pub(super) fn write_brep<'a, W: Write>(solids: impl IntoIterator<Item = &'a Soli
 		// Scoped: the streambuf flushes on drop, so the payload lands before the trailer.
 		let mut rust_writer = RustWriter::from_ref(writer);
 		if !ffi::write_brep_stream(compound.inner(), &mut rust_writer) {
-			return Err(Error::BrepWriteFailed);
+			return Err(Error::Io(std::io::Error::other("brep: OCCT writer reported failure")));
 		}
 	}
 	#[cfg(feature = "color")]
@@ -206,7 +206,7 @@ pub(super) fn mesh<'a>(solids: impl IntoIterator<Item = &'a Solid>, options: cra
 	let compound = CompoundShape::new(solids);
 	let data = ffi::mesh_shape(compound.inner(), options.deflection_linear, options.deflection_angular, options.relative_linear);
 	if !data.success {
-		return Err(Error::TriangulationFailed);
+		return Err(Error::Tesselation);
 	}
 	let vertex_count = data.vertices.len() / 3;
 	let vertices: Vec<DVec3> = (0..vertex_count).map(|i| DVec3::new(data.vertices[i * 3], data.vertices[i * 3 + 1], data.vertices[i * 3 + 2])).collect();

--- a/src/occt/solid.rs
+++ b/src/occt/solid.rs
@@ -255,7 +255,7 @@ impl SolidStruct for Solid {
 		}
 		let shape = ffi::make_extrude(&profile_vec, dir.x, dir.y, dir.z);
 		if shape.is_null() {
-			return Err(Error::ExtrudeFailed);
+			return Err(Error::Extrude);
 		}
 		Ok(Solid::new(
 			shape,
@@ -275,7 +275,7 @@ impl SolidStruct for Solid {
 		let mut history: Vec<u64> = Default::default();
 		let shape = ffi::builder_thick_solid(&self.inner, &face_vec, thickness, &mut history);
 		if shape.is_null() {
-			return Err(Error::ShellFailed);
+			return Err(Error::Shell(format!("thickness={thickness} incompatible with the geometry, or self-intersecting offset ({} open face(s))", face_vec.len())));
 		}
 		#[cfg(feature = "color")]
 		let colormap = self.remap_colormap(&shape, &history);
@@ -297,7 +297,7 @@ impl SolidStruct for Solid {
 		let mut history: Vec<u64> = Default::default();
 		let shape = ffi::builder_fillet(&self.inner, &edge_vec, radius, &mut history);
 		if shape.is_null() {
-			return Err(Error::FilletFailed);
+			return Err(Error::Fillet(format!("radius={radius} does not fit the local geometry on {} edge(s)", edge_vec.len())));
 		}
 		#[cfg(feature = "color")]
 		let colormap = self.remap_colormap(&shape, &history);
@@ -317,7 +317,7 @@ impl SolidStruct for Solid {
 		let mut history: Vec<u64> = Default::default();
 		let shape = ffi::builder_chamfer(&self.inner, &edge_vec, distance, &mut history);
 		if shape.is_null() {
-			return Err(Error::ChamferFailed);
+			return Err(Error::Chamfer(format!("distance={distance} does not fit the local geometry on {} edge(s)", edge_vec.len())));
 		}
 		#[cfg(feature = "color")]
 		let colormap = self.remap_colormap(&shape, &history);
@@ -343,7 +343,7 @@ impl SolidStruct for Solid {
 		let (kind, ux, uy, uz, aux_vec) = encode_orient(orient);
 		let shape = ffi::make_pipe_shell(&profile_vec, &spine_vec, kind, ux, uy, uz, &aux_vec);
 		if shape.is_null() {
-			return Err(Error::SweepFailed);
+			return Err(Error::Sweep(format!("profile ({} edge(s)) could not be swept along the spine ({} edge(s))", profile_vec.len(), spine_vec.len())));
 		}
 		Ok(Solid::new(
 			shape,
@@ -374,18 +374,18 @@ impl SolidStruct for Solid {
 				count += 1;
 			}
 			if count == 0 {
-				return Err(Error::LoftFailed(format!("loft: section {} is empty (each section must contain ≥1 edge)", section_count)));
+				return Err(Error::Loft(format!("loft: section {} is empty (each section must contain ≥1 edge)", section_count)));
 			}
 			section_count += 1;
 		}
 
 		if section_count < 2 {
-			return Err(Error::LoftFailed(format!("loft: need ≥2 sections, got {} (a single section has no thickness to skin across)", section_count)));
+			return Err(Error::Loft(format!("loft: need ≥2 sections, got {} (a single section has no thickness to skin across)", section_count)));
 		}
 
 		let shape = ffi::make_loft(&all_edges, ruled);
 		if shape.is_null() {
-			return Err(Error::LoftFailed(format!(
+			return Err(Error::Loft(format!(
 				"loft: OCCT BRepOffsetAPI_ThruSections failed (sections={}, ruled={}). \
 				 Check that each section forms a valid closed wire and sections are not coplanar.",
 				section_count, ruled
@@ -412,11 +412,11 @@ impl SolidStruct for Solid {
 			count += 1;
 		}
 		if count == 0 {
-			return Err(Error::SewFailed("sew: no faces given (need a face set forming one closed shell)".into()));
+			return Err(Error::Sew("sew: no faces given (need a face set forming one closed shell)".into()));
 		}
 		let shape = ffi::make_sewn_solid(&face_vec, tolerance);
 		if shape.is_null() {
-			return Err(Error::SewFailed(format!(
+			return Err(Error::Sew(format!(
 				"sew: {} faces do not form exactly one closed shell within tolerance {} \
 				 (gaps, overlaps, multiple shells, or stray faces)",
 				count, tolerance
@@ -435,7 +435,7 @@ impl SolidStruct for Solid {
 	fn offset_surface(&self, offset: f64, tolerance: f64) -> Result<Self, Error> {
 		let shape = ffi::make_offset_shape(&self.inner, offset, tolerance);
 		if shape.is_null() {
-			return Err(Error::OffsetFailed(format!(
+			return Err(Error::Offset(format!(
 				"offset_surface: OCCT BRepOffsetAPI_MakeOffsetShape failed (offset={}, tolerance={}). \
 				 Thin walls/slots whose local thickness is ≤ 2|offset| self-intersect and are rejected.",
 				offset, tolerance
@@ -453,7 +453,7 @@ impl SolidStruct for Solid {
 
 	fn bspline(u: usize, v: usize, u_periodic: bool, point: impl Fn(usize, usize) -> DVec3) -> Result<Self, Error> {
 		if u < 2 || v < 3 {
-			return Err(Error::BsplineFailed(format!("grid must be at least 2x3 (u={}, v={})", u, v)));
+			return Err(Error::Bspline(format!("grid must be at least 2x3 (u={}, v={})", u, v)));
 		}
 
 		let mut coords = Vec::with_capacity(3 * u * v);
@@ -468,7 +468,7 @@ impl SolidStruct for Solid {
 
 		let shape = ffi::make_bspline_solid(&coords, u as u32, v as u32, u_periodic);
 		if shape.is_null() {
-			return Err(Error::BsplineFailed(format!("OCCT construction failed (u={}, v={}, u_periodic={})", u, v, u_periodic)));
+			return Err(Error::Bspline(format!("OCCT construction failed (u={}, v={}, u_periodic={})", u, v, u_periodic)));
 		}
 		Ok(Solid::new(
 			shape,
@@ -484,7 +484,7 @@ impl SolidStruct for Solid {
 		let mut history: Vec<u64> = Default::default();
 		let inner = ffi::builder_clean(&self.inner, &mut history);
 		if inner.is_null() {
-			return Err(Error::CleanFailed);
+			return Err(Error::Clean);
 		}
 		#[cfg(feature = "color")]
 		let colormap = self.remap_colormap(&inner, &history);
@@ -523,7 +523,7 @@ impl SolidStruct for Solid {
 		// CellsBuilder ベースの一括評価。DIMACS-flat DNF (`clauses`) を C++ 側に渡す。
 		let (solids, clauses) = (b.solids(), b.clauses());
 		if solids.is_empty() || clauses.is_empty() {
-			return Err(Error::OneFailed(0));
+			return Err(Error::NotOne(0));
 		}
 		debug_assert!(clauses.last() == Some(&0), "clauses must be 0-terminated");
 
@@ -534,7 +534,7 @@ impl SolidStruct for Solid {
 		let mut history: Vec<u64> = Default::default();
 		let inner = ffi::builder_cells(&solid_vec, clauses, &mut history);
 		if inner.is_null() {
-			return Err(Error::BooleanOperationFailed);
+			return Err(Error::Boolean);
 		}
 
 		#[cfg(feature = "color")]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -266,7 +266,7 @@ pub enum BSplineEnd {
 	/// (position + tangent + curvature all match at the wrap-around).
 	/// The first data point must NOT be repeated at the end — periodicity
 	/// is encoded in the basis function structure. Passing a duplicated
-	/// endpoint yields [`Error::InvalidEdge`].
+	/// endpoint yields [`Error::Edge`].
 	///
 	/// Requires ≥ 3 distinct points. The most common choice for closed
 	/// profile curves (plasma poloidal sections, screw threads, gear teeth)
@@ -305,7 +305,7 @@ pub enum BSplineEnd {
 ///
 /// All constructors return `Result<..., Error>`. Invalid inputs (degenerate
 /// geometry, zero/negative radius, collinear arc points, etc.) yield
-/// `Error::InvalidEdge(String)` with a message that identifies the failing
+/// `Error::Edge(String)` with a message that identifies the failing
 /// constructor and the offending parameters.
 pub trait EdgeStruct: Sized + Clone + Transform {
 	/// Stable, backend-defined identity for this edge. Two `Edge` values
@@ -354,7 +354,7 @@ pub trait EdgeStruct: Sized + Clone + Transform {
 	/// constituent edges in order. The polygon is **always closed**: the
 	/// last point is automatically connected back to the first.
 	// 非平面の点列も受理する (検証しない) — `Solid::sweep` で face 化に失敗
-	// したとき `Error::SweepFailed` で気付ける想定なので、入力側での事前検査は省略。
+	// したとき `Error::Sweep` で気付ける想定なので、入力側での事前検査は省略。
 	fn polygon<'a>(points: impl IntoIterator<Item = &'a DVec3>) -> Result<Vec<Self>, Error>;
 
 	/// Closed circle of radius `r` centered at the world origin, lying in
@@ -368,14 +368,14 @@ pub trait EdgeStruct: Sized + Clone + Transform {
 	/// edge into place rather than relying on the implicit choice.
 	fn circle(radius: f64, axis: DVec3) -> Result<Self, Error>;
 
-	/// Straight line segment from `a` to `b`. Fails with `InvalidEdge` if
+	/// Straight line segment from `a` to `b`. Fails with `Error::Edge` if
 	/// `a == b` (zero-length segment).
 	fn line(a: DVec3, b: DVec3) -> Result<Self, Error>;
 
 	/// Circular arc through three points: start, mid, end. The unique circle
 	/// passing through the three points defines the arc; `mid` disambiguates
 	/// which of the two possible arcs is returned (the one passing through
-	/// `mid`). Fails with `InvalidEdge` if `mid` is collinear with `start`
+	/// `mid`). Fails with `Error::Edge` if `mid` is collinear with `start`
 	/// and `end`, or if any pair of points coincides.
 	fn arc_3pts(start: DVec3, mid: DVec3, end: DVec3) -> Result<Self, Error>;
 
@@ -395,7 +395,7 @@ pub trait EdgeStruct: Sized + Clone + Transform {
 	///
 	/// # Errors
 	///
-	/// Returns [`Error::InvalidEdge`] if:
+	/// Returns [`Error::Edge`] if:
 	/// - point count is below the minimum (≥3 for `Periodic`, ≥2 otherwise)
 	/// - `BSplineEnd::Periodic` is requested but the first and last points
 	///   coincide (periodicity is encoded in the basis; do not duplicate)
@@ -519,7 +519,7 @@ pub trait SolidStruct: Sized + Clone + Transform {
 
 	/// Heal/regularize this solid (fuse coplanar faces, drop micro-edges,
 	/// repair small inconsistencies). Wraps `ShapeUpgrade_UnifySameDomain`
-	/// + cleanup. Failure is reported as `Error::CleanFailed`.
+	/// + cleanup. Failure is reported as `Error::Clean`.
 	fn clean(&self) -> Result<Self, Error>;
 	/// Extrude a closed profile wire along a direction vector to form a solid.
 	///
@@ -553,7 +553,7 @@ pub trait SolidStruct: Sized + Clone + Transform {
 	/// Round the given edges of `self` with a uniform radius. Edges are
 	/// typically selected via `self.iter_edge().filter(...)`.
 	///
-	/// Wraps `BRepFilletAPI_MakeFillet`. Fails (`Error::FilletFailed`) if
+	/// Wraps `BRepFilletAPI_MakeFillet`. Fails (`Error::Fillet`) if
 	/// the radius is too large for the local geometry, if tangent
 	/// discontinuity prevents OCCT from building the fillet surface, or
 	/// if an edge not belonging to `self` is passed.
@@ -569,7 +569,7 @@ pub trait SolidStruct: Sized + Clone + Transform {
 	///
 	/// Wraps `BRepFilletAPI_MakeChamfer`. The chamfer plane is symmetric —
 	/// the same `distance` is taken off along each of the two faces
-	/// adjacent to the edge. Fails (`Error::ChamferFailed`) under the same
+	/// adjacent to the edge. Fails (`Error::Chamfer`) under the same
 	/// conditions as `fillet_edges`.
 	///
 	/// Empty `edges` is a no-op and returns a clone of `self`.
@@ -629,7 +629,7 @@ pub trait SolidStruct: Sized + Clone + Transform {
 	/// automatically so the enclosed volume is positive regardless of the
 	/// input faces' orientations).
 	///
-	/// Fails with [`Error::SewFailed`] when the faces leave gaps wider than
+	/// Fails with [`Error::Sew`] when the faces leave gaps wider than
 	/// `tolerance`, overlap, form multiple disconnected shells, or include
 	/// stray faces that belong to no closed shell.
 	fn sew<'a>(faces: impl IntoIterator<Item = &'a Self::Face>, tolerance: f64) -> Result<Self, Error>
@@ -651,7 +651,7 @@ pub trait SolidStruct: Sized + Clone + Transform {
 	/// magnitude reaches half the local wall thickness makes opposing offset
 	/// faces cross, and an outward offset pinches shut inside narrow concave
 	/// slots ≤ `2·offset` wide. OCCT rejects the self-intersecting result and
-	/// this method returns [`Error::OffsetFailed`] — reduce `offset` or
+	/// this method returns [`Error::Offset`] — reduce `offset` or
 	/// remove/split the thin feature first.
 	fn offset_surface(&self, offset: f64, tolerance: f64) -> Result<Self, Error>;
 

--- a/tests/solid_boolean.rs
+++ b/tests/solid_boolean.rs
@@ -129,12 +129,12 @@ fn test_operator_overloads() {
 	let i: Solid = (&a * &b).build().expect("a * b should yield one solid");
 	println!("a * b (intersect): volume = {:.4}", i.volume());
 
-	// 非交差での intersect → build_vec で 0 個、build で OneFailed(0)
+	// 非交差での intersect → build_vec で 0 個、build で NotOne(0)
 	let far = Solid::cube(DVec3::ZERO, DVec3::ONE).translate(DVec3::new(100.0, 0.0, 0.0));
 	match (&a * &far).build() {
-		Err(e @ cadrum::Error::OneFailed(0)) => println!("a * far (disjoint) -> {:?}", e),
-		Err(e) => panic!("expected OneFailed(0), got {:?}", e),
-		Ok(_) => panic!("expected OneFailed(0), got Ok"),
+		Err(e @ cadrum::Error::NotOne(0)) => println!("a * far (disjoint) -> {:?}", e),
+		Err(e) => panic!("expected NotOne(0), got {:?}", e),
+		Ok(_) => panic!("expected NotOne(0), got Ok"),
 	}
 }
 
@@ -151,8 +151,8 @@ fn test_singleton_build() {
 fn test_empty_returns_error() {
 	let solids: Vec<Solid> = Vec::new();
 	match solids.iter().map(Boolean::from).reduce(|x, y| x + y).unwrap_or_else(Boolean::default).build() {
-		Err(cadrum::Error::OneFailed(0)) => {}
-		other => panic!("expected OneFailed(0), got {:?}", other.is_ok()),
+		Err(cadrum::Error::NotOne(0)) => {}
+		other => panic!("expected NotOne(0), got {:?}", other.is_ok()),
 	}
 }
 

--- a/tests/solid_chamfer.rs
+++ b/tests/solid_chamfer.rs
@@ -57,5 +57,5 @@ fn test_chamfer_distance_too_large_returns_err() {
 	let edges: Vec<_> = cube.iter_edge().collect();
 	// d = 5 > a/2 = 1 → geometrically impossible; OCCT reports not-done.
 	let err = cube.chamfer_edges(5.0, edges).err().expect("oversized distance must fail");
-	assert!(matches!(err, Error::ChamferFailed), "expected ChamferFailed, got {:?}", err);
+	assert!(matches!(err, Error::Chamfer(_)), "expected Error::Chamfer, got {:?}", err);
 }

--- a/tests/solid_fillet.rs
+++ b/tests/solid_fillet.rs
@@ -55,5 +55,5 @@ fn test_fillet_radius_too_large_returns_err() {
 	let edges: Vec<_> = cube.iter_edge().collect();
 	// r = 5 > a/2 = 1 → geometrically impossible; OCCT reports not-done.
 	let err = cube.fillet_edges(5.0, edges).err().expect("oversized radius must fail");
-	assert!(matches!(err, Error::FilletFailed), "expected FilletFailed, got {:?}", err);
+	assert!(matches!(err, Error::Fillet(_)), "expected Error::Fillet, got {:?}", err);
 }

--- a/tests/solid_loft.rs
+++ b/tests/solid_loft.rs
@@ -60,10 +60,10 @@ fn test_loft_02_single_section_returns_loft_failed() {
 
 	let err = result.err().expect("single section must return Err");
 	match err {
-		Error::LoftFailed(msg) => {
+		Error::Loft(msg) => {
 			assert!(msg.contains("≥2") || msg.contains(">=2") || msg.contains("got 1"), "error message should mention min section count, got: {}", msg);
 		}
-		other => panic!("expected Error::LoftFailed, got {:?}", other),
+		other => panic!("expected Error::Loft, got {:?}", other),
 	}
 }
 
@@ -79,10 +79,10 @@ fn test_loft_03_empty_section_returns_loft_failed() {
 
 	let err = result.err().expect("empty section must return Err");
 	match err {
-		Error::LoftFailed(msg) => {
+		Error::Loft(msg) => {
 			assert!(msg.contains("empty"), "error message should mention empty section, got: {}", msg);
 		}
-		other => panic!("expected Error::LoftFailed, got {:?}", other),
+		other => panic!("expected Error::Loft, got {:?}", other),
 	}
 }
 

--- a/tests/solid_offset_surface.rs
+++ b/tests/solid_offset_surface.rs
@@ -65,8 +65,8 @@ fn test_offset_04_thin_plate_inward_returns_offset_failed() {
 
 	let result = plate.offset_surface(-0.5, 1.0e-6);
 	match result {
-		Err(Error::OffsetFailed(msg)) => assert!(msg.contains("offset"), "got: {}", msg),
-		Err(other) => panic!("expected Error::OffsetFailed, got {:?}", other),
+		Err(Error::Offset(msg)) => assert!(msg.contains("offset"), "got: {}", msg),
+		Err(other) => panic!("expected Error::Offset, got {:?}", other),
 		Ok(s) => panic!("thin-plate inward offset must fail, but produced a solid with volume {:.6}", s.volume()),
 	}
 }

--- a/tests/solid_sew.rs
+++ b/tests/solid_sew.rs
@@ -34,8 +34,8 @@ fn test_sew_02_open_shell_returns_sew_failed() {
 
 	let err = Solid::sew(five, 1.0e-6).err().expect("5 of 6 faces must not sew into a solid");
 	match err {
-		Error::SewFailed(msg) => assert!(msg.contains("closed shell"), "error message should mention closed shell, got: {}", msg),
-		other => panic!("expected Error::SewFailed, got {:?}", other),
+		Error::Sew(msg) => assert!(msg.contains("closed shell"), "error message should mention closed shell, got: {}", msg),
+		other => panic!("expected Error::Sew, got {:?}", other),
 	}
 }
 
@@ -46,7 +46,7 @@ fn test_sew_03_empty_input_returns_sew_failed() {
 	let none: Vec<&Face> = vec![];
 	let err = Solid::sew(none, 1.0e-6).err().expect("empty face set must return Err");
 	match err {
-		Error::SewFailed(msg) => assert!(msg.contains("no faces"), "error message should mention empty input, got: {}", msg),
-		other => panic!("expected Error::SewFailed, got {:?}", other),
+		Error::Sew(msg) => assert!(msg.contains("no faces"), "error message should mention empty input, got: {}", msg),
+		other => panic!("expected Error::Sew, got {:?}", other),
 	}
 }

--- a/tests/solid_sweep.rs
+++ b/tests/solid_sweep.rs
@@ -35,7 +35,7 @@ fn square_profile(spine: &Edge) -> Result<Vec<Edge>, Error> {
 }
 
 /// spine も aux も periodic B-spline 1 本のまま `ProfileOrient::Auxiliary` で sweep。
-/// 素の OCCT 8.0.1 ではこの組み合わせは SweepFailed になるか破綻形状を返すので、
+/// 素の OCCT 8.0.1 ではこの組み合わせは Error::Sweep になるか破綻形状を返すので、
 /// patches/pr1.patch (fix D) と patches/pr2.patch (fix A) が効いていることの回帰テスト。
 fn closed_auxiliary_sweep() -> Result<Solid, Error> {
 	let spine = Edge::bspline(&sample(0, CURVE_STEPS), BSplineEnd::Periodic)?;


### PR DESCRIPTION
## What

`Error` の 25 バリアントのうち大半は、呼び出した関数名を複製しているだけだった (`fillet_edges()` を呼んだ人は `FilletFailed` から新情報を得ない)。書式ごとの export エラー (Png/Stl/Gltf/Svg) も実体はすべて `write_all` 失敗で、形式に依存していなかった。`Unknown` と `HelixFailed` は構築箇所ゼロ。

16 バリアントに整理し、`Display` と全 71 箇所のエラー生成元を追従させた。

## 旧 → 新

| 旧 | 新 |
|---|---|
| `InvalidColor` / `PngExportFailed` (`Pixmap::new` の寸法不正) | `Validation(String)` |
| `StlWriteFailed` ×5 / `GltfWriteFailed` / `SvgExportFailed` / `PngExportFailed` / `StepRead` / `StepWrite` / `BrepRead` / `BrepWriteFailed` | `Io(std::io::Error)` |
| `TriangulationFailed` | `Tesselation` |
| `BooleanOperationFailed` | `Boolean` |
| `OneFailed(usize)` | `NotOne(usize)` |
| `InvalidEdge(String)` | `Edge(String)` |
| `CleanFailed` / `ExtrudeFailed` | `Clean` / `Extrude` |
| `SweepFailed` / `ShellFailed` / `FilletFailed` / `ChamferFailed` (unit だった) | `Sweep` / `Shell` / `Fillet` / `Chamfer` (`String` 付き) |
| `LoftFailed` / `SewFailed` / `OffsetFailed` / `BsplineFailed` | `Loft` / `Sew` / `Offset` / `Bspline` |
| `Unknown(String)` / `HelixFailed` | 削除 (未使用) |

## 設計上の判断

- **`Io` と `Validation` を型で分ける** — 呼び出し元にとって意味のある分岐は「リトライしていいか」。転送失敗は対象、入力不正は対象外。`ErrorKind` は `#[non_exhaustive]` なので `.kind()` 判定に落とすと網羅マッチが書けない。
- **`impl From<std::io::Error> for Error` を追加** — `mesh.rs` の `write_all` は `.map_err(|_| Error::StlWriteFailed)?` が `?` だけに縮む。従来 `map_err(|_| ...)` が `io::Error` を捨てていたので、ディスクフル・パイプ切断の真因が呼び出し元に届くようになる。
- **FFI 境界では合成 `io::Error` を包む** — `ffi.rs:225,231` の `unwrap_or(0)` が実 `io::Error` を破棄するため、STEP/BRep 経路では原因が取れない。読みは `ErrorKind::InvalidData`、書きは `io::Error::other`。`ffi.rs` 自体は変更していない。
- **unit → `String` になった 4 バリアント**には新しく診断文を書いた。doc コメントに書いてあった原因候補が実行時に出るようになる:
  ```rust
  Error::Fillet(format!("radius={radius} does not fit the local geometry on {} edge(s)", edge_vec.len()))
  ```

## Breaking change

`Error` は `pub` なので、バリアント名を参照している下流コードは壊れる。`#[non_exhaustive]` は付けていない。

## 検証

`cargo fmt --check` / `cargo clippy --all-targets` / `cargo test` (86 passed, 0 failed)。feature 分岐内にもエラー生成元があるため、既定・`--no-default-features`・`color` 単独・`png` 単独の 4 通りでビルドを確認。

注: この crate で `--all-features` は使えない (`pure` が `occt` モジュールを cfg で落とす)。