### PR TITLE
Decode the prebuilt OCCT tarball with flate2 instead of libflate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,12 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,12 +16,6 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstyle"
@@ -96,8 +84,8 @@ dependencies = [
  "cmake",
  "cxx",
  "cxx-build",
+ "flate2",
  "glam",
- "libflate",
  "minreq",
  "regex",
  "tar",
@@ -241,12 +229,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dary_heap"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,11 +331,6 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
-]
 
 [[package]]
 name = "indexmap"
@@ -380,30 +357,6 @@ name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
-
-[[package]]
-name = "libflate"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd96e993e5f3368b0cb8497dae6c860c22af8ff18388c61c6c0b86c58d86b5df"
-dependencies = [
- "adler32",
- "crc32fast",
- "dary_heap",
- "libflate_lz77",
- "no_std_io2",
-]
-
-[[package]]
-name = "libflate_lz77"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff7a10e427698aef6eef269482776debfef63384d30f13aad39a1a95e0e098fd"
-dependencies = [
- "hashbrown",
- "no_std_io2",
- "rle-decode-fast",
-]
 
 [[package]]
 name = "libredox"
@@ -463,15 +416,6 @@ dependencies = [
  "rustls",
  "rustls-webpki",
  "webpki-roots",
-]
-
-[[package]]
-name = "no_std_io2"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -580,12 +524,6 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "rle-decode-fast"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tiny-skia = { version = "0.11", optional = true }
 cxx-build = "1"
 # download and extract prebuilt OCCT tarball
 minreq = { version = "3", features = ["https-rustls"] }
-libflate = "2"
+flate2 = "1"
 tar = "0.4"
 walkdir = "2"
 # source feature only: build OCCT from upstream sources

--- a/build.rs
+++ b/build.rs
@@ -268,7 +268,7 @@ fn occt_from_prebuilt(effective_root: &Path, target: &str) -> Option<Vec<PathBuf
 }
 
 fn download_and_extract_tar_gz(url: &str, dest: &Path) -> Result<(), String> {
-	let gz = libflate::gzip::Decoder::new(fetch(url)?).map_err(|e| format!("gzip decode failed: {e}"))?;
+	let gz = flate2::read::GzDecoder::new(fetch(url)?);
 	tar::Archive::new(gz).unpack(dest).map_err(|e| format!("tar unpack failed: {e}"))
 }
 


### PR DESCRIPTION
`build.rs` unpacks the prebuilt OCCT tarball through `libflate`. Swapping it for `flate2` removes dependencies, restores a declared MSRV, and decodes faster.

（`build.rs` はプリビルド OCCT tarball の展開に `libflate` を使っている。`flate2` に差し替えると依存が減り、MSRV 宣言が戻り、伸長も速くなる。）

### 1. `libflate` declares no MSRV

Every published `libflate` 2.x version carries `rust_version: null`, so a `cargo update` can silently pull a tree that needs a newer rustc than the one a consumer has pinned. `flate2` 1.1.x declares `rust-version = "1.67.0"` and has kept it stable. This crate declares no `rust-version` of its own, so the floor is whatever the dependency tree implies — that floor should at least come from crates that state one.

（`libflate` 2.x は公開されている全バージョンが `rust_version: null` で、MSRV を宣言していない。そのため `cargo update` が、利用者の固定した rustc より新しいものを要求するツリーを黙って引き込みうる。`flate2` 1.1.x は `rust-version = "1.67.0"` を宣言し続けている。cadrum 自身は `rust-version` を持たないので下限は依存ツリー任せになるが、その下限は少なくとも宣言のあるクレート由来であるべき。）

### 2. Seven packages leave the lockfile, none arrive

`adler32`, `allocator-api2`, `dary_heap`, `libflate`, `libflate_lz77`, `no_std_io2`, `rle-decode-fast`. `flate2` and `miniz_oxide` were already in `Cargo.lock` via `png`, so nothing new is added. `Cargo.lock` shrinks by 64 lines.

（`adler32` `allocator-api2` `dary_heap` `libflate` `libflate_lz77` `no_std_io2` `rle-decode-fast` の 7 つが消える。`flate2` と `miniz_oxide` は `png` 経由で既に `Cargo.lock` にあるため新規追加はゼロ。`Cargo.lock` は 64 行減る。）

### 3. Decoding is 1.7-2.6x faster

Measured on the real payload, `occt-8_0_1_rev2-wasm32_unknown_unknown.tar.gz` (35.5 MB compressed, 160.3 MB expanded), decode only, best of 5, input preloaded into memory:

| profile | flate2 | libflate |
| --- | --- | --- |
| `opt-level = 3` | **0.218 s** (162.6 MB/s in) | 0.368 s (96.5 MB/s in) |
| `opt-level = 0` (build script default) | **1.118 s** (31.8 MB/s in) | 2.881 s (12.3 MB/s in) |

Build scripts compile unoptimized by default, so the second row is the one this crate actually pays: about 1.76 s saved per cold build, more for the larger targets (the windows-msvc tarball is 131 MB). Byte-for-byte identical output from both. flate2 1.1.10 / libflate 2.3.2, rustc 1.93.1, Windows.

（実ペイロード `occt-8_0_1_rev2-wasm32_unknown_unknown.tar.gz`（圧縮 35.5 MB / 展開 160.3 MB）で伸長のみを計測、5 回の best、入力はメモリに事前読み込み。ビルドスクリプトは既定で最適化なしにコンパイルされるため、実際に効くのは下段で、コールドビルドあたり約 1.76 秒短縮される。より大きいターゲット（windows-msvc の tarball は 131 MB）ではさらに差が開く。出力はバイト単位で一致。）

### Behaviour

`GzDecoder::new` is infallible, so the eager `map_err` disappears. A malformed gzip header now surfaces during the read as `tar unpack failed: ...` instead of `gzip decode failed: ...`. Both backends are pure Rust — default features keep `flate2` on `miniz_oxide`, so the `wasm32-unknown-unknown` self-contained build is unaffected. Do not enable the `zlib` features, which would pull in C.

（`GzDecoder::new` は `Result` を返さないので先読みの `map_err` が消える。不正な gzip ヘッダは読み出し時に `tar unpack failed: ...` として報告されるようになる。どちらも pure Rust で、既定 feature のままなら `flate2` は `miniz_oxide` を使うため `wasm32-unknown-unknown` の自己完結ビルドに影響はない。C を引き込む `zlib` 系 feature は有効にしないこと。）

### Verification

- `cargo build` ok
- Moved the cached extraction aside and forced `build.rs` to rerun: download and unpack completed through `flate2`, cache directory recreated (244 MB)
- `cargo test -j 1`: 17 suites, 91 passed, 0 failed, 3 ignored, no warnings

（キャッシュ済み展開ディレクトリを退避して `build.rs` を強制再実行し、`flate2` 経由でのダウンロードと展開、キャッシュ再作成（244 MB）を確認済み。）
