### PR TITLE
Add Face::surface, the elementary surface a face lies on

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ C++17 compiler (GCC, Clang, or MSVC) and CMake.
 | **Curves** | `Edge::line`, `Edge::arc_3pts`, `Edge::circle`, `Edge::polygon`, `Edge::helix`, `Edge::bspline` |
 | **Surfacing** | `Solid::extrude`, `Solid::sweep`, `Solid::loft`, `Solid::bspline`, `Solid::sew` |
 | **Editing** | `Solid::shell`, `Solid::offset`, `Solid::fillet_edges`, `Solid::chamfer_edges`, `Solid::clean` |
-| **Queries** | `Solid::volume`, `Solid::area`, `Solid::center`, `Solid::inertia`, `Solid::bounding_box`, `Solid::contains`, `Face::area`, `Face::center` |
+| **Queries** | `Solid::volume`, `Solid::area`, `Solid::center`, `Solid::inertia`, `Solid::bounding_box`, `Solid::contains`, `Face::area`, `Face::center`, `Face::surface` |
 | **Topology** | `Solid::iter_face`, `Solid::iter_edge`, `Face::iter_edge`, `Face::project`, `Edge::project` |
 | **Identity / history** | `Solid::id`, `Face::id`, `Edge::id`, `Solid::iter_history` |
 | **I/O** | `Solid::read_step` / `Solid::write_step`, `Solid::read_brep` / `Solid::write_brep` (BRep = OCCT's `BinTools` binary format) |

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -2,3 +2,4 @@ pub mod boolean;
 pub mod color;
 pub mod error;
 pub mod mesh;
+pub mod surface;

--- a/src/common/surface.rs
+++ b/src/common/surface.rs
@@ -1,0 +1,57 @@
+use glam::DVec3;
+
+/// The elementary surface a face lies on: STEP's `axis2_placement_3d` plus the
+/// parameters of the subtype it places.
+///
+/// Reported as the surface itself carries it — the face's own orientation is not
+/// folded in, so `axis` is not necessarily the outward normal of a planar face.
+/// `Face::project` reports that.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Surface {
+	/// STEP `location`. Not a point on the face: a cylinder places it on the
+	/// axis and a sphere at the centre.
+	pub origin: DVec3,
+	/// STEP `axis`, the placement's Z direction.
+	pub axis: DVec3,
+	/// STEP `ref_direction`, already made orthogonal to `axis` and normalised.
+	/// It carries no shape, only where `u = 0` sits on the surface.
+	pub ref_dir: DVec3,
+	/// Whether the placement is right-handed, i.e. whether its Y direction is
+	/// `axis × ref_dir` rather than its negation. Mirroring produces the latter.
+	pub right_handed: bool,
+	pub kind: SurfaceKind,
+}
+
+/// The parameters that distinguish one elementary surface from another.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SurfaceKind {
+	Plane,
+	Cylinder {
+		radius: f64,
+	},
+	Cone {
+		/// Radius where the cone crosses the plane through `origin`.
+		radius: f64,
+		/// Half-angle in radians, signed by the direction the cone widens.
+		semi_angle: f64,
+	},
+	Sphere {
+		radius: f64,
+	},
+	Torus {
+		major_radius: f64,
+		minor_radius: f64,
+	},
+}
+
+impl Surface {
+	/// The placement's Y direction, completing the frame with `axis` and `ref_dir`.
+	pub fn y_dir(&self) -> DVec3 {
+		let y = self.axis.cross(self.ref_dir);
+		if self.right_handed {
+			y
+		} else {
+			-y
+		}
+	}
+}

--- a/src/common/surface.rs
+++ b/src/common/surface.rs
@@ -13,12 +13,11 @@ pub struct Surface {
 	pub origin: DVec3,
 	/// STEP `axis`, the placement's Z direction.
 	pub axis: DVec3,
-	/// STEP `ref_direction`, already made orthogonal to `axis` and normalised.
-	/// It carries no shape, only where `u = 0` sits on the surface.
-	pub ref_dir: DVec3,
-	/// Whether the placement is right-handed, i.e. whether its Y direction is
-	/// `axis × ref_dir` rather than its negation. Mirroring produces the latter.
-	pub right_handed: bool,
+	/// The placement's X direction, fixing where `u = 0` sits on the surface.
+	/// The frame is always right-handed, so its Y direction is `axis.cross(x_dir)`.
+	/// A mirrored face is normalised into that convention, which negates STEP's
+	/// `ref_direction` and moves `u = 0` by half a turn.
+	pub x_dir: DVec3,
 	pub kind: SurfaceKind,
 }
 
@@ -42,16 +41,4 @@ pub enum SurfaceKind {
 		major_radius: f64,
 		minor_radius: f64,
 	},
-}
-
-impl Surface {
-	/// The placement's Y direction, completing the frame with `axis` and `ref_dir`.
-	pub fn y_dir(&self) -> DVec3 {
-		let y = self.axis.cross(self.ref_dir);
-		if self.right_handed {
-			y
-		} else {
-			-y
-		}
-	}
 }

--- a/src/common/surface.rs
+++ b/src/common/surface.rs
@@ -4,7 +4,7 @@ use glam::DVec3;
 /// parameters of the subtype it places.
 ///
 /// Reported as the surface itself carries it — the face's own orientation is not
-/// folded in, so `axis` is not necessarily the outward normal of a planar face.
+/// folded in, so `axis_z` is not necessarily the outward normal of a planar face.
 /// `Face::project` reports that.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Surface {
