### PR TITLE
Define _USE_STD_VECTOR_ALGORITHMS=0 for msvc builds

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -173,9 +173,11 @@ const OCC_LIBS: &[&str] = &[
 /// the OCCT source build). Shared so the wrapper and OCCT get identical flags — in particular
 /// the same wasm EH encoding, which must match the legacy-built wasi-sdk eh sysroot (#199, #233).
 fn apply_compiler_flags(mut apply: impl FnMut(&str)) {
-	// MSVC: compile sources as UTF-8.
+	// MSVC: compile sources as UTF-8, and keep std::min/max off the STL vectorized helpers
+	// (__std_min_4i etc.) in msvcp140, which impose a toolset floor on prebuilt consumers (#276).
 	if env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc") {
 		apply("/utf-8");
+		apply("/D_USE_STD_VECTOR_ALGORITHMS=0");
 	}
 	// wasm: force the legacy EH encoding, matching the legacy eh sysroot the cross image
 	// self-builds (exnref needs a runtime opt-in; #233). No-op without -fwasm-exceptions.


### PR DESCRIPTION
Part 1 of #276: the compiler flag only. Rebuilding and republishing the msvc prebuilt
(`BUILD_REVISION` -> rev3 plus the `prebuilt.yaml` tag) is deliberately left out of this PR.

MSVC implements the `std::min` / `std::max` initializer-list overloads through
`_Min_element_vectorized` / `_Max_element_vectorized`, whose helpers (`__std_min_4i`,
`__std_max_element_d`, ...) are not header-only — they live in `msvcp140` and stay
undefined in the shipped static libraries, so the consumer's linker has to resolve them.
Which of those helpers exist depends on the consumer's toolset, so the published prebuilt
fails to link on MSVC 14.38 with LNK2019 while it links on 14.44, and the floor rises on
its own whenever the CI runner image gains a newer toolset. #276 measures that the scalar
path is not slower at these call sites (3-4 elements) — it is faster per operation and
within noise end-to-end.

The flag goes into `apply_compiler_flags`, so it reaches both `src/ffi.cpp`
(`cc::Build::flag`) and the OCCT source build (`cmake::Config::cxxflag`), keeping the two
consistent the same way `/utf-8` and the wasm EH encoding already are.

`cargo test` on x86_64-pc-windows-msvc: 90 passed / 3 ignored.

---

#276 の 1 番目、コンパイルフラグのみです。msvc prebuilt の再ビルド・再公開
(`BUILD_REVISION` の rev3 化と `prebuilt.yaml` のタグ更新) は意図的に含めていません。

MSVC は `std::min` / `std::max` の initializer_list オーバーロードを
`_Min_element_vectorized` / `_Max_element_vectorized` 経由で実装しており、そのヘルパ
(`__std_min_4i`, `__std_max_element_d` 等) はヘッダオンリーではなく `msvcp140` にあります。
配布している静的ライブラリでは未解決のまま残るので、解決するのは消費者側のリンカです。
どのヘルパが存在するかはツールセット依存のため、公開 prebuilt は MSVC 14.38 で LNK2019、
14.44 では成功、という状態になり、しかも CI ランナーのイメージが新しくなるたびに下限が
黙って上がります。該当箇所は 3〜4 要素なので、スカラー経路は遅くなるどころか 1 演算あたり
では速く、全体では誤差の範囲であることが #276 で実測されています。

フラグは `apply_compiler_flags` に置いたので `src/ffi.cpp` (`cc::Build::flag`) と OCCT
ソースビルド (`cmake::Config::cxxflag`) の両方に届き、`/utf-8` や wasm の EH エンコーディングと
同じく両者が一致した状態を保ちます。

x86_64-pc-windows-msvc での `cargo test`: 90 passed / 3 ignored。