### PR TITLE
Add hole-aware extrude, Solid::revolve, Edge::ellipse and ProfileOrient::CorrectedTorsion

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,27 +374,27 @@ use cadrum::{BSplineEnd, DVec3, Edge, Error, Solid};
 /// Square polygon → box (simplest extrude).
 fn build_box() -> Result<Solid, Error> {
 	let profile = Edge::polygon(&[DVec3::new(0.0, 0.0, 0.0), DVec3::new(5.0, 0.0, 0.0), DVec3::new(5.0, 5.0, 0.0), DVec3::new(0.0, 5.0, 0.0)])?;
-	Solid::extrude(&profile, &[], DVec3::Z * 8.0)
+	Solid::extrude([&profile], DVec3::Z * 8.0)
 }
 
 /// Circle extruded at a steep angle → oblique cylinder.
 fn build_oblique_cylinder() -> Result<Solid, Error> {
 	let profile = [Edge::circle(3.0, DVec3::Z)?];
-	Solid::extrude(&profile, &[], DVec3::new(-4.0, -6.0, 8.0))
+	Solid::extrude([&profile], DVec3::new(-4.0, -6.0, 8.0))
 }
 
 /// L-shaped polygon → L-beam.
 fn build_l_beam() -> Result<Solid, Error> {
 	let profile = Edge::polygon(&[DVec3::new(0.0, 0.0, 0.0), DVec3::new(4.0, 0.0, 0.0), DVec3::new(4.0, 1.0, 0.0), DVec3::new(1.0, 1.0, 0.0), DVec3::new(1.0, 3.0, 0.0), DVec3::new(0.0, 3.0, 0.0)])?;
-	Solid::extrude(&profile, &[], DVec3::Z * 12.0)
+	Solid::extrude([&profile], DVec3::Z * 12.0)
 }
 
-/// Square plate with an elliptical hole: the second argument carries the
-/// inner wires, each of which becomes an opening in the extruded face.
+/// Square plate with an elliptical hole: the first wire is the outer boundary
+/// and every later one becomes an opening in the extruded face.
 fn build_plate_with_hole() -> Result<Solid, Error> {
 	let outer = Edge::polygon(&[DVec3::new(-4.0, -3.0, 0.0), DVec3::new(4.0, -3.0, 0.0), DVec3::new(4.0, 3.0, 0.0), DVec3::new(-4.0, 3.0, 0.0)])?;
 	let hole = vec![Edge::ellipse(2.5, 1.5, DVec3::Z, DVec3::X)?];
-	Solid::extrude(&outer, [&hole], DVec3::Z * 2.0)
+	Solid::extrude([&outer, &hole], DVec3::Z * 2.0)
 }
 
 /// Heart-shaped BSpline profile extruded along Z.
@@ -412,7 +412,7 @@ fn build_heart() -> Result<Solid, Error> {
 		],
 		BSplineEnd::Periodic,
 	)?];
-	Solid::extrude(&profile, &[], DVec3::Z * 7.0)
+	Solid::extrude([&profile], DVec3::Z * 7.0)
 }
 
 fn main() -> Result<(), Error> {

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ C++17 compiler (GCC, Clang, or MSVC) and CMake.
 | Area | Methods |
 |---|---|
 | **Primitives** | `Solid::cube`, `Solid::sphere`, `Solid::cylinder`, `Solid::cone`, `Solid::torus`, `Solid::half_space` |
-| **Curves** | `Edge::line`, `Edge::arc_3pts`, `Edge::circle`, `Edge::polygon`, `Edge::helix`, `Edge::bspline` |
-| **Surfacing** | `Solid::extrude`, `Solid::sweep`, `Solid::loft`, `Solid::bspline`, `Solid::sew` |
+| **Curves** | `Edge::line`, `Edge::arc_3pts`, `Edge::circle`, `Edge::polygon`, `Edge::helix`, `Edge::ellipse`, `Edge::bspline` |
+| **Surfacing** | `Solid::extrude`, `Solid::revolve`, `Solid::sweep`, `Solid::loft`, `Solid::bspline`, `Solid::sew` |
 | **Editing** | `Solid::shell`, `Solid::offset`, `Solid::fillet_edges`, `Solid::chamfer_edges`, `Solid::clean` |
 | **Queries** | `Solid::volume`, `Solid::area`, `Solid::center`, `Solid::inertia`, `Solid::bounding_box`, `Solid::contains`, `Face::area`, `Face::center`, `Face::surface` |
 | **Topology** | `Solid::iter_face`, `Solid::iter_edge`, `Face::iter_edge`, `Face::project`, `Edge::project` |
@@ -367,25 +367,34 @@ cargo run --example 05_extrude
 //! - **Oblique cylinder**: circle extruded at a steep angle
 //! - **L-beam**: L-shaped polygon extruded along Z
 //! - **Heart**: BSpline heart-shaped profile extruded along Z
+//! - **Plate with a hole**: square outer wire with an elliptical inner wire
 
 use cadrum::{BSplineEnd, DVec3, Edge, Error, Solid};
 
 /// Square polygon → box (simplest extrude).
 fn build_box() -> Result<Solid, Error> {
 	let profile = Edge::polygon(&[DVec3::new(0.0, 0.0, 0.0), DVec3::new(5.0, 0.0, 0.0), DVec3::new(5.0, 5.0, 0.0), DVec3::new(0.0, 5.0, 0.0)])?;
-	Solid::extrude(&profile, DVec3::Z * 8.0)
+	Solid::extrude(&profile, &[], DVec3::Z * 8.0)
 }
 
 /// Circle extruded at a steep angle → oblique cylinder.
 fn build_oblique_cylinder() -> Result<Solid, Error> {
 	let profile = [Edge::circle(3.0, DVec3::Z)?];
-	Solid::extrude(&profile, DVec3::new(-4.0, -6.0, 8.0))
+	Solid::extrude(&profile, &[], DVec3::new(-4.0, -6.0, 8.0))
 }
 
 /// L-shaped polygon → L-beam.
 fn build_l_beam() -> Result<Solid, Error> {
 	let profile = Edge::polygon(&[DVec3::new(0.0, 0.0, 0.0), DVec3::new(4.0, 0.0, 0.0), DVec3::new(4.0, 1.0, 0.0), DVec3::new(1.0, 1.0, 0.0), DVec3::new(1.0, 3.0, 0.0), DVec3::new(0.0, 3.0, 0.0)])?;
-	Solid::extrude(&profile, DVec3::Z * 12.0)
+	Solid::extrude(&profile, &[], DVec3::Z * 12.0)
+}
+
+/// Square plate with an elliptical hole: the second argument carries the
+/// inner wires, each of which becomes an opening in the extruded face.
+fn build_plate_with_hole() -> Result<Solid, Error> {
+	let outer = Edge::polygon(&[DVec3::new(-4.0, -3.0, 0.0), DVec3::new(4.0, -3.0, 0.0), DVec3::new(4.0, 3.0, 0.0), DVec3::new(-4.0, 3.0, 0.0)])?;
+	let hole = vec![Edge::ellipse(2.5, 1.5, DVec3::Z, DVec3::X)?];
+	Solid::extrude(&outer, [&hole], DVec3::Z * 2.0)
 }
 
 /// Heart-shaped BSpline profile extruded along Z.
@@ -403,7 +412,7 @@ fn build_heart() -> Result<Solid, Error> {
 		],
 		BSplineEnd::Periodic,
 	)?];
