### PR TITLE
Give each decomposed solid only its own face history

### DIFF
--- a/src/common/mesh.rs
+++ b/src/common/mesh.rs
@@ -1028,7 +1028,7 @@ impl Mesh {
 }
 
 #[cfg(feature = "png")]
-fn nice_step(target: f64) -> f64 { //Glyph/label size in pixels. Largest `{1, 2, 5} × 10^n` value ≤ `target`
+fn nice_step(target: f64) -> f64 {
 	if !target.is_finite() || target <= 0.0 {
 		return 1.0;
 	}

--- a/src/occt/compound.rs
+++ b/src/occt/compound.rs
@@ -58,20 +58,18 @@ impl CompoundShape {
 	}
 
 	/// Decompose into individual solids, consuming the compound.
-	///
-	/// Each result solid receives a clone of the full `history` — over-inclusion
-	/// is harmless because `iter_history()` consumers filter pairs by checking
-	/// `src_id` against the original input's face IDs.
 	pub fn decompose(self) -> Vec<Solid> {
 		let solid_shapes = ffi::decompose_into_solids(&self.inner);
 		solid_shapes
 			.iter()
 			.map(|s| {
+				let local: std::collections::HashSet<u64> = ffi::shape_faces(s).iter().map(ffi::face_tshape_id).collect();
+				let history = self.history.chunks_exact(2).filter(|p| local.contains(&p[0])).flatten().copied().collect();
 				Solid::new(
 					ffi::clone_shape_handle(s),
 					#[cfg(feature = "color")]
 					self.colormap.clone(),
-					self.history.clone(),
+					history,
 				)
 			})
 			.collect()

--- a/tests/solid_iter_history.rs
+++ b/tests/solid_iter_history.rs
@@ -138,3 +138,24 @@ fn test_fillet_carries_face_color_via_history() {
 		assert!(filleted.colormap().contains_key(post), "face {post} should inherit color via history");
 	}
 }
+
+/// boolean が複数ピースに割れたとき、各ピースの history は自分の face だけを
+/// `post_id` に持つ（兄弟ピースの由来を主張しない）。
+#[test]
+fn test_split_boolean_pieces_own_disjoint_history() {
+	let block = Solid::cube(DVec3::ZERO, DVec3::splat(10.0));
+	let slab = Solid::cube(DVec3::new(-1.0, -1.0, 4.0), DVec3::new(11.0, 11.0, 6.0));
+	let pieces = (&block - &slab).build_vec().expect("cut splits the block");
+	assert_eq!(pieces.len(), 2, "the slab must cut the block in two");
+
+	let mut seen: HashSet<u64> = HashSet::new();
+	for piece in &pieces {
+		let faces: HashSet<u64> = piece.iter_face().map(|f| f.id()).collect();
+		let hist: Vec<[u64; 2]> = piece.iter_history().collect();
+		assert!(!hist.is_empty(), "a cut piece must keep its own history");
+		for [post, _] in &hist {
+			assert!(faces.contains(post), "post_id {post} is not a face of this piece");
+			assert!(seen.insert(*post), "post_id {post} claimed by more than one piece");
+		}
+	}
+}


### PR DESCRIPTION
### 1. Give each decomposed solid only its own face history

`builder_cells` fills one `history` for the whole result compound, and
`CompoundShape::decompose` handed every piece a full clone of it. When a boolean
splits into several solids, each piece therefore reported `post_id`s that belong
to its siblings.

（`builder_cells` は結果コンパウンド全体で1本の `history` を埋め、
`CompoundShape::decompose` はそれを各ピースに丸ごと複製して配っていた。boolean が
複数ソリッドに割れると、各ピースが兄弟ピースの `post_id` を報告してしまう。）

The old doc comment justified the over-inclusion by saying consumers filter on
`src_id`. That filter cannot separate siblings — they descend from the same
inputs, so their pairs share `src_id`. The separating key is `post_id`, which
belongs to exactly one piece.

（従来のコメントは「消費者が `src_id` で filter するので過剰包含は無害」と説明して
いたが、兄弟ピースは同じ入力に由来するため `src_id` では分離できない。分離できるのは
ちょうど1ピースにしか属さない `post_id` の方。）

Measured before the fix — a cube cut in two by a slab:
（修正前の実測。立方体を薄板で2つに割った場合:）

```
piece 0: faces=6 history_pairs=12 post_id_not_in_this_solid=6
piece 1: faces=6 history_pairs=12 post_id_not_in_this_solid=6
```

`test_split_boolean_pieces_own_disjoint_history` covers it: every `post_id` must
be a face of its own piece, and no `post_id` may be claimed twice. It fails on
the unpatched `decompose`.

（`test_split_boolean_pieces_own_disjoint_history` を追加。各 `post_id` が自分の
ピースの face であること、および `post_id` が二重に主張されないことを検証する。
修正前の `decompose` では失敗する。）

Only boolean results that decompose into two or more solids are affected; the
I/O paths pass an empty history.
（影響するのは boolean が2個以上に分かれた場合のみ。I/O 経路は空の history を渡す。）

### 2. Run `cargo fmt` over the `nice_step` trailing comment

`main` was not `cargo fmt`-clean: rustfmt moves the trailing comment introduced
in #278 onto its own line.
（`main` が `cargo fmt` clean でなかった。#278 で入った行末コメントを rustfmt が
次行へ送るため。）

### Verification / 検証

- `cargo test` — 17 suites, all green（17スイート全て green）
- The new test fails without the `decompose` change, confirming it is a real regression guard（新テストは `decompose` の修正を外すと落ちる = 回帰テストとして機能する）
