### PR TITLE
Return the true nearest point on a trimmed face from Face::project

### DIFF
--- a/src/ffi.cpp
+++ b/src/ffi.cpp
@@ -802,8 +802,8 @@ bool face_project_point(const TopoDS_Face& face,
 
     try {
         const gp_Pnt target(px, py, pz);
-        bool found = false, has_uv = false;
-        double best_d2 = 0.0, bu = 0.0, bv = 0.0;
+        bool has_uv = false;
+        double best_d2 = Precision::Infinite(), bu = 0.0, bv = 0.0;
         gp_Pnt best_p;
 
         // Orthogonal projections onto the face interior. BRepExtrema_ExtPF
@@ -813,11 +813,10 @@ bool face_project_point(const TopoDS_Face& face,
         if (ext.IsDone()) {
             for (int i = 1; i <= ext.NbExt(); ++i) {
                 const double d2 = ext.SquareDistance(i);
-                if (found && d2 >= best_d2) continue;
+                if (d2 >= best_d2) continue;
                 best_d2 = d2;
                 best_p = ext.Point(i);
                 ext.Parameter(i, bu, bv);
-                found = true;
                 has_uv = true;
             }
         }
@@ -847,7 +846,7 @@ bool face_project_point(const TopoDS_Face& face,
             for (const double t : {u, first, last}) {
                 const gp_Pnt p = curve.Value(t);
                 const double d2 = target.SquareDistance(p);
-                if (found && d2 >= best_d2) continue;
+                if (d2 >= best_d2) continue;
                 best_d2 = d2;
                 best_p = p;
                 // The edge shares its parameter with its pcurve, so the same t
@@ -858,11 +857,10 @@ bool face_project_point(const TopoDS_Face& face,
                     bu = uv.X();
                     bv = uv.Y();
                 }
-                found = true;
             }
         }
 
-        if (!found) return false;
+        if (Precision::IsInfinite(best_d2)) return false;  // no interior extremum and no boundary
         cpx = best_p.X();
         cpy = best_p.Y();
         cpz = best_p.Z();

--- a/src/ffi.cpp
+++ b/src/ffi.cpp
@@ -801,34 +801,75 @@ bool face_project_point(const TopoDS_Face& face,
     nx = 0.0; ny = 0.0; nz = 0.0;
 
     try {
-        // BRepExtrema_ExtPF respects face trim, unlike Extrema_ExtPS which
-        // works on the underlying infinite surface. The vertex wrapping
-        // overhead (Handle alloc) is bounded — single Handle per call.
-        TopoDS_Vertex vert = BRepBuilderAPI_MakeVertex(gp_Pnt(px, py, pz));
-        BRepExtrema_ExtPF ext(vert, face);
-        if (!ext.IsDone() || ext.NbExt() < 1) return false;
+        const gp_Pnt target(px, py, pz);
+        bool found = false, has_uv = false;
+        double best_d2 = 0.0, bu = 0.0, bv = 0.0;
+        gp_Pnt best_p;
 
-        // Pick the smallest-distance extremum.
-        int best = 1;
-        double best_d2 = ext.SquareDistance(1);
-        for (int i = 2; i <= ext.NbExt(); ++i) {
-            double d2 = ext.SquareDistance(i);
-            if (d2 < best_d2) {
+        // Orthogonal projections onto the face interior. BRepExtrema_ExtPF
+        // respects the trim: it keeps only extrema classified inside the face.
+        TopoDS_Vertex vert = BRepBuilderAPI_MakeVertex(target);
+        BRepExtrema_ExtPF ext(vert, face);
+        if (ext.IsDone()) {
+            for (int i = 1; i <= ext.NbExt(); ++i) {
+                const double d2 = ext.SquareDistance(i);
+                if (found && d2 >= best_d2) continue;
                 best_d2 = d2;
-                best = i;
+                best_p = ext.Point(i);
+                ext.Parameter(i, bu, bv);
+                found = true;
+                has_uv = true;
             }
         }
 
-        gp_Pnt cp = ext.Point(best);
-        cpx = cp.X();
-        cpy = cp.Y();
-        cpz = cp.Z();
+        // Nearest points on the boundary wires. An interior extremum can be
+        // farther than the boundary (a 270° cylindrical face keeps only the far
+        // wall), and outside the trim there is no interior extremum at all, so
+        // both sets must be compared rather than one used as a fallback.
+        for (TopExp_Explorer it(face, TopAbs_EDGE); it.More(); it.Next()) {
+            const TopoDS_Edge& edge = TopoDS::Edge(it.Current());
+            BRepAdaptor_Curve curve(edge);
+            const double first = curve.FirstParameter();
+            const double last = curve.LastParameter();
+            Extrema_ExtPC extrema(target, curve, first, last);
+            double u = first;
+            if (extrema.IsDone() && extrema.NbExt() > 0) {
+                int k = 1;
+                for (int i = 2; i <= extrema.NbExt(); ++i) {
+                    if (extrema.SquareDistance(i) < extrema.SquareDistance(k)) k = i;
+                }
+                u = extrema.Point(k).Parameter();
+            }
+            // The endpoints are candidates too: an interior extremum of the
+            // curve can be farther than either end.
+            double pf = 0.0, pl = 0.0;
+            Handle(Geom2d_Curve) pcurve = BRep_Tool::CurveOnSurface(edge, face, pf, pl);
+            for (const double t : {u, first, last}) {
+                const gp_Pnt p = curve.Value(t);
+                const double d2 = target.SquareDistance(p);
+                if (found && d2 >= best_d2) continue;
+                best_d2 = d2;
+                best_p = p;
+                // The edge shares its parameter with its pcurve, so the same t
+                // gives the (u, v) the normal needs.
+                has_uv = !pcurve.IsNull();
+                if (has_uv) {
+                    const gp_Pnt2d uv = pcurve->Value(t);
+                    bu = uv.X();
+                    bv = uv.Y();
+                }
+                found = true;
+            }
+        }
 
-        double u, v;
-        ext.Parameter(best, u, v);
+        if (!found) return false;
+        cpx = best_p.X();
+        cpy = best_p.Y();
+        cpz = best_p.Z();
+        if (!has_uv) return true;  // cp valid, normal stays 0.
 
         BRepAdaptor_Surface surf(face);
-        BRepLProp_SLProps props(surf, u, v, /*derivOrder=*/1, Precision::Confusion());
+        BRepLProp_SLProps props(surf, bu, bv, /*derivOrder=*/1, Precision::Confusion());
         if (!props.IsNormalDefined()) return true;  // cp valid, normal stays 0.
 
         gp_Dir n = props.Normal();

--- a/src/occt/face.rs
+++ b/src/occt/face.rs
@@ -38,9 +38,9 @@ impl FaceStruct for Face {
 	fn project(&self, p: DVec3) -> (DVec3, DVec3) {
 		let (mut cpx, mut cpy, mut cpz) = (0.0_f64, 0.0_f64, 0.0_f64);
 		let (mut nx, mut ny, mut nz) = (0.0_f64, 0.0_f64, 0.0_f64);
-		// FFI returns false only on truly catastrophic OCCT failure; for a
-		// well-formed face this is effectively unreachable.
-		assert!(ffi::face_project_point(&self.inner, p.x, p.y, p.z, &mut cpx, &mut cpy, &mut cpz, &mut nx, &mut ny, &mut nz), "Face::project: BRepExtrema_ExtPF failed (this is a bug)");
+		// FFI returns false only when OCCT throws or the face is unbounded: a
+		// bounded face always has a boundary to fall back on.
+		assert!(ffi::face_project_point(&self.inner, p.x, p.y, p.z, &mut cpx, &mut cpy, &mut cpz, &mut nx, &mut ny, &mut nz), "Face::project: OCCT threw or the face has no boundary (this is a bug)");
 		(DVec3::new(cpx, cpy, cpz), DVec3::new(nx, ny, nz))
 	}
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -427,7 +427,10 @@ pub trait FaceStruct: Sized + Debug {
 	/// tangent)` on a 1D curve.
 	///
 	/// The closest hit respects the face's trim — projection lands on the
-	/// actual face area, not its underlying infinite surface. To project
+	/// actual face area, not its underlying infinite surface. It therefore
+	/// lands on a boundary wire whenever no interior point is nearer, and
+	/// there `p - closest_point` is not parallel to `outward_normal`, which
+	/// always describes the surface at the hit. To project
 	/// onto a full solid, iterate `Solid::iter_face()` and call `project`
 	/// on each face; the caller picks the smallest-distance face and keeps
 	/// the face object for follow-up queries (e.g. `face.id()` for


### PR DESCRIPTION
Closes #280. The `Edge::project` half landed in #281.
（#280 を解決。`Edge::project` 側は #281 で対応済み。）

`face_project_point` only consulted `BRepExtrema_ExtPF`, which keeps just the orthogonal
projections its `BRepClass_FaceClassifier` pass classifies inside the face. That failed two
different ways.

（`face_project_point` は `BRepExtrema_ExtPF` だけを見ていた。これは
`BRepClass_FaceClassifier` で面内と判定された直交射影しか残さないため、2通りに壊れていた。）

## 1. No extremum survives the trim → assert

Every face of a plain cube asserted for a point whose perpendicular foot lands outside it.
（垂線の足が面の外に落ちる点に対し、ただの立方体の6面すべてが `assert!` に当たっていた。）

Measured on the `x = 0` face of `Solid::cube(ZERO, splat(10.0))` before this change:
（修正前、`Solid::cube(ZERO, splat(10.0))` の `x = 0` 面での実測:）

| point | foot | before | after |
| --- | --- | --- | --- |
| `(5, 5, 100)` | `(0, 5, 100)` — outside the trim | **PANIC** | `(0, 5, 10)` |
| `(5, 100, 5)` | `(0, 100, 5)` — outside the trim | **PANIC** | `(0, 10, 5)` |
| `(-100, 5, 5)` | `(0, 5, 5)` — inside the trim | `(0, 5, 5)` | `(0, 5, 5)` |

## 2. Only a far extremum survives → a silently wrong answer

This one never raised anything, which makes it the worse of the two.
（こちらはエラーにすらならないので、2件のうち質が悪い。）

Cut one quadrant off a cylinder to get a **270° cylindrical face**, then project a point
inside the removed sector:
（円柱から1象限を削って **270° の円筒面**を作り、削った象限の中の点を射影する:）

```rust
let cyl = Solid::cylinder(10.0, DVec3::Z * 20.0);
let cutter = Solid::cube(DVec3::new(0.0, -20.0, -1.0), DVec3::new(20.0, 0.0, 21.0));
let part = (&cyl - &cutter).build()?;
let p = DVec3::new(5.0, -5.0, 10.0);
```

| | closest point | distance |
| --- | --- | ---: |
| before | `(-7.071, 7.071, 10)` — the opposite wall | 17.071 |
| **after** | `(10, 0, 10)` | **7.071** |
| true nearest (boundary edge) | `(10, 0, 10)` | 7.071 |

A cylinder has two orthogonal extrema, near and far. The point sits at −45°, inside the
removed sector, so the near foot is trimmed away and only the far one survives. `ExtPF`
reports `NbExt() == 1`, nothing signals a problem, and the answer is 2.4x too far.

（円筒面の直交射影の臨界点は近い側と遠い側の2つ。点の角度 −45° は削った象限にあるので
近い側の足はトリムで捨てられ、遠い側だけが残る。`ExtPF` は `NbExt() == 1` を返すので
異常が何も立たず、2.4倍遠い答えが出る。）

## Fix / 修正

The minimum over a trimmed face is attained either at an interior critical point or on a
boundary wire. An interior one existing does not make it the nearest, so **both sets are
compared** rather than the boundary being a fallback for a failed interior pass — case 2
above has `NbExt() != 0` and a fallback would never run.

（トリム面上の最小値は内部の臨界点か境界ワイヤ上で達成される。内部に臨界点があっても
それが最近点とは限らないので、**両方を比較**する。「内部が失敗したら境界へ」という
フォールバックでは、`NbExt() != 0` である上記2番目のケースを取りこぼす。）

The boundary pass reuses `BRepAdaptor_Curve` + `Extrema_ExtPC` (the same pair #281 moved
`edge_project_point` to) and also tests both endpoints, since an interior extremum of a
boundary curve can be farther than either end. Outer and inner wires need no distinction —
`TopExp_Explorer` over `TopAbs_EDGE` walks both. The normal at a boundary hit comes from
`BRep_Tool::CurveOnSurface`, evaluated at the same parameter the edge uses.

（境界パスは `BRepAdaptor_Curve` + `Extrema_ExtPC`（#281 で `edge_project_point` を移した
のと同じ組）を使い、両端点も候補に入れる（境界曲線の内部極値が端点より遠いことがある）。
外周ワイヤと穴ワイヤを区別する必要はなく `TopExp_Explorer` で全エッジを舐めれば足りる。
境界解の法線は `BRep_Tool::CurveOnSurface` の pcurve をエッジと同じパラメータで評価して得る。）

## Cost / コスト

Release build, 10000 calls, on the interior-trim case both implementations handle:
（release ビルド、10000 回。両実装が扱える「足がトリム内」のケースで計測:）

| face | before µs/call | after µs/call | ratio |
| --- | ---: | ---: | ---: |
| planar, cube face (4 boundary edges) | 5.651 | 6.834 | 1.21x |
| cylinder side face (3 boundary edges) | 10.303 | 11.681 | 1.13x |

The added boundary pass costs about 0.35 µs per boundary edge, matching the per-edge
projection figures in #281. The absolute cost stays dominated by `ExtPF` and the vertex
wrapper it needs.

（追加した境界パスは境界エッジ1本あたり約 0.35 µs で、#281 のエッジ射影の実測と一致する。
絶対値は依然として `ExtPF` とそれが要求する頂点ラッパが支配的。）

## Semantics / 意味論

`FaceStruct::project` already documented its result as `closest_point` that "respects the
face's trim", so this makes the implementation match the contract rather than changing it.
One consequence is now spelled out in the doc: when the hit lands on a boundary wire,
`p - closest_point` is not parallel to `outward_normal`, which always describes the surface
at the hit.

（`FaceStruct::project` の doc は元から「トリムを尊重した `closest_point`」と約束していたので、
これは契約の変更ではなく実装を契約に合わせる修正。一つだけ帰結を doc に明記した:
最近点が境界ワイヤ上に落ちたとき、`p - closest_point` は `outward_normal` と平行にならない。
法線は常に「その点における面の法線」を表す。）

## Verification / 検証

- `cargo test` — 17 suites, all green（17スイート全て green）
- `cargo run --example codegen -- src/traits.rs src/lib.rs` — no drift（差分なし）
- Both reproductions from #280 and the 270° case return the correct nearest point; the
  interior-trim case is unchanged
  （#280 の再現2件と 270° のケースが正しい最近点を返し、トリム内のケースは結果が変わらない）
