### PR TITLE
Use curvilinear equivalence in the Auxiliary guide law

### DIFF
--- a/src/ffi.cpp
+++ b/src/ffi.cpp
@@ -1492,7 +1492,7 @@ std::unique_ptr<TopoDS_Shape> make_pipe_shell(
                 BRepBuilderAPI_MakeWire auxMaker;
                 for (const auto& e : aux_spine_edges) auxMaker.Add(e);
                 if (!auxMaker.IsDone()) return nullptr;
-                shell.SetMode(auxMaker.Wire(), false);
+                shell.SetMode(auxMaker.Wire(), true);
                 break;
             }
             default: {


### PR DESCRIPTION
## Problem

`ProfileOrient::Auxiliary` maps the guide wire to the spine with `BRepOffsetAPI_MakePipeShell::SetMode(aux, false)` — correspondence by parameter. In practice this makes the guide law fragile:

- A **periodic (closed) B-spline spine always fails** the sweep.
- Closing the loop as an open curve with a duplicated endpoint works for a circle, but on real free-form closed curves (stellarator coil centerlines, 32 loops x 48-90 points) it fails non-deterministically and can return garbage volumes (1e12 m^3).

## Fix

Pass `true` — correspondence by curvilinear abscissa (relative arc length), the standard robust pairing for guide-controlled sweeps. One line in `ffi.cpp`, plus a comment.

## Validation (downstream, alphastell coil sweep)

- 32 stellarator coil loops x {24, 48, 90} points x {open, periodic} = 192 sweeps: **all succeed**, including periodic closed splines that previously always failed.
- Circle spine with concentric guide: swept volume matches area x length to **-0.004 %** (n=48).
- Coil conductors (0.40 x 0.50 m rectangle, guide = LCFS-normal offset curve): volumes within -6..-4 % of area x length, sections stay normal to the spine; the Up-law workaround this replaces was -13..-40 % off.

No cadrum tests exercise Auxiliary, so no test updates are required.