### PR TITLE
Project edges through BRepAdaptor_Curve so degenerate edges work

### DIFF
--- a/src/ffi.cpp
+++ b/src/ffi.cpp
@@ -84,7 +84,7 @@
 #include <GCPnts_TangentialDeflection.hxx>
 #include <GeomAPI_Interpolate.hxx>
 #include <GeomAPI_PointsToBSplineSurface.hxx>
-#include <GeomAPI_ProjectPointOnCurve.hxx>
+#include <Extrema_ExtPC.hxx>
 #include <Geom_BSplineCurve.hxx>
 #include <Geom_BSplineSurface.hxx>
 #include <NCollection_Array2.hxx>
@@ -1123,25 +1123,30 @@ bool edge_project_point(const TopoDS_Edge& edge,
     cpx = 0.0; cpy = 0.0; cpz = 0.0;
     tx = 0.0; ty = 0.0; tz = 0.0;
     try {
-        double first = 0.0, last = 0.0;
-        Handle(Geom_Curve) gcurve = BRep_Tool::Curve(edge, first, last);
-        if (gcurve.IsNull()) return false;
+        // BRepAdaptor_Curve は 3D 曲線を持たない縮退エッジ (球の極・円錐の頂点) でも
+        // pcurve + サーフェス経由で評価できる。BRep_Tool::Curve を直接引くと null で
+        // 落ちるので使わない。ファイル内の他の edge_* 関数もこのアダプタ経由。
+        BRepAdaptor_Curve curve(edge);
+        const double first = curve.FirstParameter();
+        const double last = curve.LastParameter();
         gp_Pnt target(px, py, pz);
-        GeomAPI_ProjectPointOnCurve projector(target, gcurve, first, last);
+        Extrema_ExtPC extrema(target, curve, first, last);
         double u;
-        if (projector.NbPoints() > 0) {
-            u = projector.LowerDistanceParameter();
+        if (extrema.IsDone() && extrema.NbExt() > 0) {
+            int best = 1;
+            for (int i = 2; i <= extrema.NbExt(); i++) {
+                if (extrema.SquareDistance(i) < extrema.SquareDistance(best)) best = i;
+            }
+            u = extrema.Point(best).Parameter();
         } else {
-            // No interior extremum within [first, last] — distance is monotonic
-            // along the curve segment (e.g. line segment with target beyond an
-            // endpoint). Clamp to whichever endpoint is closer.
-            double d_first = target.Distance(gcurve->Value(first));
-            double d_last  = target.Distance(gcurve->Value(last));
+            // 区間内に極値なし — 距離が単調 (端点の外側にある線分など)。近い端点にクランプ。
+            double d_first = target.Distance(curve.Value(first));
+            double d_last  = target.Distance(curve.Value(last));
             u = (d_first <= d_last) ? first : last;
         }
         gp_Pnt p;
         gp_Vec v;
-        gcurve->D1(u, p, v);
+        curve.D1(u, p, v);
         cpx = p.X(); cpy = p.Y(); cpz = p.Z();
         if (v.Magnitude() > Precision::Confusion()) {
             v.Normalize();

--- a/src/occt/edge.rs
+++ b/src/occt/edge.rs
@@ -85,11 +85,9 @@ impl EdgeStruct for Edge {
 	fn project(&self, p: DVec3) -> (DVec3, DVec3) {
 		let (mut cpx, mut cpy, mut cpz) = (0.0_f64, 0.0_f64, 0.0_f64);
 		let (mut tx, mut ty, mut tz) = (0.0_f64, 0.0_f64, 0.0_f64);
-		// FFI returns false only on truly degenerate edges (no 3D Geom_Curve,
-		// or OCCT internal exception). All cadrum-constructed edges carry a
-		// Geom_Curve, so this is effectively unreachable — treat as a bug and
-		// fail fast rather than returning silent zero.
-		assert!(ffi::edge_project_point(&self.inner, p.x, p.y, p.z, &mut cpx, &mut cpy, &mut cpz, &mut tx, &mut ty, &mut tz), "Edge::project: edge has no 3D curve or OCCT projector threw (this is a bug)");
+		// FFI returns false only when OCCT throws. Degenerate edges (sphere pole,
+		// cone apex) go through the pcurve and yield the point with a zero tangent.
+		assert!(ffi::edge_project_point(&self.inner, p.x, p.y, p.z, &mut cpx, &mut cpy, &mut cpz, &mut tx, &mut ty, &mut tz), "Edge::project: OCCT projector threw (this is a bug)");
 		(DVec3::new(cpx, cpy, cpz), DVec3::new(tx, ty, tz))
 	}
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -329,9 +329,9 @@ pub trait EdgeStruct: Sized + Clone + Debug + Transform {
 	/// Polyline approximation of the edge within `tolerance`, as ordered points.
 	fn approximation_segments(&self, tessellation: Tessellation) -> Vec<DVec3>;
 	/// Project `p` onto the edge and return `(closest_point, unit_tangent)`.
-	/// The tangent follows the curve's native parameter direction. Panics only
-	/// on an edge with no 3D geometric curve (an FFI-level bug, which
-	/// cadrum-built edges never produce), not on degenerate user input.
+	/// The tangent follows the curve's native parameter direction, and is the
+	/// zero vector on a degenerate edge (a sphere pole or cone apex, which
+	/// collapses to a single point); callers detect it via `tangent.length() == 0`.
 	fn project(&self, p: DVec3) -> (DVec3, DVec3);
 
 	/// Construct a single helical edge on a cylindrical surface centered at


### PR DESCRIPTION
Addresses the `Edge::project` half of #280. `Face::project` is untouched.
（#280 のうち `Edge::project` 側のみ。`Face::project` は手を付けていない。）

`edge_project_point` took the 3D curve with `BRep_Tool::Curve` and returned false when
it came back null. A sphere pole and a cone apex are degenerate edges: they carry a pcurve
but no 3D `Geom_Curve`, so `Edge::project` asserted on them. `Solid::sphere` builds two.

（`edge_project_point` は `BRep_Tool::Curve` で 3D 曲線を取り、null なら false を返していた。
球の極と円錐の頂点は縮退エッジで、pcurve は持つが 3D `Geom_Curve` を持たないため
`Edge::project` が `assert!` に当たっていた。`Solid::sphere` はこれを2本作る。）

`BRepAdaptor_Curve` evaluates such an edge through its pcurve and surface, and every other
`edge_*` function in this file already goes through it — `edge_project_point` was the one
exception. Switching to `Extrema_ExtPC` over that adaptor keeps the extremum selection and
the endpoint clamp identical.

（`BRepAdaptor_Curve` は pcurve とサーフェス経由で評価できる。このファイルの他の `edge_*`
関数はすべてこのアダプタ経由で、`edge_project_point` だけが例外だった。`Extrema_ExtPC` に
差し替えても、極値の選び方と端点クランプの論理は変えていない。）

## Measurements / 計測

Release build, 10000 calls per edge per implementation, the same deterministic point
sequence given to both, repeated three times.
（release ビルド、実装ごと・エッジごとに 10000 回、両者に同じ決定的な点列を与え、3回実行。）

| edge | old fail | new fail | old µs/call | new µs/call | max &#124;cp_old − cp_new&#124; |
| --- | ---: | ---: | ---: | ---: | ---: |
| sphere pole (degenerate ×2) | 10000 | 0 | 0.01 | 4.90 | 0.000e+00 |
| sphere meridian (×2) | 0 | 0 | 0.32 | 0.35 | 0.000e+00 |
| line | 0 | 0 | 0.15 | 0.19 | 0.000e+00 |
| circle | 0 | 0 | 0.41 | 0.47 | 0.000e+00 |

- **Failures**: every call on a degenerate edge failed before (each one an assert in Rust); none fail now.
  （**失敗**: 縮退エッジは全件失敗していた（Rust 側では毎回 `assert!`）。修正後はゼロ。）
- **Cost on real edges**: 1.0–1.3x, i.e. 0.03–0.06 µs absolute. Within noise.
  （**正常エッジのコスト**: 1.0〜1.3倍、絶対値で 0.03〜0.06 µs。誤差の範囲。）
- **Cost on degenerate edges**: 4.90 µs, because the adaptor evaluates through the pcurve and
  the surface. The old 0.01 µs is not speed — it is `BRep_Tool::Curve` returning null and the
  function giving up without doing any work, so the ratio on that row is meaningless.
  （**縮退エッジのコスト**: 4.90 µs。pcurve＋サーフェス経由で評価するため。旧実装の 0.01 µs は
  速いのではなく `BRep_Tool::Curve` が null を返して何もせず諦めているだけなので、この行の比は意味を持たない。）
- **Agreement**: on every call where both succeeded the two implementations returned bit-identical points.
  （**一致**: 両方成功した全ケースで、2つの実装はビット単位で同一の点を返した。）

A fast path that keeps `BRep_Tool::Curve` and only falls back to the adaptor when it is null
was considered and dropped: the measurements show there is nothing to recover.
（`BRep_Tool::Curve` を残して null のときだけアダプタに落とすハイブリッド案は、計測の結果
取り戻すものが無いので採らなかった。）

## Behaviour / 挙動

`Solid::sphere(5.0)`, projecting `(100, 100, 100)` onto each edge — the poles asserted before:
（`Solid::sphere(5.0)` の各エッジに `(100, 100, 100)` を射影。修正前は極で `assert!` していた:）

```
edge 0: closest=DVec3(2.16e-16, 2.16e-16, 5.0)     |tangent|=0
edge 1: closest=DVec3(3.5355, -8.66e-16, 3.5355)   |tangent|=1
edge 2: closest=DVec3(2.16e-16, 2.16e-16, -5.0)    |tangent|=0
```

A degenerate edge collapses to a point, so it has no tangent; the zero vector reports that,
matching the convention `FaceStruct::project` already documents for an undefined normal.
The `EdgeStruct::project` doc now states it.

（縮退エッジは1点に潰れるので接線が存在しない。ゼロベクトルがそれを表し、`FaceStruct::project`
が法線について既に文書化している規約と一致する。`EdgeStruct::project` の doc に明記した。）

## Verification / 検証

- `cargo test` — 17 suites, all green（17スイート全て green）
- `cargo check --all-targets` — no warnings（warning なし）
- `cargo run --example codegen -- src/traits.rs src/lib.rs` — no drift（差分なし）
