### PR TITLE
Drop the stale wasm exception-handling runtime requirement from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,6 @@ unsafe { __wasm_call_ctors() };
 Then run the output through `wasm-bindgen` / `wasm-pack` for browser glue. See
 [`opencascade-wasm32-unknown-unknown-example`](https://github.com/lzpel/opencascade-wasm32-unknown-unknown-example) for a complete setup.
 
-**Runtime requirement:** the module is built with Wasm exception handling
-(`-fwasm-exceptions`, the legacy encoding), so it needs a runtime that supports the
-Wasm exception-handling proposal — any current browser, or Node (no
-`--experimental-wasm-exnref` flag required).
-
 ### Building for other targets
 
 For a target without a prebuilt OCCT, build OCCT from source:


### PR DESCRIPTION
The README told wasm users that the module needs a runtime supporting the Wasm
exception-handling proposal, and that no `--experimental-wasm-exnref` flag is
required. Neither half earns its place:

- The build forces the **legacy** EH encoding (`build.rs` `apply_compiler_flags`
  passes `-mllvm -wasm-use-legacy-eh=true`, #233), which has been on by default in
  Chrome 95, Safari 15.2, Firefox 100 and Node 17 onward. There is nothing for a
  user of the documented browser path to do.
- `--experimental-wasm-exnref` only ever gated the new exnref encoding, so
  mentioning it is a leftover from before the #233 rollback.

Unlike the "Code requirement" above it, this section stated no action, so it is
dropped rather than reworded.