-	Solid::extrude(&profile, DVec3::Z * 7.0)
+	Solid::extrude(&profile, &[], DVec3::Z * 7.0)
 }
 
 fn main() -> Result<(), Error> {
@@ -413,8 +422,9 @@ fn main() -> Result<(), Error> {
 	let oblique = build_oblique_cylinder()?.color("#f1c8b0").translate(DVec3::X * 10.0);
 	let l_beam = build_l_beam()?.color("#b0f1c8").translate(DVec3::X * 20.0);
 	let heart = build_heart()?.color("#f1b0b0").translate(DVec3::X * 30.0);
+	let plate = build_plate_with_hole()?.color("#d4b0f1").translate(DVec3::X * 40.0);
 
-	let result = [box_solid, oblique, l_beam, heart];
+	let result = [box_solid, oblique, l_beam, heart, plate];
 
 	Solid::write_step(&result, &mut std::fs::File::create(format!("{example_name}.step")).unwrap())?;
 
@@ -428,7 +438,6 @@ fn main() -> Result<(), Error> {
 	println!("wrote {example_name}.step / {example_name}.svg / {example_name}.png");
 	Ok(())
 }
-
 ```
 
 Output: [05_extrude.png](https://lzpel.github.io/cadrum/05_extrude.png) | [05_extrude.step](https://lzpel.github.io/cadrum/05_extrude.step) | [05_extrude.glb](https://lzpel.github.io/cadrum/05_extrude.glb) | [05_extrude.stl](https://lzpel.github.io/cadrum/05_extrude.stl) | [05_extrude.svg](https://lzpel.github.io/cadrum/05_extrude.svg)

--- a/examples/05_extrude.rs
+++ b/examples/05_extrude.rs
@@ -11,27 +11,27 @@ use cadrum::{BSplineEnd, DVec3, Edge, Error, Solid};
 /// Square polygon → box (simplest extrude).
 fn build_box() -> Result<Solid, Error> {
 	let profile = Edge::polygon(&[DVec3::new(0.0, 0.0, 0.0), DVec3::new(5.0, 0.0, 0.0), DVec3::new(5.0, 5.0, 0.0), DVec3::new(0.0, 5.0, 0.0)])?;
-	Solid::extrude(&profile, &[], DVec3::Z * 8.0)
+	Solid::extrude([&profile], DVec3::Z * 8.0)
 }
 
 /// Circle extruded at a steep angle → oblique cylinder.
 fn build_oblique_cylinder() -> Result<Solid, Error> {
 	let profile = [Edge::circle(3.0, DVec3::Z)?];
-	Solid::extrude(&profile, &[], DVec3::new(-4.0, -6.0, 8.0))
+	Solid::extrude([&profile], DVec3::new(-4.0, -6.0, 8.0))
 }
 
 /// L-shaped polygon → L-beam.
 fn build_l_beam() -> Result<Solid, Error> {
 	let profile = Edge::polygon(&[DVec3::new(0.0, 0.0, 0.0), DVec3::new(4.0, 0.0, 0.0), DVec3::new(4.0, 1.0, 0.0), DVec3::new(1.0, 1.0, 0.0), DVec3::new(1.0, 3.0, 0.0), DVec3::new(0.0, 3.0, 0.0)])?;
-	Solid::extrude(&profile, &[], DVec3::Z * 12.0)
+	Solid::extrude([&profile], DVec3::Z * 12.0)
 }
 
-/// Square plate with an elliptical hole: the second argument carries the
-/// inner wires, each of which becomes an opening in the extruded face.
+/// Square plate with an elliptical hole: the first wire is the outer boundary
+/// and every later one becomes an opening in the extruded face.
 fn build_plate_with_hole() -> Result<Solid, Error> {
 	let outer = Edge::polygon(&[DVec3::new(-4.0, -3.0, 0.0), DVec3::new(4.0, -3.0, 0.0), DVec3::new(4.0, 3.0, 0.0), DVec3::new(-4.0, 3.0, 0.0)])?;
 	let hole = vec![Edge::ellipse(2.5, 1.5, DVec3::Z, DVec3::X)?];
-	Solid::extrude(&outer, [&hole], DVec3::Z * 2.0)
+	Solid::extrude([&outer, &hole], DVec3::Z * 2.0)
 }
 
 /// Heart-shaped BSpline profile extruded along Z.
@@ -49,7 +49,7 @@ fn build_heart() -> Result<Solid, Error> {
 		],
 		BSplineEnd::Periodic,
 	)?];
-	Solid::extrude(&profile, &[], DVec3::Z * 7.0)
+	Solid::extrude([&profile], DVec3::Z * 7.0)
 }
 
 fn main() -> Result<(), Error> {

--- a/examples/05_extrude.rs
+++ b/examples/05_extrude.rs
@@ -4,25 +4,34 @@
 //! - **Oblique cylinder**: circle extruded at a steep angle
 //! - **L-beam**: L-shaped polygon extruded along Z
 //! - **Heart**: BSpline heart-shaped profile extruded along Z
+//! - **Plate with a hole**: square outer wire with an elliptical inner wire
 
 use cadrum::{BSplineEnd, DVec3, Edge, Error, Solid};
 
 /// Square polygon → box (simplest extrude).
 fn build_box() -> Result<Solid, Error> {
 	let profile = Edge::polygon(&[DVec3::new(0.0, 0.0, 0.0), DVec3::new(5.0, 0.0, 0.0), DVec3::new(5.0, 5.0, 0.0), DVec3::new(0.0, 5.0, 0.0)])?;
-	Solid::extrude(&profile, DVec3::Z * 8.0)
+	Solid::extrude(&profile, &[], DVec3::Z * 8.0)
 }
 
 /// Circle extruded at a steep angle → oblique cylinder.
 fn build_oblique_cylinder() -> Result<Solid, Error> {
 	let profile = [Edge::circle(3.0, DVec3::Z)?];
-	Solid::extrude(&profile, DVec3::new(-4.0, -6.0, 8.0))
+	Solid::extrude(&profile, &[], DVec3::new(-4.0, -6.0, 8.0))
 }
 
 /// L-shaped polygon → L-beam.
 fn build_l_beam() -> Result<Solid, Error> {
 	let profile = Edge::polygon(&[DVec3::new(0.0, 0.0, 0.0), DVec3::new(4.0, 0.0, 0.0), DVec3::new(4.0, 1.0, 0.0), DVec3::new(1.0, 1.0, 0.0), DVec3::new(1.0, 3.0, 0.0), DVec3::new(0.0, 3.0, 0.0)])?;
-	Solid::extrude(&profile, DVec3::Z * 12.0)
+	Solid::extrude(&profile, &[], DVec3::Z * 12.0)
+}
+
+/// Square plate with an elliptical hole: the second argument carries the
+/// inner wires, each of which becomes an opening in the extruded face.
+fn build_plate_with_hole() -> Result<Solid, Error> {
+	let outer = Edge::polygon(&[DVec3::new(-4.0, -3.0, 0.0), DVec3::new(4.0, -3.0, 0.0), DVec3::new(4.0, 3.0, 0.0), DVec3::new(-4.0, 3.0, 0.0)])?;
+	let hole = vec![Edge::ellipse(2.5, 1.5, DVec3::Z, DVec3::X)?];
+	Solid::extrude(&outer, [&hole], DVec3::Z * 2.0)
 }
 
 /// Heart-shaped BSpline profile extruded along Z.
@@ -40,7 +49,7 @@ fn build_heart() -> Result<Solid, Error> {
 		],
 		BSplineEnd::Periodic,
 	)?];
-	Solid::extrude(&profile, DVec3::Z * 7.0)
+	Solid::extrude(&profile, &[], DVec3::Z * 7.0)
 }
 
 fn main() -> Result<(), Error> {
@@ -50,8 +59,9 @@ fn main() -> Result<(), Error> {
 	let oblique = build_oblique_cylinder()?.color("#f1c8b0").translate(DVec3::X * 10.0);
 	let l_beam = build_l_beam()?.color("#b0f1c8").translate(DVec3::X * 20.0);
 	let heart = build_heart()?.color("#f1b0b0").translate(DVec3::X * 30.0);
+	let plate = build_plate_with_hole()?.color("#d4b0f1").translate(DVec3::X * 40.0);
 
-	let result = [box_solid, oblique, l_beam, heart];
+	let result = [box_solid, oblique, l_beam, heart, plate];
 
 	Solid::write_step(&result, &mut std::fs::File::create(format!("{example_name}.step")).unwrap())?;
 

--- a/examples/101_joint.rs
+++ b/examples/101_joint.rs
@@ -3,7 +3,7 @@ use glam::DVec3;
 fn part(inner: f64, outer: f64, height: f64) -> Result<[Solid; 3], Error> {
 	let outer_solid = Solid::cube(DVec3::ZERO, DVec3::new(outer, outer, height)).translate(DVec3::ONE * -outer / 2.0);
 	let between_edge = Edge::polygon(&[DVec3::new(outer / 2.0, height - outer / 2.0, 0.0), DVec3::new(outer / 2.0, outer / 2.0, 0.0), DVec3::new(height - outer / 2.0, outer / 2.0, 0.0)])?;
-	let between_solid = Solid::extrude(&between_edge, &[], DVec3::Z * outer / 2.0)?;
+	let between_solid = Solid::extrude([&between_edge], DVec3::Z * outer / 2.0)?;
 	let inner_solid = Solid::cylinder(inner / 2.0, DVec3::Z * height * 1000.0);
 	Ok([outer_solid, between_solid, inner_solid])
 }

--- a/examples/101_joint.rs
+++ b/examples/101_joint.rs
@@ -3,7 +3,7 @@ use glam::DVec3;
 fn part(inner: f64, outer: f64, height: f64) -> Result<[Solid; 3], Error> {
 	let outer_solid = Solid::cube(DVec3::ZERO, DVec3::new(outer, outer, height)).translate(DVec3::ONE * -outer / 2.0);
 	let between_edge = Edge::polygon(&[DVec3::new(outer / 2.0, height - outer / 2.0, 0.0), DVec3::new(outer / 2.0, outer / 2.0, 0.0), DVec3::new(height - outer / 2.0, outer / 2.0, 0.0)])?;
-	let between_solid = Solid::extrude(&between_edge, DVec3::Z * outer / 2.0)?;
+	let between_solid = Solid::extrude(&between_edge, &[], DVec3::Z * outer / 2.0)?;
 	let inner_solid = Solid::cylinder(inner / 2.0, DVec3::Z * height * 1000.0);
 	Ok([outer_solid, between_solid, inner_solid])
 }

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -25,6 +25,9 @@ pub enum Error {
 	/// Extrusion (`Solid::extrude`) failed: empty profile, zero-length direction, or profile not closed.
 	Extrude,
 
+	/// Revolution (`Solid::revolve`) failed: empty profile, profile not closed, or a zero axis or angle.
+	Revolve(String),
+
 	/// Pipe sweep (`Solid::sweep`) failed: profile not closed, or edges not connectable into a wire.
 	Sweep(String),
 
@@ -61,6 +64,7 @@ impl std::fmt::Display for Error {
 			Error::Edge(msg) => write!(f, "Edge failed: {msg}"),
 			Error::Clean => write!(f, "Clean failed"),
 			Error::Extrude => write!(f, "Extrude failed"),
+			Error::Revolve(msg) => write!(f, "Revolve failed: {msg}"),
 			Error::Sweep(msg) => write!(f, "Sweep failed: {msg}"),
 			Error::Shell(msg) => write!(f, "Shell failed: {msg}"),
 			Error::Fillet(msg) => write!(f, "Fillet failed: {msg}"),

--- a/src/ffi.cpp
+++ b/src/ffi.cpp
@@ -24,6 +24,7 @@
 #include <gp_Ax2.hxx>
 #include <gp_Ax3.hxx>
 #include <gp_Circ.hxx>
+#include <gp_Elips.hxx>
 #include <gp_Cone.hxx>
 #include <gp_Cylinder.hxx>
 #include <gp_Pln.hxx>
@@ -58,6 +59,7 @@
 #include <BRepPrimAPI_MakeHalfSpace.hxx>
 #include <BRepPrimAPI_MakeSphere.hxx>
 #include <BRepPrimAPI_MakePrism.hxx>
+#include <BRepPrimAPI_MakeRevol.hxx>
 #include <BRepPrimAPI_MakeTorus.hxx>
 
 // --- Boolean operations & shape cleanup ---
@@ -1069,6 +1071,29 @@ std::unique_ptr<TopoDS_Edge> make_circle_edge(
     }
 }
 
+// Closed ellipse centred at the origin. `x_ref` fixes the major-axis
+// direction, projected perpendicular to the axis as gp_Ax2 does for gp_Circ.
+std::unique_ptr<TopoDS_Edge> make_ellipse_edge(
+    double ax, double ay, double az,
+    double xrx, double xry, double xrz,
+    double major_radius, double minor_radius)
+{
+    try {
+        if (minor_radius < Precision::Confusion()) return nullptr;
+        if (major_radius < minor_radius) return nullptr;
+        gp_Dir axis_dir(ax, ay, az);
+        gp_Dir x_ref(xrx, xry, xrz);
+        if (axis_dir.IsParallel(x_ref, Precision::Angular())) return nullptr;
+        gp_Ax2 ax2(gp_Pnt(0.0, 0.0, 0.0), axis_dir, x_ref);
+        gp_Elips elips(ax2, major_radius, minor_radius);
+        BRepBuilderAPI_MakeEdge edgeMaker(elips);
+        if (!edgeMaker.IsDone()) return nullptr;
+        return std::make_unique<TopoDS_Edge>(edgeMaker.Edge());
+    } catch (const Standard_Failure&) {
+        return nullptr;
+    }
+}
+
 std::unique_ptr<TopoDS_Edge> make_line_edge(
     double ax, double ay, double az,
     double bx, double by, double bz)
@@ -1527,24 +1552,78 @@ std::unique_ptr<TopoDS_Shape> builder_chamfer(
     }
 }
 
-// Extrude a closed profile wire into a solid via BRepPrimAPI_MakePrism.
-// Edges → Wire → Face → Prism (solid).
+// Build a face from null-separated wires: the first is the outer boundary,
+// the rest are holes, added reversed so they subtract from it.
+static bool face_from_wires(const std::vector<TopoDS_Edge>& edges, TopoDS_Face& out)
+{
+    std::vector<TopoDS_Wire> wires;
+    BRepBuilderAPI_MakeWire wire_maker;
+    bool has_edges = false;
+    for (const auto& e : edges) {
+        if (e.IsNull()) {
+            if (!has_edges) continue;
+            if (!wire_maker.IsDone()) return false;
+            wires.push_back(wire_maker.Wire());
+            wire_maker = BRepBuilderAPI_MakeWire();
+            has_edges = false;
+        } else {
+            wire_maker.Add(e);
+            has_edges = true;
+        }
+    }
+    if (has_edges) {
+        if (!wire_maker.IsDone()) return false;
+        wires.push_back(wire_maker.Wire());
+    }
+    if (wires.empty()) return false;
+
+    BRepBuilderAPI_MakeFace face_maker(wires.front());
+    if (!face_maker.IsDone()) return false;
+    for (std::size_t i = 1; i < wires.size(); ++i) {
+        face_maker.Add(TopoDS::Wire(wires[i].Reversed()));
+        if (!face_maker.IsDone()) return false;
+    }
+    out = face_maker.Face();
+    return true;
+}
+
+// Extrude null-separated profile wires into a solid via BRepPrimAPI_MakePrism.
 std::unique_ptr<TopoDS_Shape> make_extrude(
     const std::vector<TopoDS_Edge>& profile_edges,
     double dx, double dy, double dz)
 {
     try {
-        if (profile_edges.empty()) return nullptr;
-        BRepBuilderAPI_MakeWire wire_maker;
-        for (const auto& e : profile_edges) wire_maker.Add(e);
-        if (!wire_maker.IsDone()) return nullptr;
-        BRepBuilderAPI_MakeFace face_maker(wire_maker.Wire());
-        if (!face_maker.IsDone()) return nullptr;
-        gp_Vec dir(dx, dy, dz);
-        BRepPrimAPI_MakePrism prism(face_maker.Face(), dir);
+        const gp_Vec dir(dx, dy, dz);
+        if (dir.Magnitude() < Precision::Confusion()) return nullptr;
+        TopoDS_Face face;
+        if (!face_from_wires(profile_edges, face)) return nullptr;
+        BRepPrimAPI_MakePrism prism(face, dir);
         prism.Build();
         if (!prism.IsDone()) return nullptr;
         return std::make_unique<TopoDS_Shape>(prism.Shape());
+    } catch (const Standard_Failure&) {
+        return nullptr;
+    }
+}
+
+// Revolve null-separated profile wires about an axis via BRepPrimAPI_MakeRevol.
+std::unique_ptr<TopoDS_Shape> make_revolve(
+    const std::vector<TopoDS_Edge>& profile_edges,
+    double ox, double oy, double oz,
+    double dx, double dy, double dz,
+    double angle)
+{
+    try {
+        const gp_Vec axis_vec(dx, dy, dz);
+        if (axis_vec.Magnitude() < Precision::Confusion()) return nullptr;
+        if (std::abs(angle) < Precision::Angular()) return nullptr;
+        TopoDS_Face face;
+        if (!face_from_wires(profile_edges, face)) return nullptr;
+        const gp_Ax1 axis(gp_Pnt(ox, oy, oz), gp_Dir(axis_vec));
+        BRepPrimAPI_MakeRevol revol(face, axis, angle);
+        revol.Build();
+        if (!revol.IsDone()) return nullptr;
+        return std::make_unique<TopoDS_Shape>(revol.Shape());
     } catch (const Standard_Failure&) {
         return nullptr;
     }
@@ -1607,6 +1686,11 @@ std::unique_ptr<TopoDS_Shape> make_pipe_shell(
                 for (const auto& e : aux_spine_edges) auxMaker.Add(e);
                 if (!auxMaker.IsDone()) return nullptr;
                 shell.SetMode(auxMaker.Wire(), true);
+                break;
+            }
+            case 4: {
+                // CorrectedTorsion: OCCT's corrected-Frenet trihedron.
+                shell.SetMode(false);
                 break;
             }
             default: {

--- a/src/ffi.h
+++ b/src/ffi.h
@@ -237,6 +237,14 @@ std::unique_ptr<std::vector<TopoDS_Edge>> make_polygon_edges(
 std::unique_ptr<TopoDS_Edge> make_circle_edge(
     double ax, double ay, double az, double radius);
 
+// Construct a closed elliptical edge centered at the world origin, lying in
+// the plane normal to `axis`, with `x_ref` fixing the major-axis direction.
+// Requires major_radius >= minor_radius > 0 and x_ref not parallel to axis.
+std::unique_ptr<TopoDS_Edge> make_ellipse_edge(
+    double ax, double ay, double az,
+    double xrx, double xry, double xrz,
+    double major_radius, double minor_radius);
+
 // Construct a straight line segment edge from point a to point b.
 std::unique_ptr<TopoDS_Edge> make_line_edge(
     double ax, double ay, double az,
@@ -303,11 +311,20 @@ std::unique_ptr<TopoDS_Edge> mirror_edge(
     double ox, double oy, double oz,
     double nx, double ny, double nz);
 
-// Extrude a closed profile wire into a solid using BRepPrimAPI_MakePrism.
-// Internally builds Wire → Face → Prism.
+// Extrude null-separated profile wires into a solid using
+// BRepPrimAPI_MakePrism. The first wire is the outer boundary and the rest
+// are holes; sentinels are TopoDS_Edge().IsNull() == true.
 std::unique_ptr<TopoDS_Shape> make_extrude(
     const std::vector<TopoDS_Edge>& profile_edges,
     double dx, double dy, double dz);
+
+// Revolve the same null-separated profile wires about the axis through
+// (ox, oy, oz) along (dx, dy, dz) using BRepPrimAPI_MakeRevol.
+std::unique_ptr<TopoDS_Shape> make_revolve(
+    const std::vector<TopoDS_Edge>& profile_edges,
+    double ox, double oy, double oz,
+    double dx, double dy, double dz,
+    double angle);
 
 // Sweep a closed profile wire (built from `profile_edges`) along a spine
 // wire (built from `spine_edges`) using BRepOffsetAPI_MakePipeShell. The

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -142,6 +142,7 @@ mod ffi_bridge {
 		fn make_helix_edge(ax: f64, ay: f64, az: f64, xrx: f64, xry: f64, xrz: f64, radius: f64, pitch: f64, height: f64) -> UniquePtr<TopoDS_Edge>;
 		fn make_polygon_edges(coords: &[f64]) -> UniquePtr<CxxVector<TopoDS_Edge>>;
 		fn make_circle_edge(ax: f64, ay: f64, az: f64, radius: f64) -> UniquePtr<TopoDS_Edge>;
+		fn make_ellipse_edge(ax: f64, ay: f64, az: f64, xrx: f64, xry: f64, xrz: f64, major_radius: f64, minor_radius: f64) -> UniquePtr<TopoDS_Edge>;
 		fn make_line_edge(ax: f64, ay: f64, az: f64, bx: f64, by: f64, bz: f64) -> UniquePtr<TopoDS_Edge>;
 		fn make_arc_edge(sx: f64, sy: f64, sz: f64, mx: f64, my: f64, mz: f64, ex: f64, ey: f64, ez: f64) -> UniquePtr<TopoDS_Edge>;
 		fn make_bspline_edge(coords: &[f64], end_kind: u32, sx: f64, sy: f64, sz: f64, ex: f64, ey: f64, ez: f64) -> UniquePtr<TopoDS_Edge>;
@@ -159,6 +160,7 @@ mod ffi_bridge {
 		fn mirror_edge(edge: &TopoDS_Edge, ox: f64, oy: f64, oz: f64, nx: f64, ny: f64, nz: f64) -> UniquePtr<TopoDS_Edge>;
 
 		fn make_extrude(profile_edges: &CxxVector<TopoDS_Edge>, dx: f64, dy: f64, dz: f64) -> UniquePtr<TopoDS_Shape>;
+		fn make_revolve(profile_edges: &CxxVector<TopoDS_Edge>, ox: f64, oy: f64, oz: f64, dx: f64, dy: f64, dz: f64, angle: f64) -> UniquePtr<TopoDS_Shape>;
 		fn make_pipe_shell(all_edges: &CxxVector<TopoDS_Edge>, spine_edges: &CxxVector<TopoDS_Edge>, orient: u32, ux: f64, uy: f64, uz: f64, aux_spine_edges: &CxxVector<TopoDS_Edge>) -> UniquePtr<TopoDS_Shape>;
 		fn make_loft(all_edges: &CxxVector<TopoDS_Edge>, ruled: bool) -> UniquePtr<TopoDS_Shape>;
 		fn make_sewn_solid(faces: &CxxVector<TopoDS_Face>, tolerance: f64) -> UniquePtr<TopoDS_Shape>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,11 +206,11 @@ impl Solid {
 	pub fn clean(&self) -> Result<crate::Solid, Error> {
 		<Self as crate::traits::SolidStruct>::clean(self)
 	}
-	pub fn extrude<'a, I: IntoIterator<Item = &'a Edge>, W: IntoIterator<Item = I>>(profile: I, holes: W, dir: DVec3) -> Result<crate::Solid, Error> {
-		<Self as crate::traits::SolidStruct>::extrude(profile, holes, dir)
+	pub fn extrude<'a, I: IntoIterator<Item = &'a Edge>, W: IntoIterator<Item = I>>(wires: W, dir: DVec3) -> Result<crate::Solid, Error> {
+		<Self as crate::traits::SolidStruct>::extrude(wires, dir)
 	}
-	pub fn revolve<'a, I: IntoIterator<Item = &'a Edge>, W: IntoIterator<Item = I>>(profile: I, holes: W, axis_origin: DVec3, axis_direction: DVec3, angle: f64) -> Result<crate::Solid, Error> {
-		<Self as crate::traits::SolidStruct>::revolve(profile, holes, axis_origin, axis_direction, angle)
+	pub fn revolve<'a, I: IntoIterator<Item = &'a Edge>, W: IntoIterator<Item = I>>(wires: W, axis_origin: DVec3, axis_direction: DVec3, angle: f64) -> Result<crate::Solid, Error> {
+		<Self as crate::traits::SolidStruct>::revolve(wires, axis_origin, axis_direction, angle)
 	}
 	pub fn shell<'a>(&self, thickness: f64, open_faces: impl IntoIterator<Item = &'a Face>) -> Result<crate::Solid, Error> {
 		<Self as crate::traits::SolidStruct>::shell(self, thickness, open_faces)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,9 @@ impl Edge {
 	pub fn circle(radius: f64, axis: DVec3) -> Result<crate::Edge, Error> {
 		<Self as crate::traits::EdgeStruct>::circle(radius, axis)
 	}
+	pub fn ellipse(major_radius: f64, minor_radius: f64, axis: DVec3, x_ref: DVec3) -> Result<crate::Edge, Error> {
+		<Self as crate::traits::EdgeStruct>::ellipse(major_radius, minor_radius, axis, x_ref)
+	}
 	pub fn line(a: DVec3, b: DVec3) -> Result<crate::Edge, Error> {
 		<Self as crate::traits::EdgeStruct>::line(a, b)
 	}
@@ -203,8 +206,11 @@ impl Solid {
 	pub fn clean(&self) -> Result<crate::Solid, Error> {
 		<Self as crate::traits::SolidStruct>::clean(self)
 	}
-	pub fn extrude<'a>(profile: impl IntoIterator<Item = &'a Edge>, dir: DVec3) -> Result<crate::Solid, Error> {
-		<Self as crate::traits::SolidStruct>::extrude(profile, dir)
+	pub fn extrude<'a, I: IntoIterator<Item = &'a Edge>, W: IntoIterator<Item = I>>(profile: I, holes: W, dir: DVec3) -> Result<crate::Solid, Error> {
+		<Self as crate::traits::SolidStruct>::extrude(profile, holes, dir)
+	}
+	pub fn revolve<'a, I: IntoIterator<Item = &'a Edge>, W: IntoIterator<Item = I>>(profile: I, holes: W, axis_origin: DVec3, axis_direction: DVec3, angle: f64) -> Result<crate::Solid, Error> {
+		<Self as crate::traits::SolidStruct>::revolve(profile, holes, axis_origin, axis_direction, angle)
 	}
 	pub fn shell<'a>(&self, thickness: f64, open_faces: impl IntoIterator<Item = &'a Face>) -> Result<crate::Solid, Error> {
 		<Self as crate::traits::SolidStruct>::shell(self, thickness, open_faces)

--- a/src/occt/edge.rs
+++ b/src/occt/edge.rs
@@ -116,6 +116,11 @@ impl EdgeStruct for Edge {
 		Edge::try_from_ffi(inner, format!("circle: invalid params (radius={radius}, axis={axis:?})"))
 	}
 
+	fn ellipse(major_radius: f64, minor_radius: f64, axis: DVec3, x_ref: DVec3) -> Result<Self, Error> {
+		let inner = ffi::make_ellipse_edge(axis.x, axis.y, axis.z, x_ref.x, x_ref.y, x_ref.z, major_radius, minor_radius);
+		Edge::try_from_ffi(inner, format!("ellipse: invalid params (major_radius={major_radius}, minor_radius={minor_radius}, axis={axis:?}, x_ref={x_ref:?})"))
+	}
+
 	fn line(a: DVec3, b: DVec3) -> Result<Self, Error> {
 		let inner = ffi::make_line_edge(a.x, a.y, a.z, b.x, b.y, b.z);
 		Edge::try_from_ffi(inner, format!("line: zero-length segment (a={a:?}, b={b:?})"))

--- a/src/occt/solid.rs
+++ b/src/occt/solid.rs
@@ -34,16 +34,15 @@ fn encode_orient(orient: ProfileOrient) -> (u32, f64, f64, f64, cxx::UniquePtr<c
 	(kind, ux, uy, uz, aux_vec)
 }
 
-/// Pack the outer profile and each hole wire into one FFI vector, separated by
-/// the null-edge sentinels `make_extrude` / `make_revolve` split on.
-fn profile_with_holes<'a, I: IntoIterator<Item = &'a Edge>, W: IntoIterator<Item = I>>(profile: I, holes: W) -> cxx::UniquePtr<cxx::CxxVector<ffi::TopoDS_Edge>> {
+/// Pack the wires into one FFI vector, separated by the null-edge sentinels
+/// `make_extrude` / `make_revolve` split on.
+fn wires_to_ffi<'a, I: IntoIterator<Item = &'a Edge>, W: IntoIterator<Item = I>>(wires: W) -> cxx::UniquePtr<cxx::CxxVector<ffi::TopoDS_Edge>> {
 	let mut edge_vec = ffi::edge_vec_new();
-	for e in profile {
-		ffi::edge_vec_push(edge_vec.pin_mut(), &e.inner);
-	}
-	for hole in holes {
-		ffi::edge_vec_push_null(edge_vec.pin_mut());
-		for e in hole {
+	for (i, wire) in wires.into_iter().enumerate() {
+		if i > 0 {
+			ffi::edge_vec_push_null(edge_vec.pin_mut());
+		}
+		for e in wire {
 			ffi::edge_vec_push(edge_vec.pin_mut(), &e.inner);
 		}
 	}
@@ -271,8 +270,8 @@ impl SolidStruct for Solid {
 
 	// ==================== Extrude ====================
 
-	fn extrude<'a, I: IntoIterator<Item = &'a Edge>, W: IntoIterator<Item = I>>(profile: I, holes: W, dir: DVec3) -> Result<Self, Error> {
-		let edge_vec = profile_with_holes(profile, holes);
+	fn extrude<'a, I: IntoIterator<Item = &'a Edge>, W: IntoIterator<Item = I>>(wires: W, dir: DVec3) -> Result<Self, Error> {
+		let edge_vec = wires_to_ffi(wires);
 		let shape = ffi::make_extrude(&edge_vec, dir.x, dir.y, dir.z);
 		if shape.is_null() {
 			return Err(Error::Extrude);
@@ -287,8 +286,8 @@ impl SolidStruct for Solid {
 
 	// ==================== Revolve ====================
 
-	fn revolve<'a, I: IntoIterator<Item = &'a Edge>, W: IntoIterator<Item = I>>(profile: I, holes: W, axis_origin: DVec3, axis_direction: DVec3, angle: f64) -> Result<Self, Error> {
-		let edge_vec = profile_with_holes(profile, holes);
+	fn revolve<'a, I: IntoIterator<Item = &'a Edge>, W: IntoIterator<Item = I>>(wires: W, axis_origin: DVec3, axis_direction: DVec3, angle: f64) -> Result<Self, Error> {
+		let edge_vec = wires_to_ffi(wires);
 		let shape = ffi::make_revolve(&edge_vec, axis_origin.x, axis_origin.y, axis_origin.z, axis_direction.x, axis_direction.y, axis_direction.z, angle);
 		if shape.is_null() {
 			return Err(Error::Revolve(format!("angle={angle} about {axis_direction:?} through {axis_origin:?} did not produce a solid")));

--- a/src/occt/solid.rs
+++ b/src/occt/solid.rs
@@ -22,6 +22,7 @@ fn encode_orient(orient: ProfileOrient) -> (u32, f64, f64, f64, cxx::UniquePtr<c
 	let (kind, ux, uy, uz) = match orient {
 		ProfileOrient::Fixed => (0u32, 0.0, 0.0, 0.0),
 		ProfileOrient::Torsion => (1u32, 0.0, 0.0, 0.0),
+		ProfileOrient::CorrectedTorsion => (4u32, 0.0, 0.0, 0.0),
 		ProfileOrient::Up(v) => (2u32, v.x, v.y, v.z),
 		ProfileOrient::Auxiliary(edges) => {
 			for e in edges {
@@ -31,6 +32,22 @@ fn encode_orient(orient: ProfileOrient) -> (u32, f64, f64, f64, cxx::UniquePtr<c
 		}
 	};
 	(kind, ux, uy, uz, aux_vec)
+}
+
+/// Pack the outer profile and each hole wire into one FFI vector, separated by
+/// the null-edge sentinels `make_extrude` / `make_revolve` split on.
+fn profile_with_holes<'a, I: IntoIterator<Item = &'a Edge>, W: IntoIterator<Item = I>>(profile: I, holes: W) -> cxx::UniquePtr<cxx::CxxVector<ffi::TopoDS_Edge>> {
+	let mut edge_vec = ffi::edge_vec_new();
+	for e in profile {
+		ffi::edge_vec_push(edge_vec.pin_mut(), &e.inner);
+	}
+	for hole in holes {
+		ffi::edge_vec_push_null(edge_vec.pin_mut());
+		for e in hole {
+			ffi::edge_vec_push(edge_vec.pin_mut(), &e.inner);
+		}
+	}
+	edge_vec
 }
 
 #[cfg(feature = "color")]
@@ -254,14 +271,27 @@ impl SolidStruct for Solid {
 
 	// ==================== Extrude ====================
 
-	fn extrude<'a>(profile: impl IntoIterator<Item = &'a Edge>, dir: DVec3) -> Result<Self, Error> {
-		let mut profile_vec = ffi::edge_vec_new();
-		for e in profile {
-			ffi::edge_vec_push(profile_vec.pin_mut(), &e.inner);
-		}
-		let shape = ffi::make_extrude(&profile_vec, dir.x, dir.y, dir.z);
+	fn extrude<'a, I: IntoIterator<Item = &'a Edge>, W: IntoIterator<Item = I>>(profile: I, holes: W, dir: DVec3) -> Result<Self, Error> {
+		let edge_vec = profile_with_holes(profile, holes);
+		let shape = ffi::make_extrude(&edge_vec, dir.x, dir.y, dir.z);
 		if shape.is_null() {
 			return Err(Error::Extrude);
+		}
+		Ok(Solid::new(
+			shape,
+			#[cfg(feature = "color")]
+			std::collections::HashMap::new(),
+			Default::default(),
+		))
+	}
+
+	// ==================== Revolve ====================
+
+	fn revolve<'a, I: IntoIterator<Item = &'a Edge>, W: IntoIterator<Item = I>>(profile: I, holes: W, axis_origin: DVec3, axis_direction: DVec3, angle: f64) -> Result<Self, Error> {
+		let edge_vec = profile_with_holes(profile, holes);
+		let shape = ffi::make_revolve(&edge_vec, axis_origin.x, axis_origin.y, axis_origin.z, axis_direction.x, axis_direction.y, axis_direction.z, angle);
+		if shape.is_null() {
+			return Err(Error::Revolve(format!("angle={angle} about {axis_direction:?} through {axis_origin:?} did not produce a solid")));
 		}
 		Ok(Solid::new(
 			shape,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -554,25 +554,26 @@ pub trait SolidStruct: Sized + Clone + Debug + Transform {
 	/// repair small inconsistencies). Wraps `ShapeUpgrade_UnifySameDomain`
 	/// + cleanup. Failure is reported as `Error::Clean`.
 	fn clean(&self) -> Result<Self, Error>;
-	/// Extrude closed profile wires along a direction vector to form a solid.
+	/// Extrude closed wires along a direction vector to form a solid.
 	///
-	/// `profile` is the outer boundary and every wire in `holes` becomes an
-	/// opening in the extruded face; pass `&[]` for none. Both share the same
+	/// The first wire is the outer boundary and every later one becomes an
+	/// opening in the extruded face, so a plate with a hole is
+	/// `[&outer, &hole]` and a plain profile is `[&outer]`. All wires share one
 	/// iterator type, so mixed containers need a common spelling such as
-	/// `Solid::extrude(outer.as_slice(), [hole.as_slice()], dir)`. Internally
+	/// `Solid::extrude([outer.as_slice(), hole.as_slice()], dir)`. Internally
 	/// builds a face from the wires and uses `BRepPrimAPI_MakePrism`. Fails if
-	/// the profile is empty, not closed, or the direction is zero-length.
-	fn extrude<'a, I: IntoIterator<Item = &'a Self::Edge>, W: IntoIterator<Item = I>>(profile: I, holes: W, dir: DVec3) -> Result<Self, Error>
+	/// `wires` is empty or not closed, or if the direction is zero-length.
+	fn extrude<'a, I: IntoIterator<Item = &'a Self::Edge>, W: IntoIterator<Item = I>>(wires: W, dir: DVec3) -> Result<Self, Error>
 	where
 		Self::Edge: 'a;
 
-	/// Revolve closed profile wires about an axis to form a solid.
+	/// Revolve closed wires about an axis to form a solid.
 	///
-	/// `profile` and `holes` work as in `extrude`. The axis is the same
-	/// `(origin, direction)` pair `Transform::rotate` takes and `angle` is in
-	/// radians, so `revolve` sweeps the profile through that very rotation.
-	/// Uses `BRepPrimAPI_MakeRevol`. Fails if the axis or the angle is zero.
-	fn revolve<'a, I: IntoIterator<Item = &'a Self::Edge>, W: IntoIterator<Item = I>>(profile: I, holes: W, axis_origin: DVec3, axis_direction: DVec3, angle: f64) -> Result<Self, Error>
+	/// `wires` works as in `extrude`. The axis is the same `(origin, direction)`
+	/// pair `Transform::rotate` takes and `angle` is in radians, so `revolve`
+	/// sweeps the profile through that very rotation. Uses
+	/// `BRepPrimAPI_MakeRevol`. Fails if the axis or the angle is zero.
+	fn revolve<'a, I: IntoIterator<Item = &'a Self::Edge>, W: IntoIterator<Item = I>>(wires: W, axis_origin: DVec3, axis_direction: DVec3, angle: f64) -> Result<Self, Error>
 	where
 		Self::Edge: 'a;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -232,6 +232,14 @@ pub enum ProfileOrient<'a> {
 	///   `Up` を使う
 	Torsion,
 
+	/// Profile follows OCCT's corrected-Frenet trihedron: the same frame as
+	/// `Torsion`, transported so it stays defined where curvature drops to
+	/// zero. CadQuery's `isFrenet = false` default.
+	///
+	/// - **適**: 直線と円弧が混在する spine、変曲点を含むスプライン
+	/// - **不適**: 曲線の自然な捻れを profile に反映させたいケース (`Torsion` を使う)
+	CorrectedTorsion,
+
 	/// Profile keeps the given direction as its "up" axis (binormal).
 	///
 	/// - **適**: 道路 (`up = DVec3::Z`), 線路, パイプ, 運河 — 重力方向を
@@ -369,6 +377,12 @@ pub trait EdgeStruct: Sized + Clone + Debug + Transform {
 	/// deterministic start point should translate/rotate the resulting
 	/// edge into place rather than relying on the implicit choice.
 	fn circle(radius: f64, axis: DVec3) -> Result<Self, Error>;
+
+	/// Closed ellipse centered at the world origin, lying in the plane normal
+	/// to `axis`, with `x_ref` fixing the major-axis direction. Fails with
+	/// `Error::Edge` unless `major_radius >= minor_radius > 0` and `x_ref` is
+	/// not parallel to `axis`.
+	fn ellipse(major_radius: f64, minor_radius: f64, axis: DVec3, x_ref: DVec3) -> Result<Self, Error>;
 
 	/// Straight line segment from `a` to `b`. Fails with `Error::Edge` if
 	/// `a == b` (zero-length segment).
@@ -540,11 +554,25 @@ pub trait SolidStruct: Sized + Clone + Debug + Transform {
 	/// repair small inconsistencies). Wraps `ShapeUpgrade_UnifySameDomain`
 	/// + cleanup. Failure is reported as `Error::Clean`.
 	fn clean(&self) -> Result<Self, Error>;
-	/// Extrude a closed profile wire along a direction vector to form a solid.
+	/// Extrude closed profile wires along a direction vector to form a solid.
 	///
-	/// Internally builds a face from the wire and uses `BRepPrimAPI_MakePrism`.
-	/// Fails if the profile is empty, not closed, or the direction is zero-length.
-	fn extrude<'a>(profile: impl IntoIterator<Item = &'a Self::Edge>, dir: DVec3) -> Result<Self, Error>
+	/// `profile` is the outer boundary and every wire in `holes` becomes an
+	/// opening in the extruded face; pass `&[]` for none. Both share the same
+	/// iterator type, so mixed containers need a common spelling such as
+	/// `Solid::extrude(outer.as_slice(), [hole.as_slice()], dir)`. Internally
+	/// builds a face from the wires and uses `BRepPrimAPI_MakePrism`. Fails if
+	/// the profile is empty, not closed, or the direction is zero-length.
+	fn extrude<'a, I: IntoIterator<Item = &'a Self::Edge>, W: IntoIterator<Item = I>>(profile: I, holes: W, dir: DVec3) -> Result<Self, Error>
+	where
+		Self::Edge: 'a;
+
+	/// Revolve closed profile wires about an axis to form a solid.
+	///
+	/// `profile` and `holes` work as in `extrude`. The axis is the same
+	/// `(origin, direction)` pair `Transform::rotate` takes and `angle` is in
+	/// radians, so `revolve` sweeps the profile through that very rotation.
+	/// Uses `BRepPrimAPI_MakeRevol`. Fails if the axis or the angle is zero.
+	fn revolve<'a, I: IntoIterator<Item = &'a Self::Edge>, W: IntoIterator<Item = I>>(profile: I, holes: W, axis_origin: DVec3, axis_direction: DVec3, angle: f64) -> Result<Self, Error>
 	where
 		Self::Edge: 'a;
 

--- a/tests/edge.rs
+++ b/tests/edge.rs
@@ -6,7 +6,7 @@
 //! closest point is computed analytically from the curve definition and
 //! compared to the FFI result.
 
-use cadrum::{BSplineEnd, Edge};
+use cadrum::{BSplineEnd, Edge, Solid};
 use glam::DVec3;
 
 const TOL: f64 = 1e-6;
@@ -74,4 +74,22 @@ fn project_on_bspline_converges_to_interpolant() {
 	assert!((0.7..=1.0).contains(&r), "radius out of envelope: {r}");
 	// Tangent is unit-length.
 	assert!((tg.length() - 1.0).abs() < TOL, "|tg|={}", tg.length());
+}
+
+// ==================== ellipse ====================
+
+/// An ellipse of semi-axes a, b extruded by h encloses `π a b h`.
+#[test]
+fn ellipse_extrudes_to_the_analytical_volume() {
+	let profile = [Edge::ellipse(4.0, 2.0, DVec3::Z, DVec3::X).unwrap()];
+	let solid = Solid::extrude(&profile, &[], DVec3::Z * 3.0).unwrap();
+	let want = std::f64::consts::PI * 4.0 * 2.0 * 3.0;
+	assert!((solid.volume() - want).abs() < 1e-3, "volume = {}, want {want}", solid.volume());
+}
+
+#[test]
+fn ellipse_rejects_invalid_params() {
+	assert!(Edge::ellipse(1.0, 2.0, DVec3::Z, DVec3::X).is_err(), "minor must not exceed major");
+	assert!(Edge::ellipse(2.0, 0.0, DVec3::Z, DVec3::X).is_err(), "minor must be positive");
+	assert!(Edge::ellipse(2.0, 1.0, DVec3::Z, DVec3::Z).is_err(), "x_ref must not be parallel to axis");
 }

--- a/tests/edge.rs
+++ b/tests/edge.rs
@@ -82,7 +82,7 @@ fn project_on_bspline_converges_to_interpolant() {
 #[test]
 fn ellipse_extrudes_to_the_analytical_volume() {
 	let profile = [Edge::ellipse(4.0, 2.0, DVec3::Z, DVec3::X).unwrap()];
-	let solid = Solid::extrude(&profile, &[], DVec3::Z * 3.0).unwrap();
+	let solid = Solid::extrude([&profile], DVec3::Z * 3.0).unwrap();
 	let want = std::f64::consts::PI * 4.0 * 2.0 * 3.0;
 	assert!((solid.volume() - want).abs() < 1e-3, "volume = {}, want {want}", solid.volume());
 }

--- a/tests/solid_extrude.rs
+++ b/tests/solid_extrude.rs
@@ -14,25 +14,31 @@ fn square(side: f64, offset: f64) -> Vec<Edge> {
 
 #[test]
 fn test_extrude_without_holes_matches_analytical() {
-	let solid = Solid::extrude(&square(10.0, 0.0), &[], DVec3::Z * 3.0).expect("extrude");
+	let solid = Solid::extrude([&square(10.0, 0.0)], DVec3::Z * 3.0).expect("extrude");
 	assert!((solid.volume() - 300.0).abs() < EPS, "volume = {}", solid.volume());
 	assert_eq!(solid.iter_face().count(), 6, "a square prism has six faces");
 }
 
 #[test]
 fn test_extrude_with_one_hole_subtracts_it() {
-	let solid = Solid::extrude(&square(10.0, 0.0), [&square(4.0, 3.0)], DVec3::Z * 3.0).expect("extrude with hole");
+	let solid = Solid::extrude([&square(10.0, 0.0), &square(4.0, 3.0)], DVec3::Z * 3.0).expect("extrude with hole");
 	assert!((solid.volume() - (100.0 - 16.0) * 3.0).abs() < EPS, "volume = {}", solid.volume());
 	assert_eq!(solid.iter_face().count(), 10, "four outer walls, four hole walls, two caps");
 }
 
 #[test]
 fn test_extrude_with_two_holes_subtracts_both() {
-	let solid = Solid::extrude(&square(20.0, 0.0), [&square(2.0, 2.0), &square(3.0, 12.0)], DVec3::Z * 2.0).expect("extrude with holes");
+	let solid = Solid::extrude([&square(20.0, 0.0), &square(2.0, 2.0), &square(3.0, 12.0)], DVec3::Z * 2.0).expect("extrude with holes");
 	assert!((solid.volume() - (400.0 - 4.0 - 9.0) * 2.0).abs() < EPS, "volume = {}", solid.volume());
 }
 
 #[test]
 fn test_extrude_rejects_a_zero_direction() {
-	assert!(Solid::extrude(&square(10.0, 0.0), &[], DVec3::ZERO).is_err());
+	assert!(Solid::extrude([&square(10.0, 0.0)], DVec3::ZERO).is_err());
+}
+
+/// ワイヤが 1 本も無い場合は面を作れないのでエラー。
+#[test]
+fn test_extrude_rejects_an_empty_wire_list() {
+	assert!(Solid::extrude(Vec::<&Vec<Edge>>::new(), DVec3::Z * 3.0).is_err());
 }

--- a/tests/solid_extrude.rs
+++ b/tests/solid_extrude.rs
@@ -1,0 +1,38 @@
+//! `Solid::extrude` の穴あきプロファイルを解析解で検証する。
+//!
+//! 外周 `a` × 内周 `b` の板を高さ `h` 押し出すと体積は `(a² − b²) · h`。
+
+use cadrum::{DVec3, Edge, Solid};
+
+const EPS: f64 = 1e-6;
+
+/// 一辺 `side` の閉じた正方形を `offset` だけ平行移動したプロファイル。
+fn square(side: f64, offset: f64) -> Vec<Edge> {
+	let o = offset;
+	Edge::polygon(&[DVec3::new(o, o, 0.0), DVec3::new(o + side, o, 0.0), DVec3::new(o + side, o + side, 0.0), DVec3::new(o, o + side, 0.0)]).expect("square polygon")
+}
+
+#[test]
+fn test_extrude_without_holes_matches_analytical() {
+	let solid = Solid::extrude(&square(10.0, 0.0), &[], DVec3::Z * 3.0).expect("extrude");
+	assert!((solid.volume() - 300.0).abs() < EPS, "volume = {}", solid.volume());
+	assert_eq!(solid.iter_face().count(), 6, "a square prism has six faces");
+}
+
+#[test]
+fn test_extrude_with_one_hole_subtracts_it() {
+	let solid = Solid::extrude(&square(10.0, 0.0), [&square(4.0, 3.0)], DVec3::Z * 3.0).expect("extrude with hole");
+	assert!((solid.volume() - (100.0 - 16.0) * 3.0).abs() < EPS, "volume = {}", solid.volume());
+	assert_eq!(solid.iter_face().count(), 10, "four outer walls, four hole walls, two caps");
+}
+
+#[test]
+fn test_extrude_with_two_holes_subtracts_both() {
+	let solid = Solid::extrude(&square(20.0, 0.0), [&square(2.0, 2.0), &square(3.0, 12.0)], DVec3::Z * 2.0).expect("extrude with holes");
+	assert!((solid.volume() - (400.0 - 4.0 - 9.0) * 2.0).abs() < EPS, "volume = {}", solid.volume());
+}
+
+#[test]
+fn test_extrude_rejects_a_zero_direction() {
+	assert!(Solid::extrude(&square(10.0, 0.0), &[], DVec3::ZERO).is_err());
+}

--- a/tests/solid_iter_history.rs
+++ b/tests/solid_iter_history.rs
@@ -21,7 +21,7 @@ fn test_no_face_source_ops_have_empty_history() {
 	assert_eq!(Solid::cube(DVec3::ZERO, DVec3::splat(1.0)).iter_history().count(), 0, "cube");
 	assert_eq!(Solid::sphere(1.0).iter_history().count(), 0, "sphere");
 
-	let extruded = Solid::extrude(&square(4.0), &[], DVec3::Z * 3.0).expect("extrude");
+	let extruded = Solid::extrude([&square(4.0)], DVec3::Z * 3.0).expect("extrude");
 	assert_eq!(extruded.iter_history().count(), 0, "extrude");
 
 	let profile = [Edge::circle(1.0, DVec3::Z).expect("circle")];

--- a/tests/solid_iter_history.rs
+++ b/tests/solid_iter_history.rs
@@ -21,7 +21,7 @@ fn test_no_face_source_ops_have_empty_history() {
 	assert_eq!(Solid::cube(DVec3::ZERO, DVec3::splat(1.0)).iter_history().count(), 0, "cube");
 	assert_eq!(Solid::sphere(1.0).iter_history().count(), 0, "sphere");
 
-	let extruded = Solid::extrude(&square(4.0), DVec3::Z * 3.0).expect("extrude");
+	let extruded = Solid::extrude(&square(4.0), &[], DVec3::Z * 3.0).expect("extrude");
 	assert_eq!(extruded.iter_history().count(), 0, "extrude");
 
 	let profile = [Edge::circle(1.0, DVec3::Z).expect("circle")];

--- a/tests/solid_revolve.rs
+++ b/tests/solid_revolve.rs
@@ -15,22 +15,22 @@ fn rect(x0: f64, x1: f64, z0: f64, z1: f64) -> Vec<Edge> {
 
 #[test]
 fn test_full_revolution_matches_the_pipe_volume() {
-	let solid = Solid::revolve(&rect(2.0, 5.0, 0.0, 4.0), &[], DVec3::ZERO, DVec3::Z, TAU).expect("revolve");
+	let solid = Solid::revolve([&rect(2.0, 5.0, 0.0, 4.0)], DVec3::ZERO, DVec3::Z, TAU).expect("revolve");
 	let want = PI * (5.0f64.powi(2) - 2.0f64.powi(2)) * 4.0;
 	assert!((solid.volume() - want).abs() < EPS, "volume = {}, want {want}", solid.volume());
 }
 
 #[test]
 fn test_partial_revolution_scales_with_the_angle() {
-	let full = Solid::revolve(&rect(2.0, 5.0, 0.0, 4.0), &[], DVec3::ZERO, DVec3::Z, TAU).expect("full turn");
-	let quarter = Solid::revolve(&rect(2.0, 5.0, 0.0, 4.0), &[], DVec3::ZERO, DVec3::Z, TAU / 4.0).expect("quarter turn");
+	let full = Solid::revolve([&rect(2.0, 5.0, 0.0, 4.0)], DVec3::ZERO, DVec3::Z, TAU).expect("full turn");
+	let quarter = Solid::revolve([&rect(2.0, 5.0, 0.0, 4.0)], DVec3::ZERO, DVec3::Z, TAU / 4.0).expect("quarter turn");
 	assert!((quarter.volume() - full.volume() / 4.0).abs() < EPS, "quarter = {}, full = {}", quarter.volume(), full.volume());
 }
 
 /// 断面に開けた穴は、パップスの定理どおり自身の重心半径で体積を減らす。
 #[test]
 fn test_a_hole_in_the_profile_is_revolved_too() {
-	let solid = Solid::revolve(&rect(1.0, 5.0, 0.0, 6.0), [&rect(2.5, 3.5, 2.5, 3.5)], DVec3::ZERO, DVec3::Z, TAU).expect("revolve with hole");
+	let solid = Solid::revolve([&rect(1.0, 5.0, 0.0, 6.0), &rect(2.5, 3.5, 2.5, 3.5)], DVec3::ZERO, DVec3::Z, TAU).expect("revolve with hole");
 	let outer = TAU * 3.0 * 24.0;
 	let hole = TAU * 3.0 * 1.0;
 	assert!((solid.volume() - (outer - hole)).abs() < EPS, "volume = {}, want {}", solid.volume(), outer - hole);
@@ -38,6 +38,6 @@ fn test_a_hole_in_the_profile_is_revolved_too() {
 
 #[test]
 fn test_revolve_rejects_a_zero_axis_or_angle() {
-	assert!(Solid::revolve(&rect(2.0, 5.0, 0.0, 4.0), &[], DVec3::ZERO, DVec3::ZERO, TAU).is_err(), "zero axis");
-	assert!(Solid::revolve(&rect(2.0, 5.0, 0.0, 4.0), &[], DVec3::ZERO, DVec3::Z, 0.0).is_err(), "zero angle");
+	assert!(Solid::revolve([&rect(2.0, 5.0, 0.0, 4.0)], DVec3::ZERO, DVec3::ZERO, TAU).is_err(), "zero axis");
+	assert!(Solid::revolve([&rect(2.0, 5.0, 0.0, 4.0)], DVec3::ZERO, DVec3::Z, 0.0).is_err(), "zero angle");
 }

--- a/tests/solid_revolve.rs
+++ b/tests/solid_revolve.rs
@@ -1,0 +1,43 @@
+//! `Solid::revolve` を解析解で検証する。
+//!
+//! XZ 平面の断面を Z 軸まわりに一周させると、パップス・ギュルダンの定理から
+//! 体積は `2π · x̄ · A`（x̄ は断面重心の軸からの距離、A は断面積）になる。
+
+use cadrum::{DVec3, Edge, Solid};
+use std::f64::consts::{PI, TAU};
+
+const EPS: f64 = 1e-3;
+
+/// XZ 平面上の矩形 `x ∈ [x0, x1]`, `z ∈ [z0, z1]`。
+fn rect(x0: f64, x1: f64, z0: f64, z1: f64) -> Vec<Edge> {
+	Edge::polygon(&[DVec3::new(x0, 0.0, z0), DVec3::new(x1, 0.0, z0), DVec3::new(x1, 0.0, z1), DVec3::new(x0, 0.0, z1)]).expect("rect polygon")
+}
+
+#[test]
+fn test_full_revolution_matches_the_pipe_volume() {
+	let solid = Solid::revolve(&rect(2.0, 5.0, 0.0, 4.0), &[], DVec3::ZERO, DVec3::Z, TAU).expect("revolve");
+	let want = PI * (5.0f64.powi(2) - 2.0f64.powi(2)) * 4.0;
+	assert!((solid.volume() - want).abs() < EPS, "volume = {}, want {want}", solid.volume());
+}
+
+#[test]
+fn test_partial_revolution_scales_with_the_angle() {
+	let full = Solid::revolve(&rect(2.0, 5.0, 0.0, 4.0), &[], DVec3::ZERO, DVec3::Z, TAU).expect("full turn");
+	let quarter = Solid::revolve(&rect(2.0, 5.0, 0.0, 4.0), &[], DVec3::ZERO, DVec3::Z, TAU / 4.0).expect("quarter turn");
+	assert!((quarter.volume() - full.volume() / 4.0).abs() < EPS, "quarter = {}, full = {}", quarter.volume(), full.volume());
+}
+
+/// 断面に開けた穴は、パップスの定理どおり自身の重心半径で体積を減らす。
+#[test]
+fn test_a_hole_in_the_profile_is_revolved_too() {
+	let solid = Solid::revolve(&rect(1.0, 5.0, 0.0, 6.0), [&rect(2.5, 3.5, 2.5, 3.5)], DVec3::ZERO, DVec3::Z, TAU).expect("revolve with hole");
+	let outer = TAU * 3.0 * 24.0;
+	let hole = TAU * 3.0 * 1.0;
+	assert!((solid.volume() - (outer - hole)).abs() < EPS, "volume = {}, want {}", solid.volume(), outer - hole);
+}
+
+#[test]
+fn test_revolve_rejects_a_zero_axis_or_angle() {
+	assert!(Solid::revolve(&rect(2.0, 5.0, 0.0, 4.0), &[], DVec3::ZERO, DVec3::ZERO, TAU).is_err(), "zero axis");
+	assert!(Solid::revolve(&rect(2.0, 5.0, 0.0, 4.0), &[], DVec3::ZERO, DVec3::Z, 0.0).is_err(), "zero angle");
+}

--- a/tests/solid_sweep.rs
+++ b/tests/solid_sweep.rs
@@ -67,3 +67,29 @@ fn test_sweep_02_closed_auxiliary_volume_matches_pappus() {
 	let rel = (solid.volume() - expected).abs() / expected;
 	assert!(rel < 1.0e-3, "volume {:.3} vs Pappus {:.3} (relative error {:.3e})", solid.volume(), expected, rel);
 }
+
+// ==================== CorrectedTorsion ====================
+
+/// 螺旋 spine は捩率が一定で非ゼロ。`CorrectedTorsion` は捩れを追わない
+/// フレームで掃くので、体積は断面積 × spine 長に一致する。
+#[test]
+fn test_sweep_04_corrected_torsion_on_a_helix_matches_the_tube_volume() {
+	let (radius, pitch, height) = (5., 4., 12.);
+	let spine = Edge::helix(radius, pitch, height, DVec3::Z, DVec3::X).expect("helix");
+	let profile = square_profile(&spine).expect("profile");
+	let solid = Solid::sweep(&profile, &[spine], ProfileOrient::CorrectedTorsion).expect("corrected sweep");
+
+	let per_turn = ((std::f64::consts::TAU * radius).powi(2) + pitch.powi(2)).sqrt();
+	let want = SIDE * SIDE * per_turn * (height / pitch);
+	assert!((solid.volume() - want).abs() < 1e-2, "volume = {}, want {want}", solid.volume());
+}
+
+/// 平面 spine は捩率がゼロなので、corrected frame は raw Frenet と一致する。
+#[test]
+fn test_sweep_05_corrected_torsion_equals_torsion_on_a_planar_spine() {
+	let spine = Edge::arc_3pts(DVec3::X, DVec3::new(6., 0., 5.), DVec3::new(11., 0., 0.)).expect("arc");
+	let profile = square_profile(&spine).expect("profile");
+	let torsion = Solid::sweep(&profile, &[spine.clone()], ProfileOrient::Torsion).expect("torsion sweep");
+	let corrected = Solid::sweep(&profile, &[spine], ProfileOrient::CorrectedTorsion).expect("corrected sweep");
+	assert!((torsion.volume() - corrected.volume()).abs() < 1e-9, "torsion {} vs corrected {}", torsion.volume(), corrected.volume());
+}


### PR DESCRIPTION
The four upstream candidates from the fork survey in #286. Closes #286 and #115.

（#286 のフォーク調査で残った上流化候補 4 件。#286 と #115 を close する。）

## 1. `ProfileOrient::CorrectedTorsion`

**From: inferno-sh** — [`177968db`](https://github.com/inferno-sh/cadrum/commit/177968db)

OCCT's corrected-Frenet trihedron, reached through `BRepOffsetAPI_MakePipeShell::SetMode(false)` as orientation kind 4. `Torsion` (raw Frenet–Serret, `SetMode(true)`) stays the default for its cases. Named after the existing `Torsion` rather than after OCCT's "Frenet", matching how this enum already avoids the kernel's jargon.

（OCCT の corrected-Frenet 三面体。orientation kind 4 として `SetMode(false)` に対応させた。既存の `Torsion`（raw Frenet–Serret、`SetMode(true)`）はそのまま。この enum が既にカーネルの専門用語を避けている流儀に合わせ、`Frenet` ではなく `Torsion` と対になる名前にした。）

The `default:` arm of that switch is also `SetMode(true)`, so a volume test alone cannot tell a wired `case 4` from a fall-through. Measured with the profile properly seated on the spine:

（同じ switch の `default:` も `SetMode(true)` なので、体積テストだけでは `case 4` が配線されているのか素通りしているのか区別できない。プロファイルをスパイン始点に正しく載せて実測した。）

| spine | `Torsion` | `CorrectedTorsion` |
| --- | --- | --- |
| helix r=5 pitch=4 h=12 | 136.812434 | **136.812385** |
| planar arc | 22.619467 | 22.619467 |

The helix differs, so kind 4 does reach `SetMode(false)`. The planar spine agreeing is the theory: a planar curve has zero torsion, so the corrected frame and the raw Frenet frame coincide. Both facts are pinned as tests.

（螺旋では値が違うので kind 4 が `SetMode(false)` に届いている。平面スパインで一致するのは理論どおりで、平面曲線は捩率ゼロなので corrected frame と raw Frenet frame が一致する。どちらもテストで固定した。）

## 2. `extrude` takes a list of wires

**From: cadona-app [`ff15a725`](https://github.com/cadona-app/cadona-cadrum/commit/ff15a725) and julivehs1 — two unrelated forks, independently**

```rust
fn extrude<'a, I: IntoIterator<Item = &'a Self::Edge>, W: IntoIterator<Item = I>>(wires: W, dir: DVec3) -> Result<Self, Error>;
```

The first wire is the outer boundary and every later one becomes an opening, so a plain profile is `[&outer]` and a plate with a hole is `[&outer, &hole]`. This is the shape `loft<'a, I, S>(sections, ruled)` already uses for a collection of wires.

（先頭ワイヤが外周、以降が穴。素のプロファイルは `[&outer]`、穴あきの板は `[&outer, &hole]`。既存の `loft<'a, I, S>(sections, ruled)` がワイヤ列に使っている形と同じ。）

**Breaking**: `extrude(&profile, dir)` becomes `extrude([&profile], dir)`. Every call site in `examples/`, `tests/` and the README is updated.

（**破壊的変更**: `extrude(&profile, dir)` が `extrude([&profile], dir)` になる。`examples/` `tests/` README の全呼び出し箇所を更新した。）

The C++ gains one helper, `face_from_wires`, that splits a flat edge vector on null-edge sentinels — the convention `make_pipe_shell` already uses for profile sections — and builds a face whose first wire is the outer boundary and whose remaining wires are added reversed, so they subtract. `make_extrude` and `make_revolve` share it. No new FFI type.

（C++ に helper を 1 つ足した。`face_from_wires` は平坦なエッジ列を null エッジ番兵で分割し（`make_pipe_shell` が profile section に既に使っている規約）、先頭ワイヤを外周、残りを反転して追加した面を作る。`make_extrude` と `make_revolve` が共有する。新しい FFI 型は作っていない。）

Compiled call spellings, since `W: IntoIterator<Item = I>` makes every wire share one iterator type:

（`W: IntoIterator<Item = I>` により全ワイヤが同じイテレータ型になるため、実際にコンパイルを通して確かめた呼び出し形。）

| spelling | |
| --- | --- |
| `[&outer]`, `[&outer, &hole]`, `vec![&outer, &hole]` | ok |
| `[&arr]` where `arr: [Edge; 4]` | ok |
| `[&Edge::polygon(..)?]` (temporary) | ok |
| `[outer.as_slice(), arr.as_slice()]` — mixed containers | ok |
| `[[Edge; 4]; 1]` — an array by value yields `Edge`, not `&Edge` | **NG** |
| `[&outer, &arr]` — a `Vec` and an array mixed without `as_slice` | **NG** |
| `&outer` — a single wire passed where a list is expected | **NG**, caught at compile time |

The cost of one list is that "the first wire is the outer boundary" lives in the doc rather than in the type, and an empty list is a runtime error instead of an unrepresentable state. A test pins that `extrude` rejects an empty list; an empty `[]` literal does not even infer, so only a dynamically empty collection reaches it.

（1 本のリストにした代償は、「先頭が外周」という規約が型ではなく doc に載ること、そして空リストが表現不可能ではなく実行時エラーになること。空リストを弾くことはテストで固定した。`[]` リテラルはそもそも型推論が付かないので、到達しうるのは動的に空なコレクションだけ。）

## 3. `Solid::revolve`

**From: julivehs1** — tracked as #115

```rust
fn revolve<'a, I: IntoIterator<Item = &'a Self::Edge>, W: IntoIterator<Item = I>>(wires: W, axis_origin: DVec3, axis_direction: DVec3, angle: f64) -> Result<Self, Error>;
```

`BRepPrimAPI_MakeRevol` behind the same wire handling as `extrude`. `extrude` existed and `revolve` did not, leaving the pair of basic surfacing operations half missing. The `(axis_origin, axis_direction, angle)` triple is the one `Transform::rotate` already takes, and matches OCCT's `gp_Ax1` + angle and STEP's `axis1_placement` — so `revolve` sweeps the profile through exactly the rotation `rotate` would apply to it. Adds `Error::Revolve(String)`.

（ワイヤの扱いは `extrude` と共通で、裏は `BRepPrimAPI_MakeRevol`。`extrude` があって `revolve` が無く、基本的なサーフェシング操作の対が片方欠けていた。`(axis_origin, axis_direction, angle)` は既存の `Transform::rotate` と同じ 3 つ組で、OCCT の `gp_Ax1` + angle、STEP の `axis1_placement` とも一致する。`Error::Revolve(String)` を追加。）

## 4. `Edge::ellipse`

**From: inferno-sh** — [`0b4cd35f`](https://github.com/inferno-sh/cadrum/commit/0b4cd35f)

```rust
fn ellipse(major_radius: f64, minor_radius: f64, axis: DVec3, x_ref: DVec3) -> Result<Self, Error>;
```

Lines up with `Edge::circle(radius, axis)` and `Edge::helix(radius, pitch, height, axis, x_ref)`. Rejects `major_radius < minor_radius`, a non-positive minor radius, and an `x_ref` parallel to `axis`.

（既存の `Edge::circle` と `Edge::helix` に揃えた署名。`major_radius < minor_radius`、非正の短半径、`axis` と平行な `x_ref` を弾く。）

## Three things this does beyond the four items

**A zero-length extrusion direction now fails.** The existing doc already promised "Fails if … the direction is zero-length", but `BRepPrimAPI_MakePrism` accepted a zero vector and returned a degenerate solid. A new test caught the gap; one guard in C++ makes the documented contract true.

（既存の doc が「direction が zero-length なら失敗」と書いていたのに `BRepPrimAPI_MakePrism` はゼロベクトルを受け付け、縮退した solid を返していた。新規テストで発覚し、C++ のガード 1 行で doc どおりの挙動にした。）

**The README's embedded example source is synced.** `src/lib.rs` starts with `#![doc = include_str!("../README.md")]`, so every rust fence in the README compiles as a doctest. Changing `examples/05_extrude.rs` broke `cargo test --doc` with eight errors until the embedded copy matched. Only that code block was replaced — the images, output links and the rest of the generated section are untouched, and `make update` in CI regenerates them.

（`src/lib.rs` の先頭が `#![doc = include_str!("../README.md")]` なので、README の rust フェンスはすべて doctest としてコンパイルされる。`examples/05_extrude.rs` を変更した時点で埋め込み側が古いままとなり `cargo test --doc` が 8 errors で落ちたため、当該コードブロックのみ同期した。画像・出力リンク・生成節の他の部分には触れておらず、CI の `make update` が再生成する。）

**No CHANGELOG entry.** #283, #284 and #285 did not add one either; the file is compiled at release time.

（#283 #284 #285 のいずれも追加していない。リリース時にまとめる運用に見えるので合わせた。）

## Verification

- `cargo fmt` applied; `cargo run --example codegen -- src/traits.rs src/lib.rs` reports **no diff** on both files, so the inherent wrappers match what codegen emits
- `cargo test -j 1`: **19 suites, 109 passed, 0 failed, 3 ignored**, no warnings
- New tests, all against analytical solutions: a plate with one hole and with two holes loses exactly the hole volume; an empty wire list and a zero direction both error; a full revolution matches `π(r_out² − r_in²)h`; a quarter turn is a quarter of the volume; a hole in a revolved profile removes `2π x̄ A` as Pappus predicts; an ellipse extrudes to `π a b h`; a helix swept with `CorrectedTorsion` matches cross-section × spine length; a planar spine gives the same solid under `Torsion` and `CorrectedTorsion`; a zero axis and a zero angle both error

（新規テストはすべて解析解と照合している。穴 1 つ・2 つの板が穴の体積ちょうど分だけ減ること、空のワイヤ列とゼロ方向がエラーになること、一周回転が `π(r_out² − r_in²)h` に一致すること、四分の一回転が体積の四分の一になること、回転断面の穴がパップスの定理どおり `2π x̄ A` を削ること、楕円の押し出しが `π a b h` になること、螺旋の `CorrectedTorsion` sweep が断面積 × spine 長に一致すること、平面スパインで `Torsion` と `CorrectedTorsion` が一致すること、ゼロ軸とゼロ角がエラーになること。）

## Not included

`SweepTransition` / `sweep_with_transition` (inferno-sh [`ed18afa2`](https://github.com/inferno-sh/cadrum/commit/ed18afa2)) is held back as instructed in #286.

（#286 の指示どおり保留。）
