### PR TITLE
Simplify the markdown example generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,10 +177,10 @@ fn main() -> Result<(), cadrum::Error> {
 }
 
 ```
+
 Output: [01_primitives.png](https://lzpel.github.io/cadrum/01_primitives.png) | [01_primitives.step](https://lzpel.github.io/cadrum/01_primitives.step) | [01_primitives.glb](https://lzpel.github.io/cadrum/01_primitives.glb) | [01_primitives.stl](https://lzpel.github.io/cadrum/01_primitives.stl) | [01_primitives.svg](https://lzpel.github.io/cadrum/01_primitives.svg)
 
-<div align=center><img src='https://lzpel.github.io/cadrum/01_primitives.svg' alt='01_primitives' width='360'/></div>
-
+<img src='https://lzpel.github.io/cadrum/01_primitives.svg' alt='01_primitives' width='360'/>
 
 #### Write read
 
@@ -239,10 +239,10 @@ fn main() -> Result<(), cadrum::Error> {
 }
 
 ```
+
 Output: [02_write_read.png](https://lzpel.github.io/cadrum/02_write_read.png) | [02_write_read.step](https://lzpel.github.io/cadrum/02_write_read.step) | [02_write_read.glb](https://lzpel.github.io/cadrum/02_write_read.glb) | [02_write_read.brep](https://lzpel.github.io/cadrum/02_write_read.brep) | [02_write_read.stl](https://lzpel.github.io/cadrum/02_write_read.stl) | [02_write_read.svg](https://lzpel.github.io/cadrum/02_write_read.svg)
 
-<div align=center><img src='https://lzpel.github.io/cadrum/02_write_read.svg' alt='02_write_read' width='360'/></div>
-
+<img src='https://lzpel.github.io/cadrum/02_write_read.svg' alt='02_write_read' width='360'/>
 
 #### Transform
 
@@ -290,10 +290,10 @@ fn main() -> Result<(), cadrum::Error> {
 }
 
 ```
+
 Output: [03_transform.png](https://lzpel.github.io/cadrum/03_transform.png) | [03_transform.step](https://lzpel.github.io/cadrum/03_transform.step) | [03_transform.glb](https://lzpel.github.io/cadrum/03_transform.glb) | [03_transform.stl](https://lzpel.github.io/cadrum/03_transform.stl) | [03_transform.svg](https://lzpel.github.io/cadrum/03_transform.svg)
 
-<div align=center><img src='https://lzpel.github.io/cadrum/03_transform.svg' alt='03_transform' width='360'/></div>
-
+<img src='https://lzpel.github.io/cadrum/03_transform.svg' alt='03_transform' width='360'/>
 
 #### Boolean
 
@@ -350,10 +350,10 @@ fn main() -> Result<(), cadrum::Error> {
 }
 
 ```
+
 Output: [04_boolean.png](https://lzpel.github.io/cadrum/04_boolean.png) | [04_boolean.step](https://lzpel.github.io/cadrum/04_boolean.step) | [04_boolean.glb](https://lzpel.github.io/cadrum/04_boolean.glb) | [04_boolean.stl](https://lzpel.github.io/cadrum/04_boolean.stl) | [04_boolean.svg](https://lzpel.github.io/cadrum/04_boolean.svg)
 
-<div align=center><img src='https://lzpel.github.io/cadrum/04_boolean.svg' alt='04_boolean' width='360'/></div>
-
+<img src='https://lzpel.github.io/cadrum/04_boolean.svg' alt='04_boolean' width='360'/>
 
 #### Extrude
 
@@ -433,10 +433,10 @@ fn main() -> Result<(), Error> {
 }
 
 ```
+
 Output: [05_extrude.png](https://lzpel.github.io/cadrum/05_extrude.png) | [05_extrude.step](https://lzpel.github.io/cadrum/05_extrude.step) | [05_extrude.glb](https://lzpel.github.io/cadrum/05_extrude.glb) | [05_extrude.stl](https://lzpel.github.io/cadrum/05_extrude.stl) | [05_extrude.svg](https://lzpel.github.io/cadrum/05_extrude.svg)
 
-<div align=center><img src='https://lzpel.github.io/cadrum/05_extrude.svg' alt='05_extrude' width='360'/></div>
-
+<img src='https://lzpel.github.io/cadrum/05_extrude.svg' alt='05_extrude' width='360'/>
 
 #### Loft
 
@@ -539,10 +539,10 @@ fn main() -> Result<(), Error> {
 }
 
 ```
+
 Output: [06_loft.png](https://lzpel.github.io/cadrum/06_loft.png) | [06_loft.step](https://lzpel.github.io/cadrum/06_loft.step) | [06_loft.glb](https://lzpel.github.io/cadrum/06_loft.glb) | [06_loft.stl](https://lzpel.github.io/cadrum/06_loft.stl) | [06_loft.svg](https://lzpel.github.io/cadrum/06_loft.svg)
 
-<div align=center><img src='https://lzpel.github.io/cadrum/06_loft.svg' alt='06_loft' width='360'/></div>
-
+<img src='https://lzpel.github.io/cadrum/06_loft.svg' alt='06_loft' width='360'/>
 
 #### Sweep
 
@@ -690,10 +690,10 @@ fn main() -> Result<(), Error> {
 }
 
 ```
+
 Output: [07_sweep.png](https://lzpel.github.io/cadrum/07_sweep.png) | [07_sweep.step](https://lzpel.github.io/cadrum/07_sweep.step) | [07_sweep.glb](https://lzpel.github.io/cadrum/07_sweep.glb) | [07_sweep.stl](https://lzpel.github.io/cadrum/07_sweep.stl) | [07_sweep.svg](https://lzpel.github.io/cadrum/07_sweep.svg)
 
-<div align=center><img src='https://lzpel.github.io/cadrum/07_sweep.svg' alt='07_sweep' width='360'/></div>
-
+<img src='https://lzpel.github.io/cadrum/07_sweep.svg' alt='07_sweep' width='360'/>
 
 #### Shell
 
@@ -761,12 +761,14 @@ fn main() -> Result<(), Error> {
 }
 
 ```
+
 Output: [08_shell.png](https://lzpel.github.io/cadrum/08_shell.png) | [08_shell.step](https://lzpel.github.io/cadrum/08_shell.step) | [08_shell.glb](https://lzpel.github.io/cadrum/08_shell.glb) | [08_shell.stl](https://lzpel.github.io/cadrum/08_shell.stl) | [08_shell.svg](https://lzpel.github.io/cadrum/08_shell.svg)
 
-<div align=center><img src='https://lzpel.github.io/cadrum/08_shell.svg' alt='08_shell' width='360'/></div>
-
+<img src='https://lzpel.github.io/cadrum/08_shell.svg' alt='08_shell' width='360'/>
 
 #### Bspline
+
+
 
 ```sh
 cargo run --example 09_bspline
@@ -828,10 +830,10 @@ fn main() -> Result<(), cadrum::Error> {
 }
 
 ```
+
 Output: [09_bspline.png](https://lzpel.github.io/cadrum/09_bspline.png) | [09_bspline.step](https://lzpel.github.io/cadrum/09_bspline.step) | [09_bspline.glb](https://lzpel.github.io/cadrum/09_bspline.glb) | [09_bspline.stl](https://lzpel.github.io/cadrum/09_bspline.stl) | [09_bspline.svg](https://lzpel.github.io/cadrum/09_bspline.svg)
 
-<div align=center><img src='https://lzpel.github.io/cadrum/09_bspline.svg' alt='09_bspline' width='360'/></div>
-
+<img src='https://lzpel.github.io/cadrum/09_bspline.svg' alt='09_bspline' width='360'/>
 
 #### Fillet
 
@@ -890,10 +892,10 @@ fn main() -> Result<(), Error> {
 }
 
 ```
+
 Output: [10_fillet.png](https://lzpel.github.io/cadrum/10_fillet.png) | [10_fillet.step](https://lzpel.github.io/cadrum/10_fillet.step) | [10_fillet.glb](https://lzpel.github.io/cadrum/10_fillet.glb) | [10_fillet.stl](https://lzpel.github.io/cadrum/10_fillet.stl) | [10_fillet.svg](https://lzpel.github.io/cadrum/10_fillet.svg)
 
-<div align=center><img src='https://lzpel.github.io/cadrum/10_fillet.svg' alt='10_fillet' width='360'/></div>
-
+<img src='https://lzpel.github.io/cadrum/10_fillet.svg' alt='10_fillet' width='360'/>
 
 #### Chamfer
 
@@ -952,10 +954,10 @@ fn main() -> Result<(), Error> {
 }
 
 ```
+
 Output: [11_chamfer.png](https://lzpel.github.io/cadrum/11_chamfer.png) | [11_chamfer.step](https://lzpel.github.io/cadrum/11_chamfer.step) | [11_chamfer.glb](https://lzpel.github.io/cadrum/11_chamfer.glb) | [11_chamfer.stl](https://lzpel.github.io/cadrum/11_chamfer.stl) | [11_chamfer.svg](https://lzpel.github.io/cadrum/11_chamfer.svg)
 
-<div align=center><img src='https://lzpel.github.io/cadrum/11_chamfer.svg' alt='11_chamfer' width='360'/></div>
-
+<img src='https://lzpel.github.io/cadrum/11_chamfer.svg' alt='11_chamfer' width='360'/>
 
 #### Multiview
 
@@ -995,9 +997,10 @@ fn main() -> Result<(), cadrum::Error> {
 }
 
 ```
+
 Output: [12_multiview.png](https://lzpel.github.io/cadrum/12_multiview.png) | [12_multiview.glb](https://lzpel.github.io/cadrum/12_multiview.glb) | [12_multiview.stl](https://lzpel.github.io/cadrum/12_multiview.stl)
 
-
+<img src='https://lzpel.github.io/cadrum/12_multiview.png' alt='12_multiview' width='360'/>
 
 ## The Type Map
 

--- a/examples/markdown.rs
+++ b/examples/markdown.rs
@@ -52,6 +52,26 @@ impl Entry {
 		self.content.lines().find(|l| l.starts_with("//!")).map(|l| l.trim_start_matches("//!").trim()).unwrap_or("")
 	}
 }
+// 生成物
+type Output = (PathBuf, Vec<u8>); // (relative path, contents) / (相対パス, 内容)
+
+fn main() {
+	let entries: Vec<Entry> = collect_entries();
+	let outputs: Vec<Output> = collect_outputs(&entries);
+
+	// Each arg is a file path: dispatch by filename / 各引数をファイル名で判別して処理
+	for arg in std::env::args().skip(1) {
+		let path = PathBuf::from(&arg);
+		let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+		if name.starts_with("SUMMARY") {
+			write_summary(&path, &entries, &outputs);
+		} else if name.starts_with("README") {
+			write_readme(&path, &entries[1..], &outputs);
+		} else {
+			eprintln!("unknown target: {arg} (expected SUMMARY.md or README.md)");
+		}
+	}
+}
 
 /// Collect numbered example files (NN_*.rs) sorted by name.
 /// 番号付き example (NN_*.rs) をファイル名順に収集する。
@@ -77,7 +97,7 @@ fn collect_entries() -> Vec<Entry> {
 
 /// Run each example in a temp directory and collect all generated files, sorted by path.
 /// 一時ディレクトリで各 example を実行し、生成されたファイルをパス順で回収する。
-fn collect_outputs(entries: &[Entry]) -> Vec<(PathBuf, Vec<u8>)> {
+fn collect_outputs(entries: &[Entry]) -> Vec<Output> {
 	let tmp = std::env::temp_dir().join("cadrum_examples");
 	clean_dir(&tmp);
 
@@ -90,7 +110,7 @@ fn collect_outputs(entries: &[Entry]) -> Vec<(PathBuf, Vec<u8>)> {
 	}
 
 	// Read all files from the temp directory / 一時ディレクトリの全ファイルを読み込む
-	let mut outputs: Vec<(PathBuf, Vec<u8>)> = fs::read_dir(&tmp)
+	let mut outputs: Vec<Output> = fs::read_dir(&tmp)
 		.unwrap()
 		.filter_map(|e| e.ok())
 		.filter_map(|e| {
@@ -107,7 +127,7 @@ fn collect_outputs(entries: &[Entry]) -> Vec<(PathBuf, Vec<u8>)> {
 
 /// Write output files, SUMMARY.md, and per-example markdown pages.
 /// 生成物・SUMMARY.md・各 example の markdown ページを出力する。
-fn write_summary(summary_path: &Path, entries: &[Entry], outputs: &[(PathBuf, Vec<u8>)]) {
+fn write_summary(summary_path: &Path, entries: &[Entry], outputs: &[Output]) {
 	let out_dir = summary_path.parent().expect("summary_path must have a parent directory");
 	clean_dir(out_dir);
 
@@ -135,102 +155,53 @@ fn write_summary(summary_path: &Path, entries: &[Entry], outputs: &[(PathBuf, Ve
 	eprintln!("generated: {}", summary_path.display());
 }
 
-/// Render a single example as markdown (description + run command + code + image) for README.
-/// README 用に 1つの example を説明 + 実行コマンド + ソース + 画像の markdown として生成する。
-/// 画像は GitHub Pages (mdbook 出力) の URL を参照する。
-fn render_example(entry: &Entry, outputs: &[(PathBuf, Vec<u8>)]) -> String {
-	let (stem, desc) = (entry.stem(), entry.description());
-	let mut s = String::new();
-	if !desc.is_empty() {
-		s.push_str(&format!("\n{}\n", desc));
-	}
-	s.push_str(&format!("\n```sh\ncargo run --example {}\n```\n", stem));
-	// `rust,no_run`: the README is `include_str!`'d into `src/lib.rs`, so each
-	// example program would otherwise become a doctest that `cargo test` tries
-	// to compile and run (slow + writes files). `no_run` keeps the type check.
-	s.push_str(&format!("\n```rust,no_run\n{}\n```\n", entry.content));
-	s.push_str(&render_assets(entry, outputs));
-	s.push('\n');
-	s
-}
-
-/// Render README asset markdown for an entry: a single-line `Output:` row of
-/// download links (present artifacts only, fixed type order) followed by the
-/// SVG preview image.
-/// entry に属するアセットを 1 行の `Output:` リンク行 + SVG プレビュー画像にして返す。
-fn render_assets(entry: &Entry, outputs: &[(PathBuf, Vec<u8>)]) -> String {
+/// Render README asset markdown for an entry: Output links + preview images.
+fn render_assets(entry: &Entry, outputs: &[Output]) -> String {
 	let stem = entry.stem();
-	// Files belonging to this example, e.g. "01_primitives.glb" / この example の生成物
-	let owned = |ext: &str| -> Vec<String> { outputs.iter().filter_map(|(p, _)| p.to_str().map(str::to_string)).filter(|name| name.starts_with(stem) && name.ends_with(&format!(".{ext}"))).collect() };
-
-	// One link per present artifact, in a fixed type order / 固定順で存在物のみリンク化
-	let links: Vec<String> = ["png", "step", "glb", "brep", "stl", "svg"].iter().flat_map(|ext| owned(ext)).map(|name| format!("[{name}](https://lzpel.github.io/cadrum/{name})")).collect();
-	if links.is_empty() {
-		return String::new();
-	}
-
-	let mut out = format!("Output: {}\n", links.join(" | "));
-	// Keep the SVG preview image below the links / SVG プレビュー画像を下に残す
-	for name in owned("svg") {
-		out.push_str(&format!("\n<div align=center><img src='https://lzpel.github.io/cadrum/{name}' alt='{stem}' width='360'/></div>\n"));
-	}
-	out
+	let links: Vec<String> = ["png", "step", "glb", "brep", "stl", "svg"].iter().filter_map(|ext| find_output(outputs, stem, ext).map(|v| format!("[{}]({})", format!("{}.{}", stem, ext), link_output(&v)))).collect();
+	let previews = ["svg", "png"].iter().find_map(|ext| find_output(outputs, stem, ext).map(|out| format!("<img src='{}' alt='{}' width='360'/>", link_output(&out), stem)));
+	format!("Output: {}\n\n{}", links.join(" | "), previews.unwrap_or_default())
 }
 
 /// Render the `## Usage` section: thumbnail table + install instructions.
-fn render_usage(entries: &[Entry], outputs: &[(PathBuf, Vec<u8>)]) -> String {
+fn render_usage(entries: &[Entry], outputs: &[Output]) -> String {
 	const COLS: usize = 4;
-	let mut s = String::from("<!--GALLERY-->\n\n<table>\n");
-	if !entries.is_empty() {
-		let rows = entries.len().div_ceil(COLS);
-		for row in 0..rows {
-			let cells: Vec<Option<(&Entry, &str)>> = (0..COLS)
-				.map(|col| {
-					let entry = entries.get(row * COLS + col)?;
-					let img = outputs.iter().filter_map(|(p, _)| p.to_str()).find(|n| n.starts_with(entry.stem()) && (n.ends_with(".svg") || n.ends_with(".png")))?;
-					Some((entry, img))
-				})
-				.collect();
-			s.push_str(&format!(
-				"<tr>{}</tr>\n",
-				cells
-					.iter()
-					.map(|cell| {
-						let v = cell.map(|(e, _)| format!("<a href='#{anchor}'>{title}</a>", anchor = e.slug(), title = e.plain_title())).unwrap_or_default();
-						format!("<th width='25%'>{}</th>", v)
-					})
-					.collect::<String>()
-			));
-			s.push_str(&format!(
-				"<tr>{}</tr>\n",
-				cells
-					.iter()
-					.map(|cell| {
-						let v = cell.map(|(e, img)| format!("<a href='#{anchor}'><img src='https://lzpel.github.io/cadrum/{img}' width='100%' height='auto' alt='{title}'/></a>", anchor = e.slug(), title = e.plain_title())).unwrap_or_default();
-						format!("<td width='25%'>{}</td>", v)
-					})
-					.collect::<String>()
-			));
+	let cells: Vec<[String; 2]> = entries
+		.iter()
+		.map(|entry| {
+			let img = &find_output(outputs, entry.stem(), "png").map(link_output).unwrap_or_default();
+			let th = format!("<a href='#{anchor}'>{title}</a>", anchor = entry.slug(), title = entry.plain_title());
+			let td = format!("<a href='#{anchor}'><img src='{img}' width='100%' height='auto' alt='{title}'/></a>", anchor = entry.slug(), title = entry.plain_title());
+			[th, td]
+		})
+		.collect();
+	{
+		let mut s = String::from("<!--GALLERY-->\n\n<table>\n");
+		for chunk in cells.chunks(COLS) {
+			for (i, tag) in ["th", "td"].iter().enumerate() {
+				let row: String = (0..COLS).map(|col| format!("<{tag} width='25%'>{}</{tag}>", chunk.get(col).map(|cell| cell[i].as_str()).unwrap_or_default())).collect();
+				s.push_str(&format!("<tr>{row}</tr>\n"));
+			}
 		}
+		s.push_str("</table>\n");
+		s
 	}
-	s.push_str("</table>\n");
-	s
 }
 
 /// Render the `## Example` section: every entry listed with `#### Title`.
-fn render_example_section(entries: &[Entry], outputs: &[(PathBuf, Vec<u8>)]) -> String {
-	let mut s = String::from("## Examples\n");
-	for entry in entries {
-		s.push_str(&format!("\n#### {}\n", entry.title()));
-		s.push_str(&render_example(entry, outputs));
+fn render_example_section(entries: &[Entry], outputs: &[Output]) -> String {
+	fn render_example(entry: &Entry, outputs: &[Output]) -> String {
+		let header = format!("\n{}\n\n```sh\ncargo run --example {}\n```\n\n```rust,no_run\n{}\n```\n", entry.description(), entry.stem(), entry.content);
+		let asset = render_assets(entry, outputs);
+		format!("{}\n{}", header, asset)
 	}
-	s.push('\n');
-	s
+	let examples: Vec<String> = entries.iter().map(|entry| format!("\n#### {}\n{}", entry.title(), &render_example(entry, outputs))).collect();
+	format!("## Examples\n{}\n", examples.join("\n"))
 }
 
 /// Update README.md by replacing `## Usage` and `## Example` sections.
 /// README.md の `## Usage` と `## Example` 節を自動生成で置換する。
-fn write_readme(readme_path: &Path, entries: &[Entry], outputs: &[(PathBuf, Vec<u8>)]) {
+fn write_readme(readme_path: &Path, entries: &[Entry], outputs: &[Output]) {
 	let readme = fs::read_to_string(readme_path).expect("failed to read README.md");
 
 	let mut new_readme = String::with_capacity(readme.len());
@@ -268,20 +239,10 @@ fn clean_dir(dir: &Path) {
 	fs::create_dir_all(dir).expect("failed to create directory");
 }
 
-fn main() {
-	let entries = collect_entries();
-	let outputs = collect_outputs(&entries);
+fn find_output<'a>(outputs: &'a [Output], stem: &str, ext: &str) -> Option<&'a Output> {
+	outputs.iter().find(|(p, _)| p.extension().is_some_and(|v| v == ext) && p.file_stem().is_some_and(|s| s == stem))
+}
 
-	// Each arg is a file path: dispatch by filename / 各引数をファイル名で判別して処理
-	for arg in std::env::args().skip(1) {
-		let path = PathBuf::from(&arg);
-		let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-		if name.starts_with("SUMMARY") {
-			write_summary(&path, &entries, &outputs);
-		} else if name.starts_with("README") {
-			write_readme(&path, &entries[1..], &outputs);
-		} else {
-			eprintln!("unknown target: {arg} (expected SUMMARY.md or README.md)");
-		}
-	}
+fn link_output(output: &Output) -> String {
+	format!("https://lzpel.github.io/cadrum/{}", output.0.file_name().unwrap_or_default().to_string_lossy())
 }


### PR DESCRIPTION
## Summary

- Extract `find_output` and `link_output` helpers so asset lookup and GitHub Pages URL construction are written once
- Rebuild the README gallery rows from a precomputed th/td cell list, removing the borrow of a temporary in the row loop
- Collapse `render_assets` and `render_example_section` into shorter expression-based forms and introduce the `Output` type alias
- Regenerate the README with the updated asset format (inline `<img>` previews instead of centered `<div>` wrappers, PNG preview for multiview)

## Test plan

- `cargo check --example markdown` passes with no warnings
- `cargo fmt` applied