@@ -12,12 +12,12 @@ pub struct Surface {
 	/// axis and a sphere at the centre.
 	pub origin: DVec3,
 	/// STEP `axis`, the placement's Z direction.
-	pub axis: DVec3,
+	pub axis_z: DVec3,
 	/// The placement's X direction, fixing where `u = 0` sits on the surface.
-	/// The frame is always right-handed, so its Y direction is `axis.cross(x_dir)`.
-	/// A mirrored face is normalised into that convention, which negates STEP's
-	/// `ref_direction` and moves `u = 0` by half a turn.
-	pub x_dir: DVec3,
+	/// The frame is always right-handed, so Y is `axis_z.cross(axis_x)` and is
+	/// not carried. A mirrored face is normalised into that convention, which
+	/// negates STEP's `ref_direction` and moves `u = 0` by half a turn.
+	pub axis_x: DVec3,
 	pub kind: SurfaceKind,
 }
 

--- a/src/ffi.cpp
+++ b/src/ffi.cpp
@@ -22,8 +22,13 @@
 // --- Geometry primitives (gp / Geom / 2d) ---
 #include <gp_Ax1.hxx>
 #include <gp_Ax2.hxx>
+#include <gp_Ax3.hxx>
 #include <gp_Circ.hxx>
+#include <gp_Cone.hxx>
+#include <gp_Cylinder.hxx>
 #include <gp_Pln.hxx>
+#include <gp_Sphere.hxx>
+#include <gp_Torus.hxx>
 #include <gp_Trsf.hxx>
 #include <Geom_CylindricalSurface.hxx>
 #include <Geom2d_Line.hxx>
@@ -70,6 +75,7 @@
 #include <BRepOffset_MakeOffset.hxx>
 #include <BRepOffset_Mode.hxx>
 #include <GeomAbs_JoinType.hxx>
+#include <GeomAbs_SurfaceType.hxx>
 
 // --- Mesh, classification, mass / surface properties ---
 #include <BRepMesh_IncrementalMesh.hxx>
