### PR TITLE
Add Face::area and Face::center

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ C++17 compiler (GCC, Clang, or MSVC) and CMake.
 | **Curves** | `Edge::line`, `Edge::arc_3pts`, `Edge::circle`, `Edge::polygon`, `Edge::helix`, `Edge::bspline` |
 | **Surfacing** | `Solid::extrude`, `Solid::sweep`, `Solid::loft`, `Solid::bspline`, `Solid::sew` |
 | **Editing** | `Solid::shell`, `Solid::offset`, `Solid::fillet_edges`, `Solid::chamfer_edges`, `Solid::clean` |
-| **Queries** | `Solid::volume`, `Solid::area`, `Solid::center`, `Solid::inertia`, `Solid::bounding_box`, `Solid::contains` |
+| **Queries** | `Solid::volume`, `Solid::area`, `Solid::center`, `Solid::inertia`, `Solid::distance`, `Solid::bounding_box`, `Solid::contains`, `Face::area`, `Face::center` |
 | **Topology** | `Solid::iter_face`, `Solid::iter_edge`, `Face::iter_edge`, `Face::project`, `Edge::project` |
 | **Identity / history** | `Solid::id`, `Face::id`, `Edge::id`, `Solid::iter_history` |
 | **I/O** | `Solid::read_step` / `Solid::write_step`, `Solid::read_brep` / `Solid::write_brep` (BRep = OCCT's `BinTools` binary format) |

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ C++17 compiler (GCC, Clang, or MSVC) and CMake.
 | **Curves** | `Edge::line`, `Edge::arc_3pts`, `Edge::circle`, `Edge::polygon`, `Edge::helix`, `Edge::bspline` |
 | **Surfacing** | `Solid::extrude`, `Solid::sweep`, `Solid::loft`, `Solid::bspline`, `Solid::sew` |
 | **Editing** | `Solid::shell`, `Solid::offset`, `Solid::fillet_edges`, `Solid::chamfer_edges`, `Solid::clean` |
-| **Queries** | `Solid::volume`, `Solid::area`, `Solid::center`, `Solid::inertia`, `Solid::distance`, `Solid::bounding_box`, `Solid::contains`, `Face::area`, `Face::center` |
+| **Queries** | `Solid::volume`, `Solid::area`, `Solid::center`, `Solid::inertia`, `Solid::bounding_box`, `Solid::contains`, `Face::area`, `Face::center` |
 | **Topology** | `Solid::iter_face`, `Solid::iter_edge`, `Face::iter_edge`, `Face::project`, `Edge::project` |
 | **Identity / history** | `Solid::id`, `Face::id`, `Edge::id`, `Solid::iter_history` |
 | **I/O** | `Solid::read_step` / `Solid::write_step`, `Solid::read_brep` / `Solid::write_brep` (BRep = OCCT's `BinTools` binary format) |

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -22,6 +22,9 @@ pub enum Error {
 	/// Shape cleaning (UnifySameDomain) failed.
 	Clean,
 
+	/// Minimum-distance query (`Solid::distance`) failed.
+	Distance,
+
 	/// Extrusion (`Solid::extrude`) failed: empty profile, zero-length direction, or profile not closed.
 	Extrude,
 
@@ -60,6 +63,7 @@ impl std::fmt::Display for Error {
 			Error::NotOne(n) => write!(f, "Expected exactly one resulting Solid, got {n}"),
 			Error::Edge(msg) => write!(f, "Edge failed: {msg}"),
 			Error::Clean => write!(f, "Clean failed"),
+			Error::Distance => write!(f, "Distance failed"),
 			Error::Extrude => write!(f, "Extrude failed"),
 			Error::Sweep(msg) => write!(f, "Sweep failed: {msg}"),
 			Error::Shell(msg) => write!(f, "Shell failed: {msg}"),

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -22,9 +22,6 @@ pub enum Error {
 	/// Shape cleaning (UnifySameDomain) failed.
 	Clean,
 
-	/// Minimum-distance query (`Solid::distance`) failed.
-	Distance,
-
 	/// Extrusion (`Solid::extrude`) failed: empty profile, zero-length direction, or profile not closed.
 	Extrude,
 
@@ -63,7 +60,6 @@ impl std::fmt::Display for Error {
 			Error::NotOne(n) => write!(f, "Expected exactly one resulting Solid, got {n}"),
 			Error::Edge(msg) => write!(f, "Edge failed: {msg}"),
 			Error::Clean => write!(f, "Clean failed"),
-			Error::Distance => write!(f, "Distance failed"),
 			Error::Extrude => write!(f, "Extrude failed"),
 			Error::Sweep(msg) => write!(f, "Sweep failed: {msg}"),
 			Error::Shell(msg) => write!(f, "Shell failed: {msg}"),

--- a/src/ffi.cpp
+++ b/src/ffi.cpp
@@ -586,12 +586,6 @@ double shape_volume(const TopoDS_Shape& shape) {
     return props.Mass();
 }
 
-double shape_surface_area(const TopoDS_Shape& shape) {
-    GProp_GProps props;
-    BRepGProp::SurfaceProperties(shape, props);
-    return props.Mass();
-}
-
 void shape_center_of_mass(const TopoDS_Shape& shape,
     double& x, double& y, double& z)
 {

--- a/src/ffi.cpp
+++ b/src/ffi.cpp
@@ -44,7 +44,6 @@
 #include <BRepBuilderAPI_Sewing.hxx>
 #include <BRepBuilderAPI_Transform.hxx>
 #include <BRepClass3d_SolidClassifier.hxx>
-#include <BRepExtrema_DistShapeShape.hxx>
 #include <BRepExtrema_ExtPF.hxx>
 #include <BRepLProp_SLProps.hxx>
 #include <BRepAdaptor_Surface.hxx>
@@ -619,23 +618,6 @@ void shape_inertia_tensor(const TopoDS_Shape& shape,
     m02 = ic.Value(1,3) - mass * dx * dz;
     m12 = ic.Value(2,3) - mass * dy * dz;
     m10 = m01; m20 = m02; m21 = m12;
-}
-
-// Exact minimum distance; zero when the two volumes overlap (InnerSolution).
-bool shape_distance(const TopoDS_Shape& first, const TopoDS_Shape& second, double& out_distance) {
-    try {
-        BRepExtrema_DistShapeShape query(first, second);
-        if (!query.IsDone()) return false;
-        if (query.InnerSolution()) {
-            out_distance = 0.0;
-            return true;
-        }
-        if (query.NbSolution() == 0) return false;
-        out_distance = query.Value();
-        return std::isfinite(out_distance) && out_distance >= 0.0;
-    } catch (const Standard_Failure&) {
-        return false;
-    }
 }
 
 bool shape_contains_point(const TopoDS_Shape& shape, double x, double y, double z) {

--- a/src/ffi.cpp
+++ b/src/ffi.cpp
@@ -44,6 +44,7 @@
 #include <BRepBuilderAPI_Sewing.hxx>
 #include <BRepBuilderAPI_Transform.hxx>
 #include <BRepClass3d_SolidClassifier.hxx>
+#include <BRepExtrema_DistShapeShape.hxx>
 #include <BRepExtrema_ExtPF.hxx>
 #include <BRepLProp_SLProps.hxx>
 #include <BRepAdaptor_Surface.hxx>
@@ -626,6 +627,23 @@ void shape_inertia_tensor(const TopoDS_Shape& shape,
     m10 = m01; m20 = m02; m21 = m12;
 }
 
+// Exact minimum distance; zero when the two volumes overlap (InnerSolution).
+bool shape_distance(const TopoDS_Shape& first, const TopoDS_Shape& second, double& out_distance) {
+    try {
+        BRepExtrema_DistShapeShape query(first, second);
+        if (!query.IsDone()) return false;
+        if (query.InnerSolution()) {
+            out_distance = 0.0;
+            return true;
+        }
+        if (query.NbSolution() == 0) return false;
+        out_distance = query.Value();
+        return std::isfinite(out_distance) && out_distance >= 0.0;
+    } catch (const Standard_Failure&) {
+        return false;
+    }
+}
+
 bool shape_contains_point(const TopoDS_Shape& shape, double x, double y, double z) {
     BRepClass3d_SolidClassifier classifier(shape, gp_Pnt(x, y, z), 1e-6);
     return classifier.State() == TopAbs_IN;
@@ -788,6 +806,21 @@ uint64_t shape_tshape_id(const TopoDS_Shape& shape) {
 
 uint64_t edge_tshape_id(const TopoDS_Edge& edge) {
     return reinterpret_cast<uint64_t>(edge.TShape().get());
+}
+
+double face_surface_area(const TopoDS_Face& face) {
+    GProp_GProps props;
+    BRepGProp::SurfaceProperties(face, props);
+    return props.Mass();
+}
+
+void face_center_of_mass(const TopoDS_Face& face,
+    double& x, double& y, double& z)
+{
+    GProp_GProps props;
+    BRepGProp::SurfaceProperties(face, props);
+    gp_Pnt center = props.CentreOfMass();
+    x = center.X(); y = center.Y(); z = center.Z();
 }
 
 bool face_project_point(const TopoDS_Face& face,

--- a/src/ffi.h
+++ b/src/ffi.h
@@ -171,7 +171,6 @@ void shape_inertia_tensor(const TopoDS_Shape& shape,
     double& m00, double& m01, double& m02,
     double& m10, double& m11, double& m12,
     double& m20, double& m21, double& m22);
-bool shape_distance(const TopoDS_Shape& first, const TopoDS_Shape& second, double& out_distance);
 bool shape_contains_point(const TopoDS_Shape& shape, double x, double y, double z);
 void shape_bounding_box(const TopoDS_Shape& shape,
     double& xmin, double& ymin, double& zmin,

--- a/src/ffi.h
+++ b/src/ffi.h
@@ -172,6 +172,7 @@ void shape_inertia_tensor(const TopoDS_Shape& shape,
     double& m00, double& m01, double& m02,
     double& m10, double& m11, double& m12,
     double& m20, double& m21, double& m22);
+bool shape_distance(const TopoDS_Shape& first, const TopoDS_Shape& second, double& out_distance);
 bool shape_contains_point(const TopoDS_Shape& shape, double x, double y, double z);
 void shape_bounding_box(const TopoDS_Shape& shape,
     double& xmin, double& ymin, double& zmin,
@@ -388,6 +389,11 @@ std::unique_ptr<TopoDS_Shape> make_bspline_solid(
 uint64_t face_tshape_id(const TopoDS_Face& face);
 uint64_t shape_tshape_id(const TopoDS_Shape& shape);
 uint64_t edge_tshape_id(const TopoDS_Edge& edge);
+
+double face_surface_area(const TopoDS_Face& face);
+// Area-weighted center of the trimmed face surface.
+void face_center_of_mass(const TopoDS_Face& face,
+    double& x, double& y, double& z);
 
 // Project a 3D point onto `face`. Sister of `edge_project_point`.
 // Returns the closest point on the (trimmed) face surface and the outward

--- a/src/ffi.h
+++ b/src/ffi.h
@@ -165,7 +165,6 @@ std::unique_ptr<TopoDS_Shape> transform_mirror(
 bool shape_is_null(const TopoDS_Shape& shape);
 bool shape_is_solid(const TopoDS_Shape& shape);
 double shape_volume(const TopoDS_Shape& shape);
-double shape_surface_area(const TopoDS_Shape& shape);
 void shape_center_of_mass(const TopoDS_Shape& shape,
     double& x, double& y, double& z);
 void shape_inertia_tensor(const TopoDS_Shape& shape,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -100,7 +100,6 @@ mod ffi_bridge {
 		fn shape_is_null(shape: &TopoDS_Shape) -> bool;
 		fn shape_is_solid(shape: &TopoDS_Shape) -> bool;
 		fn shape_volume(shape: &TopoDS_Shape) -> f64;
-		fn shape_surface_area(shape: &TopoDS_Shape) -> f64;
 		fn shape_center_of_mass(shape: &TopoDS_Shape, x: &mut f64, y: &mut f64, z: &mut f64);
 		fn shape_inertia_tensor(shape: &TopoDS_Shape, m00: &mut f64, m01: &mut f64, m02: &mut f64, m10: &mut f64, m11: &mut f64, m12: &mut f64, m20: &mut f64, m21: &mut f64, m22: &mut f64);
 		fn shape_distance(first: &TopoDS_Shape, second: &TopoDS_Shape, out_distance: &mut f64) -> bool;

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -102,7 +102,6 @@ mod ffi_bridge {
 		fn shape_volume(shape: &TopoDS_Shape) -> f64;
 		fn shape_center_of_mass(shape: &TopoDS_Shape, x: &mut f64, y: &mut f64, z: &mut f64);
 		fn shape_inertia_tensor(shape: &TopoDS_Shape, m00: &mut f64, m01: &mut f64, m02: &mut f64, m10: &mut f64, m11: &mut f64, m12: &mut f64, m20: &mut f64, m21: &mut f64, m22: &mut f64);
-		fn shape_distance(first: &TopoDS_Shape, second: &TopoDS_Shape, out_distance: &mut f64) -> bool;
 		fn shape_contains_point(shape: &TopoDS_Shape, x: f64, y: f64, z: f64) -> bool;
 		fn shape_bounding_box(shape: &TopoDS_Shape, xmin: &mut f64, ymin: &mut f64, zmin: &mut f64, xmax: &mut f64, ymax: &mut f64, zmax: &mut f64);
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -103,6 +103,7 @@ mod ffi_bridge {
 		fn shape_surface_area(shape: &TopoDS_Shape) -> f64;
 		fn shape_center_of_mass(shape: &TopoDS_Shape, x: &mut f64, y: &mut f64, z: &mut f64);
 		fn shape_inertia_tensor(shape: &TopoDS_Shape, m00: &mut f64, m01: &mut f64, m02: &mut f64, m10: &mut f64, m11: &mut f64, m12: &mut f64, m20: &mut f64, m21: &mut f64, m22: &mut f64);
+		fn shape_distance(first: &TopoDS_Shape, second: &TopoDS_Shape, out_distance: &mut f64) -> bool;
 		fn shape_contains_point(shape: &TopoDS_Shape, x: f64, y: f64, z: f64) -> bool;
 		fn shape_bounding_box(shape: &TopoDS_Shape, xmin: &mut f64, ymin: &mut f64, zmin: &mut f64, xmax: &mut f64, ymax: &mut f64, zmax: &mut f64);
 
@@ -131,6 +132,8 @@ mod ffi_bridge {
 		fn shape_tshape_id(shape: &TopoDS_Shape) -> u64;
 		fn edge_tshape_id(edge: &TopoDS_Edge) -> u64;
 
+		fn face_surface_area(face: &TopoDS_Face) -> f64;
+		fn face_center_of_mass(face: &TopoDS_Face, x: &mut f64, y: &mut f64, z: &mut f64);
 		fn face_project_point(face: &TopoDS_Face, px: f64, py: f64, pz: f64, cpx: &mut f64, cpy: &mut f64, cpz: &mut f64, nx: &mut f64, ny: &mut f64, nz: &mut f64) -> bool;
 
 		// ==================== Edge Methods ====================

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,9 +182,6 @@ impl Solid {
 	pub fn inertia(&self) -> DMat3 {
 		<Self as crate::traits::SolidStruct>::inertia(self)
 	}
-	pub fn distance(&self, other: &crate::Solid) -> Result<f64, Error> {
-		<Self as crate::traits::SolidStruct>::distance(self, other)
-	}
 	pub fn contains(&self, point: DVec3) -> bool {
 		<Self as crate::traits::SolidStruct>::contains(self, point)
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,12 @@ impl Face {
 	pub fn id(&self) -> u64 {
 		<Self as crate::traits::FaceStruct>::id(self)
 	}
+	pub fn area(&self) -> f64 {
+		<Self as crate::traits::FaceStruct>::area(self)
+	}
+	pub fn center(&self) -> DVec3 {
+		<Self as crate::traits::FaceStruct>::center(self)
+	}
 	pub fn project(&self, p: DVec3) -> (DVec3, DVec3) {
 		<Self as crate::traits::FaceStruct>::project(self, p)
 	}
@@ -175,6 +181,9 @@ impl Solid {
 	}
 	pub fn inertia(&self) -> DMat3 {
 		<Self as crate::traits::SolidStruct>::inertia(self)
+	}
+	pub fn distance(&self, other: &crate::Solid) -> Result<f64, Error> {
+		<Self as crate::traits::SolidStruct>::distance(self, other)
 	}
 	pub fn contains(&self, point: DVec3) -> bool {
 		<Self as crate::traits::SolidStruct>::contains(self, point)

--- a/src/occt/face.rs
+++ b/src/occt/face.rs
@@ -35,6 +35,16 @@ impl FaceStruct for Face {
 		ffi::face_tshape_id(&self.inner)
 	}
 
+	fn area(&self) -> f64 {
+		ffi::face_surface_area(&self.inner)
+	}
+
+	fn center(&self) -> DVec3 {
+		let (mut x, mut y, mut z) = (0.0_f64, 0.0_f64, 0.0_f64);
+		ffi::face_center_of_mass(&self.inner, &mut x, &mut y, &mut z);
+		DVec3::new(x, y, z)
+	}
+
 	fn project(&self, p: DVec3) -> (DVec3, DVec3) {
 		let (mut cpx, mut cpy, mut cpz) = (0.0_f64, 0.0_f64, 0.0_f64);
 		let (mut nx, mut ny, mut nz) = (0.0_f64, 0.0_f64, 0.0_f64);

--- a/src/occt/solid.rs
+++ b/src/occt/solid.rs
@@ -642,6 +642,11 @@ impl SolidStruct for Solid {
 		glam::DMat3::from_cols_array(&[m00, m10, m20, m01, m11, m21, m02, m12, m22])
 	}
 
+	fn distance(&self, other: &Self) -> Result<f64, Error> {
+		let mut distance = 0.0;
+		ffi::shape_distance(&self.inner, &other.inner, &mut distance).then_some(distance).ok_or(Error::Distance)
+	}
+
 	fn contains(&self, point: DVec3) -> bool {
 		ffi::shape_contains_point(&self.inner, point.x, point.y, point.z)
 	}

--- a/src/occt/solid.rs
+++ b/src/occt/solid.rs
@@ -622,10 +622,6 @@ impl SolidStruct for Solid {
 		ffi::shape_volume(&self.inner)
 	}
 
-	fn area(&self) -> f64 {
-		ffi::shape_surface_area(&self.inner)
-	}
-
 	fn center(&self) -> DVec3 {
 		let (mut x, mut y, mut z) = (0.0_f64, 0.0_f64, 0.0_f64);
 		ffi::shape_center_of_mass(&self.inner, &mut x, &mut y, &mut z);

--- a/src/occt/solid.rs
+++ b/src/occt/solid.rs
@@ -638,11 +638,6 @@ impl SolidStruct for Solid {
 		glam::DMat3::from_cols_array(&[m00, m10, m20, m01, m11, m21, m02, m12, m22])
 	}
 
-	fn distance(&self, other: &Self) -> Result<f64, Error> {
-		let mut distance = 0.0;
-		ffi::shape_distance(&self.inner, &other.inner, &mut distance).then_some(distance).ok_or(Error::Distance)
-	}
-
 	fn contains(&self, point: DVec3) -> bool {
 		ffi::shape_contains_point(&self.inner, point.x, point.y, point.z)
 	}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -508,7 +508,9 @@ pub trait SolidStruct: Sized + Clone + Debug + Transform {
 	/// Volume of the solid (uniform density).
 	fn volume(&self) -> f64;
 	/// Total surface area of the solid.
-	fn area(&self) -> f64;
+	fn area(&self) -> f64 {
+		self.iter_face().map(FaceStruct::area).sum()
+	}
 	/// Center of mass (uniform density).
 	fn center(&self) -> DVec3;
 	/// Inertia tensor about the **world origin** (uniform density).

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -515,8 +515,6 @@ pub trait SolidStruct: Sized + Clone + Debug + Transform {
 	fn center(&self) -> DVec3;
 	/// Inertia tensor about the **world origin** (uniform density).
 	fn inertia(&self) -> DMat3;
-	/// Exact minimum distance to `other`; zero when the two volumes overlap.
-	fn distance(&self, other: &Self) -> Result<f64, Error>;
 	/// Whether `point` lies inside (or on) the solid.
 	fn contains(&self, point: DVec3) -> bool;
 	/// Axis-aligned bounding box as `[min, max]`.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -422,6 +422,13 @@ pub trait FaceStruct: Sized + Debug {
 	/// meaning beyond equality / hash use.
 	fn id(&self) -> u64;
 
+	/// Area of the trimmed face.
+	fn area(&self) -> f64;
+
+	/// Area-weighted center of the trimmed face, for directional face selection.
+	/// Curved or concave faces place it off the face; `project` maps it back on.
+	fn center(&self) -> DVec3;
+
 	/// Project a 3D point onto this face. Returns `(closest_point,
 	/// outward_normal)`. Sister of `Wire::project` which returns `(closest,
 	/// tangent)` on a 1D curve.
@@ -506,6 +513,8 @@ pub trait SolidStruct: Sized + Clone + Debug + Transform {
 	fn center(&self) -> DVec3;
 	/// Inertia tensor about the **world origin** (uniform density).
 	fn inertia(&self) -> DMat3;
+	/// Exact minimum distance to `other`; zero when the two volumes overlap.
+	fn distance(&self, other: &Self) -> Result<f64, Error>;
 	/// Whether `point` lies inside (or on) the solid.
 	fn contains(&self, point: DVec3) -> bool;
 	/// Axis-aligned bounding box as `[min, max]`.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -426,7 +426,8 @@ pub trait FaceStruct: Sized + Debug {
 	fn area(&self) -> f64;
 
 	/// Area-weighted center of the trimmed face, for directional face selection.
-	/// Curved or concave faces place it off the face; `project` maps it back on.
+	/// Curved or concave faces place it off the face, and on a closed surface
+	/// no single point of the face is nearest to it, so `project` picks one arbitrarily.
 	fn center(&self) -> DVec3;
 
 	/// Project a 3D point onto this face. Returns `(closest_point,

--- a/tests/solid_query.rs
+++ b/tests/solid_query.rs
@@ -83,22 +83,6 @@ fn test_cube_face_centers_match_analytical() {
 	}
 }
 
-/// Minimum distance between two 10-cubes offset along x: a 5 gap measures 5
-/// and is symmetric, while touching, overlapping and nested pairs read zero.
-#[test]
-fn test_cube_distance_matches_analytical() {
-	let a = 10.0_f64;
-	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(a));
-	let shifted = |dx: f64| Solid::cube(DVec3::new(dx, 0.0, 0.0), DVec3::new(dx + a, a, a));
-	let nested = Solid::cube(DVec3::splat(2.0), DVec3::splat(8.0));
-
-	assert!((cube.distance(&shifted(15.0)).unwrap() - 5.0).abs() < EPS);
-	assert!((shifted(15.0).distance(&cube).unwrap() - 5.0).abs() < EPS);
-	assert!(cube.distance(&shifted(10.0)).unwrap() < EPS);
-	assert!(cube.distance(&shifted(9.0)).unwrap() < EPS);
-	assert!(cube.distance(&nested).unwrap() < EPS);
-}
-
 /// Every face of a cube has area a², and the six sum to the solid's own area.
 #[test]
 fn test_cube_face_areas_match_analytical() {

--- a/tests/solid_query.rs
+++ b/tests/solid_query.rs
@@ -62,3 +62,53 @@ fn test_sphere_mass_properties_match_analytical() {
 	assert!(i.col(2).x.abs() < 1e-3);
 	assert!(i.col(2).y.abs() < 1e-3);
 }
+
+/// A cube's six face centers sit at the middle of each side: per axis the
+/// extremes are 0 and `a`, and every center lies on its own face.
+#[test]
+fn test_cube_face_centers_match_analytical() {
+	let a = 10.0_f64;
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(a));
+	let centers = cube.iter_face().map(|face| face.center()).collect::<Vec<_>>();
+
+	assert_eq!(centers.len(), 6);
+	for axis in 0..3 {
+		let min = centers.iter().map(|c| c[axis]).fold(f64::INFINITY, f64::min);
+		let max = centers.iter().map(|c| c[axis]).fold(f64::NEG_INFINITY, f64::max);
+		assert!(min.abs() < EPS, "axis {axis} minimum = {min}, expected 0");
+		assert!((max - a).abs() < EPS, "axis {axis} maximum = {max}, expected {a}");
+	}
+	for (face, center) in cube.iter_face().zip(&centers) {
+		assert!((face.project(*center).0 - *center).length() < EPS, "center {center} is off its own face");
+	}
+}
+
+/// Minimum distance between two 10-cubes offset along x: a 5 gap measures 5
+/// and is symmetric, while touching, overlapping and nested pairs read zero.
+#[test]
+fn test_cube_distance_matches_analytical() {
+	let a = 10.0_f64;
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(a));
+	let shifted = |dx: f64| Solid::cube(DVec3::new(dx, 0.0, 0.0), DVec3::new(dx + a, a, a));
+	let nested = Solid::cube(DVec3::splat(2.0), DVec3::splat(8.0));
+
+	assert!((cube.distance(&shifted(15.0)).unwrap() - 5.0).abs() < EPS);
+	assert!((shifted(15.0).distance(&cube).unwrap() - 5.0).abs() < EPS);
+	assert!(cube.distance(&shifted(10.0)).unwrap() < EPS);
+	assert!(cube.distance(&shifted(9.0)).unwrap() < EPS);
+	assert!(cube.distance(&nested).unwrap() < EPS);
+}
+
+/// Every face of a cube has area a², and the six sum to the solid's own area.
+#[test]
+fn test_cube_face_areas_match_analytical() {
+	let a = 10.0_f64;
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(a));
+	let areas = cube.iter_face().map(|face| face.area()).collect::<Vec<_>>();
+
+	assert_eq!(areas.len(), 6);
+	for area in &areas {
+		assert!((area - a.powi(2)).abs() < EPS, "face area = {area}, expected {}", a.powi(2));
+	}
+	assert!((areas.iter().sum::<f64>() - cube.area()).abs() < EPS);
+}


### PR DESCRIPTION
Two exact face queries picked from the `inferno-sh/cadrum` fork — `Face::area` and `Face::center` — and, on the strength of the measurements below, one FFI function removed.

（`inferno-sh/cadrum` フォークから拾った 2 つの厳密な面クエリ `Face::area` と `Face::center`。加えて、下記の計測を根拠に FFI 関数を 1 本削除する。）

### Why a face center

Two unrelated forks of this crate — `inferno-sh/cadrum` and `cadona-app/cadona-cadrum` — independently added a face center. When two downstreams write the same thing twice without knowing about each other, the gap is real rather than project-specific.

（このクレートの無関係な 2 つのフォークが、面の中心を互いに独立に実装していた。2 つの下流が互いを知らないまま同じものを書いたなら、その欠落はプロジェクト固有の要求ではなく本当の欠落。）

The other fork also carries a `face_planar_frame` returning a point plus a normal in one call. That is not added here. `face.project(face.center())` composes the same pair out of APIs that already exist, without a "planar surfaces only" restriction, and since #282 made `Face::project` return the true nearest point on a trimmed face it lands on the face. The face-center test asserts this on a cube.

（もう一方のフォークは点と法線を 1 回で返す `face_planar_frame` も持つが、ここでは追加しない。`face.project(face.center())` が既存 API だけで同じ組を作れ、平面限定の制約も無く、#282 以降は面上に落ちる。面中心のテストは cube でこれを検証している。）

`center` deliberately returns the centroid rather than that pair. The centroid is a geometric invariant; the projection of it is not. On a closed surface every point of the face is equidistant from the centroid, so the projected point is whichever one OCCT reaches first:

（`center` があえてその組ではなく重心を返すのは、重心が幾何的不変量である一方、その投影先はそうではないため。閉じた曲面では面上のどの点も重心から等距離なので、投影先は OCCT が先に到達した点になる。）

| shape | face | distance from centroid to its projection |
| --- | --- | --- |
| cube | all six | 0.0000 |
| cylinder | end caps | 0.0000 |
| cylinder | side | 3.0000 |
| cone | side | 3.5576 |
| sphere | the one face | 5.0000 |
| torus | the one face | 7.0000 |

Composing at the call site keeps that visible instead of hiding it inside `center`. The doc comment now says so.

（呼び出し側で合成させれば、その事実が `center` の内側に隠れずに見える。doc コメントにもそう書いた。）

### `Face::area` does not shadow `Solid::area`

Summing the faces is exact, not an approximation. `cargo test --release`, best of 300:

| shape | faces | `Solid::area()` | `sum(Face::area())` | difference |
| --- | --- | --- | --- | --- |
| cube | 6 | 55.6 us | 56.0 us | **0.000e0** |
| sphere | 1 | 64.4 us | 64.3 us | **0.000e0** |
| cylinder | 3 | 64.2 us | 64.3 us | **0.000e0** |
| cone | 3 | 69.9 us | 73.4 us | **0.000e0** |
| torus | 1 | 65.2 us | 68.6 us | **0.000e0** |
| 20 fused cubes | 158 | 1401.8 us | 1426.8 us | **0.000e0** |

Bit-identical in every case, and the error against the analytical area is identical too (cube 1.137e-13, sphere 0, cylinder 2.842e-14 for both). Both paths run `BRepGProp::SurfaceProperties`, and the whole-shape call walks the same faces in the same order, so even the floating-point summation order matches. The whole-shape call leads by 1.8% at 158 faces, because the per-face path pays N FFI hops instead of one; the Gauss quadrature dominates either way.

（全ケースでビット単位に一致し、解析解との誤差も同一。どちらも `BRepGProp::SurfaceProperties` を呼び、全体版は同じ面を同じ順に走査するため加算順序まで一致する。158 面での全体版の優位は 1.8%。）

### So `shape_surface_area` goes away

`SolidStruct::area` becomes a default trait method:

```rust
	/// Total surface area of the solid.
	fn area(&self) -> f64 {
		self.iter_face().map(FaceStruct::area).sum()
	}
```

That drops one C++ function, one header declaration, one bridge line and one backend impl, and a future backend inherits `area` without implementing it. Net for the whole PR: two public methods added, one FFI function added, one removed.

（C++ 関数・ヘッダ宣言・ブリッジ行・バックエンド実装が 1 つずつ減り、将来のバックエンドは `area` を実装せずに済む。PR 全体では公開メソッド +2、FFI は +1 / −1。）

Two consequences. `Solid::area()` used to be allocation-free; it now populates the `iter_face` cache, so a 158-face solid retains 158 `Face` values afterwards — about 1.2 us on a cube, and later topology queries get cheaper. And the `sum == Solid::area()` line in the face-area test is now satisfied by definition for this backend; it survives as a contract check for any backend that overrides `area`.

（副作用が 2 つ。`Solid::area()` はこれまでアロケーションゼロだったが `iter_face` のキャッシュを埋めるようになる。cube で約 1.2 us、以降のトポロジクエリは速くなる。もう 1 つ、面積テストの `sum == Solid::area()` の行はこのバックエンドでは定義上成立するようになり、`area` を独自実装するバックエンドへの契約チェックとしてのみ残る。）

### Adjustments from the original patch

- The fork inserts `center` after its own `FaceStruct::area`, which never existed here — that `area` is its addition, so both methods are new. `FaceStruct` goes from 3 to 5 methods.
- `face_center_of_mass` / `face_surface_area` sit in the Face section of `ffi.rs` / `ffi.h` / `ffi.cpp` rather than among the shape queries.
- Tests go to `tests/solid_query.rs`, which already checks `area` / `center` / `inertia` against analytical solutions.

（フォーク側は自前の `FaceStruct::area` の後ろに `center` を挿入しているが、その `area` は上流に存在しないフォーク独自の追加なので、両方とも新規となり `FaceStruct` は 3 → 5 メソッドになる。FFI は Face セクションに配置。テストは解析解との照合を行っている既存ファイルに追加。）

### Verification

- `cargo build` ok, `cargo fmt` applied
- `cargo test -j 1`: 16 suites, 93 passed, 0 failed, 2 ignored, no warnings
- New tests: cube face areas are a² each and sum to `Solid::area`; cube face centers bracket each axis at 0 and a and each lands on its own face