@@ -788,6 +794,60 @@ double face_surface_area(const TopoDS_Face& face) {
     GProp_GProps props;
     BRepGProp::SurfaceProperties(face, props);
     return props.Mass();
+}
+
+uint32_t face_surface(const TopoDS_Face& face,
+    double& ox, double& oy, double& oz,
+    double& ax, double& ay, double& az,
+    double& rx, double& ry, double& rz,
+    bool& right_handed,
+    double& p1, double& p2)
+{
+    uint32_t kind = 0;
+    gp_Ax3 pos;
+    p1 = 0.0; p2 = 0.0;
+    try {
+        BRepAdaptor_Surface surf(face);
+        switch (surf.GetType()) {
+            case GeomAbs_Plane: {
+                kind = 1; pos = surf.Plane().Position();
+                break;
+            }
+            case GeomAbs_Cylinder: {
+                const gp_Cylinder cyl = surf.Cylinder();
+                kind = 2; pos = cyl.Position(); p1 = cyl.Radius();
+                break;
+            }
+            case GeomAbs_Cone: {
+                const gp_Cone cone = surf.Cone();
+                kind = 3; pos = cone.Position();
+                p1 = cone.RefRadius(); p2 = cone.SemiAngle();
+                break;
+            }
+            case GeomAbs_Sphere: {
+                const gp_Sphere sph = surf.Sphere();
+                kind = 4; pos = sph.Position(); p1 = sph.Radius();
+                break;
+            }
+            case GeomAbs_Torus: {
+                const gp_Torus tor = surf.Torus();
+                kind = 5; pos = tor.Position();
+                p1 = tor.MajorRadius(); p2 = tor.MinorRadius();
+                break;
+            }
+            default: break;
+        }
+    } catch (const Standard_Failure&) {
+        return 0;
+    }
+    const gp_Pnt origin = pos.Location();
+    const gp_Dir axis = pos.Direction();
+    const gp_Dir ref = pos.XDirection();
+    ox = origin.X(); oy = origin.Y(); oz = origin.Z();
+    ax = axis.X(); ay = axis.Y(); az = axis.Z();
+    rx = ref.X(); ry = ref.Y(); rz = ref.Z();
+    right_handed = pos.Direct();
+    return kind;
 }
 
 void face_center_of_mass(const TopoDS_Face& face,

--- a/src/ffi.cpp
+++ b/src/ffi.cpp
@@ -799,8 +799,7 @@ double face_surface_area(const TopoDS_Face& face) {
 uint32_t face_surface(const TopoDS_Face& face,
     double& ox, double& oy, double& oz,
     double& ax, double& ay, double& az,
-    double& rx, double& ry, double& rz,
-    bool& right_handed,
+    double& xx, double& xy, double& xz,
     double& p1, double& p2)
 {
     uint32_t kind = 0;
@@ -842,11 +841,12 @@ uint32_t face_surface(const TopoDS_Face& face,
     }
     const gp_Pnt origin = pos.Location();
     const gp_Dir axis = pos.Direction();
-    const gp_Dir ref = pos.XDirection();
+    gp_Dir x = pos.XDirection();
+    // Normalise a mirrored placement, so axis x X is always its Y direction.
+    if (!pos.Direct()) x.Reverse();
     ox = origin.X(); oy = origin.Y(); oz = origin.Z();
     ax = axis.X(); ay = axis.Y(); az = axis.Z();
-    rx = ref.X(); ry = ref.Y(); rz = ref.Z();
-    right_handed = pos.Direct();
+    xx = x.X(); xy = x.Y(); xz = x.Z();
     return kind;
 }
 

--- a/src/ffi.cpp
+++ b/src/ffi.cpp
@@ -798,7 +798,7 @@ double face_surface_area(const TopoDS_Face& face) {
 
 uint32_t face_surface(const TopoDS_Face& face,
     double& ox, double& oy, double& oz,
-    double& ax, double& ay, double& az,
+    double& zx, double& zy, double& zz,
     double& xx, double& xy, double& xz,
     double& p1, double& p2)
 {
@@ -845,7 +845,7 @@ uint32_t face_surface(const TopoDS_Face& face,
     // Normalise a mirrored placement, so axis x X is always its Y direction.
     if (!pos.Direct()) x.Reverse();
     ox = origin.X(); oy = origin.Y(); oz = origin.Z();
-    ax = axis.X(); ay = axis.Y(); az = axis.Z();
+    zx = axis.X(); zy = axis.Y(); zz = axis.Z();
     xx = x.X(); xy = x.Y(); xz = x.Z();
     return kind;
 }

--- a/src/ffi.h
+++ b/src/ffi.h
@@ -391,12 +391,11 @@ uint64_t edge_tshape_id(const TopoDS_Edge& edge);
 double face_surface_area(const TopoDS_Face& face);
 // The face's elementary surface as its STEP axis2_placement_3d-shaped
 // placement. Returns the kind: 0 other, 1 plane, 2 cylinder, 3 cone, 4 sphere,
-// 5 torus. `p1` / `p2` carry the subtype radii and semi-angle.
+// 5 torus. A mirrored placement is normalised so that axis x X is its Y.
 uint32_t face_surface(const TopoDS_Face& face,
     double& ox, double& oy, double& oz,
     double& ax, double& ay, double& az,
-    double& rx, double& ry, double& rz,
-    bool& right_handed,
+    double& xx, double& xy, double& xz,
     double& p1, double& p2);
 // Area-weighted center of the trimmed face surface.
 void face_center_of_mass(const TopoDS_Face& face,

--- a/src/ffi.h
+++ b/src/ffi.h
@@ -394,7 +394,7 @@ double face_surface_area(const TopoDS_Face& face);
 // 5 torus. A mirrored placement is normalised so that axis x X is its Y.
 uint32_t face_surface(const TopoDS_Face& face,
     double& ox, double& oy, double& oz,
-    double& ax, double& ay, double& az,
+    double& zx, double& zy, double& zz,
     double& xx, double& xy, double& xz,
     double& p1, double& p2);
 // Area-weighted center of the trimmed face surface.

--- a/src/ffi.h
+++ b/src/ffi.h
@@ -389,6 +389,15 @@ uint64_t shape_tshape_id(const TopoDS_Shape& shape);
 uint64_t edge_tshape_id(const TopoDS_Edge& edge);
 
 double face_surface_area(const TopoDS_Face& face);
+// The face's elementary surface as its STEP axis2_placement_3d-shaped
+// placement. Returns the kind: 0 other, 1 plane, 2 cylinder, 3 cone, 4 sphere,
+// 5 torus. `p1` / `p2` carry the subtype radii and semi-angle.
+uint32_t face_surface(const TopoDS_Face& face,
+    double& ox, double& oy, double& oz,
+    double& ax, double& ay, double& az,
+    double& rx, double& ry, double& rz,
+    bool& right_handed,
+    double& p1, double& p2);
 // Area-weighted center of the trimmed face surface.
 void face_center_of_mass(const TopoDS_Face& face,
     double& x, double& y, double& z);

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -130,7 +130,7 @@ mod ffi_bridge {
 		fn shape_tshape_id(shape: &TopoDS_Shape) -> u64;
 		fn edge_tshape_id(edge: &TopoDS_Edge) -> u64;
 
-		fn face_surface(face: &TopoDS_Face, ox: &mut f64, oy: &mut f64, oz: &mut f64, ax: &mut f64, ay: &mut f64, az: &mut f64, rx: &mut f64, ry: &mut f64, rz: &mut f64, right_handed: &mut bool, p1: &mut f64, p2: &mut f64) -> u32;
+		fn face_surface(face: &TopoDS_Face, ox: &mut f64, oy: &mut f64, oz: &mut f64, ax: &mut f64, ay: &mut f64, az: &mut f64, xx: &mut f64, xy: &mut f64, xz: &mut f64, p1: &mut f64, p2: &mut f64) -> u32;
 		fn face_surface_area(face: &TopoDS_Face) -> f64;
 		fn face_center_of_mass(face: &TopoDS_Face, x: &mut f64, y: &mut f64, z: &mut f64);
 		fn face_project_point(face: &TopoDS_Face, px: f64, py: f64, pz: f64, cpx: &mut f64, cpy: &mut f64, cpz: &mut f64, nx: &mut f64, ny: &mut f64, nz: &mut f64) -> bool;

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -130,6 +130,7 @@ mod ffi_bridge {
 		fn shape_tshape_id(shape: &TopoDS_Shape) -> u64;
 		fn edge_tshape_id(edge: &TopoDS_Edge) -> u64;
 
+		fn face_surface(face: &TopoDS_Face, ox: &mut f64, oy: &mut f64, oz: &mut f64, ax: &mut f64, ay: &mut f64, az: &mut f64, rx: &mut f64, ry: &mut f64, rz: &mut f64, right_handed: &mut bool, p1: &mut f64, p2: &mut f64) -> u32;
 		fn face_surface_area(face: &TopoDS_Face) -> f64;
 		fn face_center_of_mass(face: &TopoDS_Face, x: &mut f64, y: &mut f64, z: &mut f64);
 		fn face_project_point(face: &TopoDS_Face, px: f64, py: f64, pz: f64, cpx: &mut f64, cpy: &mut f64, cpz: &mut f64, nx: &mut f64, ny: &mut f64, nz: &mut f64) -> bool;

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -130,7 +130,7 @@ mod ffi_bridge {
 		fn shape_tshape_id(shape: &TopoDS_Shape) -> u64;
 		fn edge_tshape_id(edge: &TopoDS_Edge) -> u64;
 
-		fn face_surface(face: &TopoDS_Face, ox: &mut f64, oy: &mut f64, oz: &mut f64, ax: &mut f64, ay: &mut f64, az: &mut f64, xx: &mut f64, xy: &mut f64, xz: &mut f64, p1: &mut f64, p2: &mut f64) -> u32;
+		fn face_surface(face: &TopoDS_Face, ox: &mut f64, oy: &mut f64, oz: &mut f64, zx: &mut f64, zy: &mut f64, zz: &mut f64, xx: &mut f64, xy: &mut f64, xz: &mut f64, p1: &mut f64, p2: &mut f64) -> u32;
 		fn face_surface_area(face: &TopoDS_Face) -> f64;
 		fn face_center_of_mass(face: &TopoDS_Face, x: &mut f64, y: &mut f64, z: &mut f64);
 		fn face_project_point(face: &TopoDS_Face, px: f64, py: f64, pz: f64, cpx: &mut f64, cpy: &mut f64, cpz: &mut f64, nx: &mut f64, ny: &mut f64, nz: &mut f64) -> bool;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub use common::{
 	boolean::Boolean,
 	error::Error,
 	mesh::{Mesh, Scene2D, SceneOption},
+	surface::{Surface, SurfaceKind},
 };
 // Re-export glam types used in cadrum's public API. Users should reach glam
 // through these re-exports (or the `cadrum::glam` module below) instead of
@@ -127,6 +128,9 @@ impl Face {
 	}
 	pub fn area(&self) -> f64 {
 		<Self as crate::traits::FaceStruct>::area(self)
+	}
+	pub fn surface(&self) -> Option<Surface> {
+		<Self as crate::traits::FaceStruct>::surface(self)
 	}
 	pub fn center(&self) -> DVec3 {
 		<Self as crate::traits::FaceStruct>::center(self)

--- a/src/occt/face.rs
+++ b/src/occt/face.rs
@@ -1,5 +1,6 @@
 use super::edge::Edge;
 use super::ffi;
+use crate::common::surface::{Surface, SurfaceKind};
 use crate::traits::FaceStruct;
 use glam::DVec3;
 use std::sync::OnceLock;
@@ -33,6 +34,22 @@ impl FaceStruct for Face {
 
 	fn id(&self) -> u64 {
 		ffi::face_tshape_id(&self.inner)
+	}
+
+	fn surface(&self) -> Option<Surface> {
+		let (mut ox, mut oy, mut oz) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut ax, mut ay, mut az) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut rx, mut ry, mut rz) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut right_handed, mut p1, mut p2) = (false, 0.0_f64, 0.0_f64);
+		let kind = match ffi::face_surface(&self.inner, &mut ox, &mut oy, &mut oz, &mut ax, &mut ay, &mut az, &mut rx, &mut ry, &mut rz, &mut right_handed, &mut p1, &mut p2) {
+			1 => SurfaceKind::Plane,
+			2 => SurfaceKind::Cylinder { radius: p1 },
+			3 => SurfaceKind::Cone { radius: p1, semi_angle: p2 },
+			4 => SurfaceKind::Sphere { radius: p1 },
+			5 => SurfaceKind::Torus { major_radius: p1, minor_radius: p2 },
+			_ => return None,
+		};
+		Some(Surface { origin: DVec3::new(ox, oy, oz), axis: DVec3::new(ax, ay, az), ref_dir: DVec3::new(rx, ry, rz), right_handed, kind })
 	}
 
 	fn area(&self) -> f64 {

--- a/src/occt/face.rs
+++ b/src/occt/face.rs
@@ -39,9 +39,9 @@ impl FaceStruct for Face {
 	fn surface(&self) -> Option<Surface> {
 		let (mut ox, mut oy, mut oz) = (0.0_f64, 0.0_f64, 0.0_f64);
 		let (mut ax, mut ay, mut az) = (0.0_f64, 0.0_f64, 0.0_f64);
-		let (mut rx, mut ry, mut rz) = (0.0_f64, 0.0_f64, 0.0_f64);
-		let (mut right_handed, mut p1, mut p2) = (false, 0.0_f64, 0.0_f64);
-		let kind = match ffi::face_surface(&self.inner, &mut ox, &mut oy, &mut oz, &mut ax, &mut ay, &mut az, &mut rx, &mut ry, &mut rz, &mut right_handed, &mut p1, &mut p2) {
+		let (mut xx, mut xy, mut xz) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut p1, mut p2) = (0.0_f64, 0.0_f64);
+		let kind = match ffi::face_surface(&self.inner, &mut ox, &mut oy, &mut oz, &mut ax, &mut ay, &mut az, &mut xx, &mut xy, &mut xz, &mut p1, &mut p2) {
 			1 => SurfaceKind::Plane,
 			2 => SurfaceKind::Cylinder { radius: p1 },
 			3 => SurfaceKind::Cone { radius: p1, semi_angle: p2 },
@@ -49,7 +49,7 @@ impl FaceStruct for Face {
 			5 => SurfaceKind::Torus { major_radius: p1, minor_radius: p2 },
 			_ => return None,
 		};
-		Some(Surface { origin: DVec3::new(ox, oy, oz), axis: DVec3::new(ax, ay, az), ref_dir: DVec3::new(rx, ry, rz), right_handed, kind })
+		Some(Surface { origin: DVec3::new(ox, oy, oz), axis: DVec3::new(ax, ay, az), x_dir: DVec3::new(xx, xy, xz), kind })
 	}
 
 	fn area(&self) -> f64 {

--- a/src/occt/face.rs
+++ b/src/occt/face.rs
@@ -38,10 +38,10 @@ impl FaceStruct for Face {
 
 	fn surface(&self) -> Option<Surface> {
 		let (mut ox, mut oy, mut oz) = (0.0_f64, 0.0_f64, 0.0_f64);
-		let (mut ax, mut ay, mut az) = (0.0_f64, 0.0_f64, 0.0_f64);
+		let (mut zx, mut zy, mut zz) = (0.0_f64, 0.0_f64, 0.0_f64);
 		let (mut xx, mut xy, mut xz) = (0.0_f64, 0.0_f64, 0.0_f64);
 		let (mut p1, mut p2) = (0.0_f64, 0.0_f64);
-		let kind = match ffi::face_surface(&self.inner, &mut ox, &mut oy, &mut oz, &mut ax, &mut ay, &mut az, &mut xx, &mut xy, &mut xz, &mut p1, &mut p2) {
+		let kind = match ffi::face_surface(&self.inner, &mut ox, &mut oy, &mut oz, &mut zx, &mut zy, &mut zz, &mut xx, &mut xy, &mut xz, &mut p1, &mut p2) {
 			1 => SurfaceKind::Plane,
 			2 => SurfaceKind::Cylinder { radius: p1 },
 			3 => SurfaceKind::Cone { radius: p1, semi_angle: p2 },
@@ -49,7 +49,7 @@ impl FaceStruct for Face {
 			5 => SurfaceKind::Torus { major_radius: p1, minor_radius: p2 },
 			_ => return None,
 		};
-		Some(Surface { origin: DVec3::new(ox, oy, oz), axis: DVec3::new(ax, ay, az), x_dir: DVec3::new(xx, xy, xz), kind })
+		Some(Surface { origin: DVec3::new(ox, oy, oz), axis_z: DVec3::new(zx, zy, zz), axis_x: DVec3::new(xx, xy, xz), kind })
 	}
 
 	fn area(&self) -> f64 {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -106,6 +106,7 @@ use crate::common::boolean::Boolean;
 use crate::common::color::Color;
 use crate::common::error::Error;
 use crate::common::mesh::Mesh;
+use crate::common::surface::Surface;
 use glam::{DMat3, DQuat, DVec3};
 use std::fmt::Debug;
 
@@ -424,6 +425,10 @@ pub trait FaceStruct: Sized + Debug {
 
 	/// Area of the trimmed face.
 	fn area(&self) -> f64;
+
+	/// The elementary surface this face lies on. `None` for B-spline, Bezier,
+	/// offset and other non-elementary surfaces.
+	fn surface(&self) -> Option<Surface>;
 
 	/// Area-weighted center of the trimmed face, for directional face selection.
 	/// Curved or concave faces place it off the face, and on a closed surface

--- a/tests/solid_query.rs
+++ b/tests/solid_query.rs
@@ -97,26 +97,6 @@ fn test_cube_face_areas_match_analytical() {
 	assert!((areas.iter().sum::<f64>() - cube.area()).abs() < EPS);
 }
 
-/// Every cube face lies on a plane whose placement is an orthonormal frame
-/// through the face, oriented along the face normal up to sign.
-#[test]
-fn test_cube_faces_report_planes() {
-	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(10.0));
-	for face in cube.iter_face() {
-		let s = face.surface().expect("a cube face lies on a plane");
-		assert_eq!(s.kind, SurfaceKind::Plane);
-		assert!((s.axis.length() - 1.0).abs() < EPS);
-		assert!((s.ref_dir.length() - 1.0).abs() < EPS);
-		assert!(s.axis.dot(s.ref_dir).abs() < EPS, "ref_dir must be orthogonal to axis");
-		assert!(s.right_handed, "an unmirrored cube keeps right-handed placements");
-		assert!((s.y_dir() - s.axis.cross(s.ref_dir)).length() < EPS);
-
-		let (on_face, normal) = face.project(face.center());
-		assert!((on_face - s.origin).dot(s.axis).abs() < EPS, "the face must lie on its own plane");
-		assert!((s.axis.dot(normal).abs() - 1.0).abs() < EPS, "the plane's axis is the face normal up to orientation");
-	}
-}
-
 /// Primitives report the parameters they were built from, and the placement
 /// origin is the surface's, not a point on the face.
 #[test]
@@ -150,4 +130,38 @@ fn test_primitive_surfaces_match_construction() {
 		})
 		.expect("a cone has a conical face");
 	assert!((angle.abs().tan() - 0.3).abs() < EPS, "tan(semi_angle) = (r1 - r2) / height, got {angle}");
+}
+
+/// Every cube face lies on a plane whose placement is a right-handed orthonormal
+/// frame through the face, aligned with the face normal up to sign.
+#[test]
+fn test_cube_faces_report_planes() {
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(10.0));
+	for face in cube.iter_face() {
+		let s = face.surface().expect("a cube face lies on a plane");
+		assert_eq!(s.kind, SurfaceKind::Plane);
+		assert!((s.axis.length() - 1.0).abs() < EPS);
+		assert!((s.x_dir.length() - 1.0).abs() < EPS);
+		assert!(s.axis.dot(s.x_dir).abs() < EPS, "x_dir must be orthogonal to axis");
+		assert!((s.axis.cross(s.x_dir).length() - 1.0).abs() < EPS, "the frame must be orthonormal");
+
+		let (on_face, normal) = face.project(face.center());
+		assert!((on_face - s.origin).dot(s.axis).abs() < EPS, "the face must lie on its own plane");
+		assert!((s.axis.dot(normal).abs() - 1.0).abs() < EPS, "the plane's axis is the face normal up to orientation");
+	}
+}
+
+/// Mirroring keeps the frame right-handed: `axis.cross(x_dir)` stays the
+/// placement's Y direction instead of flipping to its negation.
+#[test]
+fn test_mirrored_faces_keep_right_handed_frames() {
+	let mirrored = Solid::cube(DVec3::ZERO, DVec3::splat(10.0)).mirror(DVec3::ZERO, DVec3::X);
+	for face in mirrored.iter_face() {
+		let s = face.surface().expect("a cube face lies on a plane");
+		let y = s.axis.cross(s.x_dir);
+		assert!((y.length() - 1.0).abs() < EPS);
+		assert!((y.dot(s.axis)).abs() < EPS);
+		assert!((y.dot(s.x_dir)).abs() < EPS);
+		assert!((s.x_dir.cross(y) - s.axis).length() < EPS, "x cross y must return the axis");
+	}
 }

--- a/tests/solid_query.rs
+++ b/tests/solid_query.rs
@@ -3,7 +3,7 @@
 //! OCCT computes properties with uniform density ρ = 1; the inertia tensor is
 //! returned about the world origin (not the center of mass).
 
-use cadrum::Solid;
+use cadrum::{Solid, SurfaceKind};
 use glam::DVec3;
 
 const EPS: f64 = 1e-6;
@@ -95,4 +95,59 @@ fn test_cube_face_areas_match_analytical() {
 		assert!((area - a.powi(2)).abs() < EPS, "face area = {area}, expected {}", a.powi(2));
 	}
 	assert!((areas.iter().sum::<f64>() - cube.area()).abs() < EPS);
+}
+
+/// Every cube face lies on a plane whose placement is an orthonormal frame
+/// through the face, oriented along the face normal up to sign.
+#[test]
+fn test_cube_faces_report_planes() {
+	let cube = Solid::cube(DVec3::ZERO, DVec3::splat(10.0));
+	for face in cube.iter_face() {
+		let s = face.surface().expect("a cube face lies on a plane");
+		assert_eq!(s.kind, SurfaceKind::Plane);
+		assert!((s.axis.length() - 1.0).abs() < EPS);
+		assert!((s.ref_dir.length() - 1.0).abs() < EPS);
+		assert!(s.axis.dot(s.ref_dir).abs() < EPS, "ref_dir must be orthogonal to axis");
+		assert!(s.right_handed, "an unmirrored cube keeps right-handed placements");
+		assert!((s.y_dir() - s.axis.cross(s.ref_dir)).length() < EPS);
+
+		let (on_face, normal) = face.project(face.center());
+		assert!((on_face - s.origin).dot(s.axis).abs() < EPS, "the face must lie on its own plane");
+		assert!((s.axis.dot(normal).abs() - 1.0).abs() < EPS, "the plane's axis is the face normal up to orientation");
+	}
+}
+
+/// Primitives report the parameters they were built from, and the placement
+/// origin is the surface's, not a point on the face.
+#[test]
+fn test_primitive_surfaces_match_construction() {
+	let cylinder = Solid::cylinder(3.0, DVec3::Z * 10.0);
+	let radii = cylinder
+		.iter_face()
+		.filter_map(|f| match f.surface().expect("elementary").kind {
+			SurfaceKind::Cylinder { radius } => Some(radius),
+			_ => None,
+		})
+		.collect::<Vec<_>>();
+	assert_eq!(radii.len(), 1, "a cylinder has one cylindrical face and two caps");
+	assert!((radii[0] - 3.0).abs() < EPS);
+
+	let sphere = Solid::sphere(5.0);
+	let s = sphere.iter_face().next().unwrap().surface().expect("elementary");
+	assert!(matches!(s.kind, SurfaceKind::Sphere { radius } if (radius - 5.0).abs() < EPS));
+	assert!(s.origin.length() < EPS, "a sphere places its origin at the centre, off the face");
+
+	let torus = Solid::torus(10.0, 3.0, DVec3::Z);
+	let t = torus.iter_face().next().unwrap().surface().expect("elementary");
+	assert!(matches!(t.kind, SurfaceKind::Torus { major_radius, minor_radius } if (major_radius - 10.0).abs() < EPS && (minor_radius - 3.0).abs() < EPS));
+
+	let cone = Solid::cone(5.0, 2.0, DVec3::Z * 10.0);
+	let angle = cone
+		.iter_face()
+		.find_map(|f| match f.surface().expect("elementary").kind {
+			SurfaceKind::Cone { semi_angle, .. } => Some(semi_angle),
+			_ => None,
+		})
+		.expect("a cone has a conical face");
+	assert!((angle.abs().tan() - 0.3).abs() < EPS, "tan(semi_angle) = (r1 - r2) / height, got {angle}");
 }

--- a/tests/solid_query.rs
+++ b/tests/solid_query.rs
@@ -140,28 +140,28 @@ fn test_cube_faces_report_planes() {
 	for face in cube.iter_face() {
 		let s = face.surface().expect("a cube face lies on a plane");
 		assert_eq!(s.kind, SurfaceKind::Plane);
-		assert!((s.axis.length() - 1.0).abs() < EPS);
-		assert!((s.x_dir.length() - 1.0).abs() < EPS);
-		assert!(s.axis.dot(s.x_dir).abs() < EPS, "x_dir must be orthogonal to axis");
-		assert!((s.axis.cross(s.x_dir).length() - 1.0).abs() < EPS, "the frame must be orthonormal");
+		assert!((s.axis_z.length() - 1.0).abs() < EPS);
+		assert!((s.axis_x.length() - 1.0).abs() < EPS);
+		assert!(s.axis_z.dot(s.axis_x).abs() < EPS, "axis_x must be orthogonal to axis_z");
+		assert!((s.axis_z.cross(s.axis_x).length() - 1.0).abs() < EPS, "the frame must be orthonormal");
 
 		let (on_face, normal) = face.project(face.center());
-		assert!((on_face - s.origin).dot(s.axis).abs() < EPS, "the face must lie on its own plane");
-		assert!((s.axis.dot(normal).abs() - 1.0).abs() < EPS, "the plane's axis is the face normal up to orientation");
+		assert!((on_face - s.origin).dot(s.axis_z).abs() < EPS, "the face must lie on its own plane");
+		assert!((s.axis_z.dot(normal).abs() - 1.0).abs() < EPS, "the plane's axis is the face normal up to orientation");
 	}
 }
 
-/// Mirroring keeps the frame right-handed: `axis.cross(x_dir)` stays the
+/// Mirroring keeps the frame right-handed: `axis_z.cross(axis_x)` stays the
 /// placement's Y direction instead of flipping to its negation.
 #[test]
 fn test_mirrored_faces_keep_right_handed_frames() {
 	let mirrored = Solid::cube(DVec3::ZERO, DVec3::splat(10.0)).mirror(DVec3::ZERO, DVec3::X);
 	for face in mirrored.iter_face() {
 		let s = face.surface().expect("a cube face lies on a plane");
-		let y = s.axis.cross(s.x_dir);
+		let y = s.axis_z.cross(s.axis_x);
 		assert!((y.length() - 1.0).abs() < EPS);
-		assert!((y.dot(s.axis)).abs() < EPS);
-		assert!((y.dot(s.x_dir)).abs() < EPS);
-		assert!((s.x_dir.cross(y) - s.axis).length() < EPS, "x cross y must return the axis");
+		assert!((y.dot(s.axis_z)).abs() < EPS);
+		assert!((y.dot(s.axis_x)).abs() < EPS);
+		assert!((s.axis_x.cross(y) - s.axis_z).length() < EPS, "x cross y must return the axis");
 	}
 }


### PR DESCRIPTION
`Face::surface` reports the elementary surface a face lies on, shaped after STEP's `elementary_surface`: one placement plus the parameters of the subtype it places.

（面が乗っている elementary surface を返す `Face::surface`。STEP の `elementary_surface` に倣い、配置 1 つとサブタイプのパラメータという形にしてある。）

```rust
pub struct Surface {
	pub origin: DVec3,   // STEP location
	pub axis_z: DVec3,   // STEP axis
	pub axis_x: DVec3,   // the frame's X; Y is always axis_z.cross(axis_x)
	pub kind: SurfaceKind,
}

pub enum SurfaceKind {
	Plane,
	Cylinder { radius: f64 },
	Cone { radius: f64, semi_angle: f64 },
	Sphere { radius: f64 },
	Torus { major_radius: f64, minor_radius: f64 },
}

fn surface(&self) -> Option<Surface>;   // None for B-spline, Bezier, offset, ...
```

### Why one placement instead of one variant per shape

Two downstream forks reached for this separately: `cadona-app/cadona-cadrum` with a `face_planar_frame` that returns a point and a normal but fails on anything curved, and `julivehs1/cadrum` with a `Surface` enum covering planes and cylinders, each variant carrying its own copy of the placement.

（2 つの下流フォークが別々にこれを求めていた。`cadona-app/cadona-cadrum` は点と法線を返すが曲面では失敗する `face_planar_frame`、`julivehs1/cadrum` は平面と円筒だけを覆い、配置を variant ごとに持つ `Surface` enum。）

STEP already generalises all five: `plane`, `cylindrical_surface`, `conical_surface`, `spherical_surface` and `toroidal_surface` are subtypes of `elementary_surface`, sharing exactly one attribute — `position : axis2_placement_3d` — and differing only in scalars. OCCT mirrors this: `gp_Pln`, `gp_Cylinder`, `gp_Cone`, `gp_Sphere` and `gp_Torus` all expose `Position()` as a `gp_Ax3`. Following the file format keeps the placement on one extraction path and leaves only the scalars to branch on.

（STEP は既に 5 種類を一般化している。いずれも `elementary_surface` のサブタイプで、共有する属性は `position : axis2_placement_3d` ただ 1 つ、違いはスカラーだけ。OCCT も同じ構造で、5 つの `gp_` 型すべてが `Position()` で `gp_Ax3` を返す。ファイル形式に合わせておけば、配置の取り出しが 1 経路に集約され、分岐するのはスカラーだけで済む。）

### Mirrored placements are normalised, not reported

STEP derives its Y direction as `axis × ref_direction`, so an `axis2_placement_3d` is always right-handed. `gp_Ax3` is not: it carries a handedness flag, and a mirrored face holds a left-handed placement whose Y is the negation of that cross product. Measured on a cube, with the C++ temporarily instrumented to say when the flag is set:

（STEP は Y を `axis × ref_direction` で導出するので `axis2_placement_3d` は常に右手系だが、`gp_Ax3` は左右手系のフラグを持ち、鏡映した面は Y がその外積の符号反転になる左手系の配置を持つ。C++ に一時的な細工を入れて立方体で実測した。）

| solid | faces | left-handed placements |
| --- | --- | --- |
| as built | 6 | 0 |
| `mirror` | 6 | **6** |
| `scale` by −1 | 6 | **6** |

So the case is not theoretical: every face of a mirrored solid carries one, and anyone computing `axis_z.cross(axis_x)` would get a Y that points the wrong way on all of them.

（机上の話ではない。鏡映したソリッドは全ての面が該当し、`axis_z.cross(axis_x)` を計算した呼び出し側は全面で Y が逆を向く。）

Rather than surfacing a handedness flag for callers to remember, the C++ reverses X when the placement is indirect. That keeps Y and Z as they were, makes the frame right-handed by construction, and lets the struct carry neither a flag nor a Y direction:

（左右手系のフラグを出して呼び出し側に覚えさせるのではなく、配置が indirect のとき C++ 側で X を反転する。Y と Z はそのままで枠が構成上右手系になり、フラグも Y 方向も struct に持たずに済む。）

```cpp
gp_Dir x = pos.XDirection();
if (!pos.Direct()) x.Reverse();
```

The cost is that `axis_x` is then the negation of the file's STEP `ref_direction` on those faces, which moves `u = 0` by half a turn. The field is named for what it is — the frame's X axis, not STEP's `ref_direction` — and nothing in this crate exposes surface parameters or pcurves today, so nothing can observe the shift.

（代償として、それらの面では `axis_x` がファイル中の STEP `ref_direction` の符号反転になり、`u = 0` が半周ずれる。フィールド名は実態どおり「枠の X 軸」であって `ref_direction` ではない。またこのクレートは現在パラメータ空間も pcurve も公開していないので、このずれを観測できるものは無い。）

### Face orientation is deliberately not folded in

The placement is reported as the surface carries it, so a planar face's `axis_z` is not necessarily the outward normal — `Face::project` reports that, and the test asserts the two agree up to sign. Flipping `axis_z` for a reversed face would invert the frame's handedness relative to `axis_x`, splitting one rule into two.

（配置は曲面が持っているまま返すので、平面フェイスの `axis_z` が外向き法線とは限らない。外向き法線は `Face::project` の担当で、テストは両者が符号を除いて一致することを検証している。面が反転しているときに `axis_z` を反転させると `axis_x` に対する枠の左右手系が崩れ、規則が 2 つに割れてしまう。）

`origin` is likewise the surface's, not a point on the face: a cylinder places it on the axis and a sphere at its centre. The sphere test asserts exactly that.

（`origin` も同様に曲面のものであって面上の点ではない。円柱は軸上、球は中心に置く。球のテストがそれを検証している。）

### FFI

One function with out-parameters, in the style of `face_project_point` and `shape_inertia_tensor`, returning the kind:

```cpp
uint32_t face_surface(const TopoDS_Face& face,
    double& ox, double& oy, double& oz,
    double& zx, double& zy, double& zz,
    double& xx, double& xy, double& xz,
    double& p1, double& p2);
```

Nothing is allocated and there is no length to check on the Rust side. `BRepAdaptor_Surface` applies the face's location, so the values are in world coordinates.

（out 引数 1 本で、既存の `face_project_point` や `shape_inertia_tensor` と同じ流儀。戻り値が種別。アロケーションは無く、Rust 側に長さ検査も要らない。`BRepAdaptor_Surface` が面の location を適用するので値は世界座標。）

### Verification

- `cargo build` ok, `cargo fmt` applied
- `cargo test -j 1`: 17 suites, 96 passed, 0 failed, 3 ignored, no warnings
- New tests: every cube face reports a plane whose frame is orthonormal, passes through the face and agrees with `Face::project` up to sign; a mirrored cube still satisfies `axis_x × (axis_z × axis_x) == axis_z` on every face; a cylinder reports exactly one cylindrical face at radius 3; a sphere reports its radius with the origin at the centre rather than on the face; a torus reports both radii; a cone satisfies `tan(semi_angle) = (r1 - r2) / height`
